### PR TITLE
feat(actionsheet): More native iOS look (translucent)

### DIFF
--- a/src/components/action-sheet/action-sheet-component.ts
+++ b/src/components/action-sheet/action-sheet-component.ts
@@ -18,6 +18,7 @@ import { assert } from '../../util/util';
     '<div class="action-sheet-wrapper">' +
       '<div class="action-sheet-container">' +
         '<div class="action-sheet-group">' +
+          '<div class="action-sheet-background"></div>' +
           '<div class="action-sheet-title" id="{{hdrId}}" *ngIf="d.title">{{d.title}}</div>' +
           '<div class="action-sheet-sub-title" id="{{descId}}" *ngIf="d.subTitle">{{d.subTitle}}</div>' +
           '<button ion-button="action-sheet-button" (click)="click(b)" *ngFor="let b of d.buttons" class="disable-hover" [attr.icon-left]="b.icon ? \'\' : null" [ngClass]="b.cssClass">' +
@@ -70,6 +71,9 @@ export class ActionSheetCmp {
     this.mode = _config.get('mode');
     renderer.setElementClass(_elementRef.nativeElement, `action-sheet-${this.mode}`, true);
 
+    if (_config.getBoolean('backdropEffects')) {
+      renderer.setElementClass(_elementRef.nativeElement, `backdrop-effect`, true);
+    }
     if (this.d.cssClass) {
       this.d.cssClass.split(' ').forEach(cssClass => {
         // Make sure the class isn't whitespace, otherwise it throws exceptions

--- a/src/components/action-sheet/action-sheet.ios.scss
+++ b/src/components/action-sheet/action-sheet.ios.scss
@@ -142,3 +142,49 @@ $action-sheet-ios-button-cancel-font-weight:            600 !default;
   font-weight: $action-sheet-ios-button-cancel-font-weight;
   background: $action-sheet-ios-button-cancel-background;
 }
+
+&.hairlines {
+  .action-sheet-title,
+  .action-sheet-button {
+    border-bottom-width: $hairlines-width;
+  }
+}
+
+
+// iOS backdrop filter (blur effect)
+// --------------------------------------------------
+
+.action-sheet-ios.backdrop-effect .action-sheet-button:not(.action-sheet-cancel),
+.action-sheet-ios.backdrop-effect .action-sheet-title {
+  margin-bottom: 1px;
+  border-bottom: $hairlines-width solid rgba(0, 0, 0, .1);
+
+  background-color: rgba(250, 250, 250, .85);
+
+  background-clip: border-box;
+}
+
+.action-sheet-ios.backdrop-effect .action-sheet-button.activated {
+  background-color: rgba(216, 216, 220, 0.65);
+}
+
+.action-sheet-ios.backdrop-effect .action-sheet-group {
+  background: transparent;
+
+  transform: translateZ(0);
+}
+
+.action-sheet-ios.backdrop-effect .action-sheet-background {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+
+  z-index: -1;
+
+  display: block;
+
+  -webkit-backdrop-filter: blur(20px) brightness(220%) saturate(140%);
+  backdrop-filter: blur(20px) brightness(220%) saturate(140%);
+}

--- a/src/components/action-sheet/action-sheet.scss
+++ b/src/components/action-sheet/action-sheet.scss
@@ -37,3 +37,7 @@ ion-action-sheet {
 .action-sheet-button {
   width: $action-sheet-width;
 }
+
+.action-sheet-background {
+  display: none;
+}

--- a/src/components/action-sheet/test/basic/main.html
+++ b/src/components/action-sheet/test/basic/main.html
@@ -20,4 +20,40 @@
     Result: {{result}}
   </pre>
 
+  <div class="float left"></div>
+  <div class="float center"></div>
+  <div class="float right"></div>
+  <div class="float black"></div>
+
 </ion-content>
+
+
+<style>
+  .float {
+    z-index: -2;
+    position: absolute;
+    bottom: 0px;
+    width: 25%;
+    height: 250px;
+  }
+  .left {
+    left: 0;
+    background: #f53d3d;
+  }
+  .center {
+    left: 37.5%;
+    background: #387ef5;
+  }
+  .right {
+    right: 0;
+    height: 400px;
+    background: #32db64;
+  }
+  .black {
+    bottom: 40px;
+    right: 0px;
+    width: 50%;
+    height: 100px;
+    background: black;
+  }
+</style>

--- a/src/components/alert/alert-component.ts
+++ b/src/components/alert/alert-component.ts
@@ -15,6 +15,7 @@ import { GestureController, BlockerDelegate, BLOCK_ALL } from '../../gestures/ge
   template:
     '<ion-backdrop (click)="bdClick()" [class.backdrop-no-tappable]="!d.enableBackdropDismiss"></ion-backdrop>' +
     '<div class="alert-wrapper">' +
+      '<div class="alert-background"></div>' +
       '<div class="alert-head">' +
         '<h2 id="{{hdrId}}" class="alert-title" *ngIf="d.title" [innerHTML]="d.title"></h2>' +
         '<h3 id="{{subHdrId}}" class="alert-sub-title" *ngIf="d.subTitle" [innerHTML]="d.subTitle"></h3>' +
@@ -102,6 +103,9 @@ export class AlertCmp {
     this.mode = _config.get('mode');
     renderer.setElementClass(_elementRef.nativeElement, `alert-${this.mode}`, true);
 
+    if (_config.getBoolean('backdropEffects')) {
+      renderer.setElementClass(_elementRef.nativeElement, `backdrop-effect`, true);
+    }
     if (this.d.cssClass) {
       this.d.cssClass.split(' ').forEach(cssClass => {
         // Make sure the class isn't whitespace, otherwise it throws exceptions

--- a/src/components/alert/alert.ios.scss
+++ b/src/components/alert/alert.ios.scss
@@ -458,3 +458,35 @@ $alert-ios-checkbox-icon-transform:             rotate(45deg) !default;
 .alert-ios .alert-button.activated {
   background-color: $alert-ios-button-background-color-activated;
 }
+
+.alert-ios.backdrop-effect .alert-button,
+.alert-ios.backdrop-effect .alert-head,
+.alert-ios.backdrop-effect .alert-message,
+.alert-ios.backdrop-effect .alert-radio-group,
+.alert-ios.backdrop-effect .alert-input-group,
+.alert-ios.backdrop-effect .alert-checkbox-group {
+  background-color: rgba(250, 250, 250, .7);
+}
+
+.alert-ios.backdrop-effect .alert-button.activated {
+  background-color: rgba(230, 230, 230, 0.6);
+}
+
+.alert-ios.backdrop-effect .alert-wrapper {
+  background-color: transparent;
+}
+
+.alert-ios.backdrop-effect .alert-background {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+
+  z-index: -1;
+
+  display: block;
+
+  -webkit-backdrop-filter: blur(20px) brightness(220%) saturate(140%);
+  backdrop-filter: blur(20px) brightness(220%) saturate(140%);
+}

--- a/src/components/alert/alert.scss
+++ b/src/components/alert/alert.scss
@@ -101,3 +101,7 @@ ion-alert input {
   text-align: left;
   background: transparent;
 }
+
+.alert-background {
+  display: none;
+}

--- a/src/components/tap-click/activator.ts
+++ b/src/components/tap-click/activator.ts
@@ -14,7 +14,7 @@ export class Activator implements ActivatorBase {
   clearDelay = CLEAR_STATE_DEFERS;
 
   constructor(protected app: App, config: Config) {
-    this._css = config.get('activatedClass') || 'activated';
+    this._css = config.get('activatedClass', 'activated');
   }
 
   clickAction(ev: UIEvent, activatableEle: HTMLElement, startCoord: PointerCoordinates) {

--- a/src/platform/platform-registry.ts
+++ b/src/platform/platform-registry.ts
@@ -112,6 +112,7 @@ export const PLATFORM_CONFIGS: {[key: string]: PlatformConfig} = {
       tapPolyfill: isIOSUI,
       virtualScrollEventAssist: isIOSUI,
       disableScrollAssist: isIOS,
+      backdropEffects: supportsBackdropFilter
     },
     isMatch(p: Platform) {
       return p.isPlatformMatch('ios', ['iphone', 'ipad', 'ipod'], ['windows phone']);
@@ -217,6 +218,10 @@ export const PLATFORM_CONFIGS: {[key: string]: PlatformConfig} = {
     }
   }
 };
+
+function supportsBackdropFilter(p: Platform) {
+  return 'webkitBackdropFilter' in document.body.style;
+}
 
 function isCordova(): boolean {
   return !!((<any>window).cordova);


### PR DESCRIPTION
#### Short description of what this resolves:

<img width="48%" src="https://cloud.githubusercontent.com/assets/127379/16401083/9eb43012-3ce1-11e6-8667-6f875fc326ea.PNG"> <img width="48%" src="https://cloud.githubusercontent.com/assets/127379/16401084/a23eb14e-3ce1-11e6-8107-bc811887f75d.PNG">

Both screenshots taken from device (iPhone 6).

STILL WORK IN PROGRESS
activate state does not look good
- This change can be potentially implemented for Alert as well.

**Ionic Version**: 2.x
