### PR TITLE
feat(ion-input): incorporate HTML5 <input> attributes

### DIFF
--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -11,7 +11,7 @@ import { Item } from '../item/item';
 import { NativeInput, NextInput } from './native-input';
 import { NavController } from '../../navigation/nav-controller';
 import { Platform } from '../../platform/platform';
-
+import { isTrueProperty } from '../../util/util';
 
 /**
  * @name Input
@@ -75,10 +75,53 @@ import { Platform } from '../../platform/platform';
 @Component({
   selector: 'ion-input',
   template:
-    '<input [type]="type" [(ngModel)]="_value" (blur)="inputBlurred($event)" (focus)="inputFocused($event)" [placeholder]="placeholder" class="text-input" [ngClass]="\'text-input-\' + _mode">' +
-    '<input [type]="type" aria-hidden="true" next-input *ngIf="_useAssist">' +
-    '<button ion-button clear [hidden]="!clearInput" type="button" class="text-input-clear-icon" (click)="clearTextInput()" (mousedown)="clearTextInput()"></button>' +
-    '<div (touchstart)="pointerStart($event)" (touchend)="pointerEnd($event)" (mousedown)="pointerStart($event)" (mouseup)="pointerEnd($event)" class="input-cover" tappable *ngIf="_useAssist"></div>',
+    '<input' +
+      ' [type]="_type"' +
+      ' [(ngModel)]="_value"' +
+      ' (blur)="inputBlurred($event)"' +
+      ' (focus)="inputFocused($event)"' +
+      ' [placeholder]="placeholder"' +
+      ' class="text-input"' +
+      ' [ngClass]="\'text-input-\' + _mode"' +
+      ' [attr.autocomplete]="autocomplete"' +
+      ' [attr.autocorrect]="autocorrect"' +
+      ' [attr.autocapitalize]="autocapitalize"' +
+      ' [autofocus]="_autofocus"' +
+      ' [disabled]="_disabled"' +
+      ' [attr.list]="list"' +
+      ' [attr.max]="max"' +
+      ' [attr.maxlength]="maxlength"' +
+      ' [attr.min]="min"' +
+      ' [attr.minlength]="minlength"' +
+      ' [readonly]="_readonly"' +
+      ' [required]="_required"' +
+      ' [spellcheck]="_spellcheck"' +
+      ' [attr.step]="step"' +
+      ' [attr.tabindex]="tabindex"' +
+      ' [attr.name]="name">' +
+    '<input' +
+      ' [type]="_type"' +
+      ' aria-hidden="true"' +
+      ' next-input' +
+      ' *ngIf="_useAssist">' +
+    '<button' +
+      ' ion-button' +
+      ' clear' +
+      ' [hidden]="!_clearInput"' +
+      ' type="button"' +
+      ' class="text-input-clear-icon"' +
+      ' (click)="clearTextInput()"' +
+      ' (mousedown)="clearTextInput()">' +
+    '</button>' +
+    '<div' +
+      ' (touchstart)="pointerStart($event)"' +
+      ' (touchend)="pointerEnd($event)"'+
+      ' (mousedown)="pointerStart($event)"' +
+      ' (mouseup)="pointerEnd($event)"' +
+      ' class="input-cover"' +
+      ' tappable' +
+      ' *ngIf="_useAssist">' +
+    '</div>',
   encapsulation: ViewEncapsulation.None,
 })
 export class TextInput extends InputBase {
@@ -104,6 +147,101 @@ export class TextInput extends InputBase {
    * @private
    */
   _clearInput: boolean = false;
+
+  /**
+   * @private
+   */
+  @Input() autocomplete: string;
+
+  /**
+   * @private
+   */
+  @Input() autocorrect: string;
+
+  /**
+   * @private
+   */
+  @Input() autocapitalize: string;
+
+  /**
+   * @private
+   */
+  get autofocus(): boolean {
+    return this._autofocus;
+  }
+  @Input() set autofocus(value: boolean) {
+    this._autofocus = isTrueProperty(value);
+  }
+
+  /**
+   * @private
+   */
+  @Input() list: string = null;
+
+  /**
+   * @private
+   */
+  @Input() max: string | number = null;
+
+  /**
+   * @private
+   */
+  @Input() maxlength: number = null;
+
+  /**
+   * @private
+   */
+  @Input() min: string | number = null;
+
+  /**
+   * @private
+   */
+  @Input() minlength: number = null;
+
+  /**
+   * @private
+   */
+  get readonly(): boolean {
+    return this._readonly;
+  }
+  @Input() set readonly(value: boolean) {
+    this._readonly = isTrueProperty(value);
+  }
+
+  /**
+   * @private
+   */
+  get required(): boolean {
+    return this._required;
+  }
+  @Input() set required(value: boolean) {
+    this._required = isTrueProperty(value);
+  }
+
+  /**
+   * @private
+   */
+  get spellcheck(): boolean {
+    return this._spellcheck;
+  }
+  @Input() set spellcheck(value: boolean) {
+    this._spellcheck = isTrueProperty(value);
+  }
+
+  /**
+   * @private
+   */
+  @Input() step: number = null;
+
+  /**
+   * @private
+   */
+  @Input() tabindex: number = null;
+
+  /**
+   * @private
+   */
+  @Input() name: string = null;
 
   /**
    * @private
@@ -283,9 +421,37 @@ export class TextInput extends InputBase {
 @Component({
   selector: 'ion-textarea',
   template:
-    '<textarea [(ngModel)]="_value" (blur)="inputBlurred($event)" (focus)="inputFocused($event)" [placeholder]="placeholder" class="text-input" [ngClass]="\'text-input-\' + _mode"></textarea>' +
-    '<input type="text" aria-hidden="true" next-input *ngIf="_useAssist">' +
-    '<div (touchstart)="pointerStart($event)" (touchend)="pointerEnd($event)" (mousedown)="pointerStart($event)" (mouseup)="pointerEnd($event)" class="input-cover" tappable *ngIf="_useAssist"></div>',
+    '<textarea' +
+      ' [(ngModel)]="_value"' +
+      ' (blur)="inputBlurred($event)"' +
+      ' (focus)="inputFocused($event)"' +
+      ' [placeholder]="placeholder"' +
+      ' class="text-input"' +
+      ' [ngClass]="\'text-input-\' + _mode">' +
+      ' [attr.autocomplete]="autocomplete"' +
+      ' [attr.autocapitalize]="autocapitalize"' +
+      ' [autofocus]="_autofocus"' +
+      ' [disabled]="_disabled"' +
+      ' [attr.maxlength]="maxlength"' +
+      ' [attr.minlength]="minlength"' +
+      ' [readonly]="_readonly"' +
+      ' [required]="_required"' +
+      ' [spellcheck]="_spellcheck"' +
+      ' [attr.name]="name">' +
+    '</textarea>' +
+    '<input type="text"' +
+      ' aria-hidden="true"' +
+      ' next-input' +
+      ' *ngIf="_useAssist">' +
+    '<div' +
+      ' (touchstart)="pointerStart($event)"' +
+      ' (touchend)="pointerEnd($event)"' +
+      ' (mousedown)="pointerStart($event)"' +
+      ' (mouseup)="pointerEnd($event)"' +
+      ' class="input-cover"' +
+      ' tappable' +
+      ' *ngIf="_useAssist">' +
+    '</div>',
   encapsulation: ViewEncapsulation.None,
 })
 export class TextArea extends InputBase {
@@ -416,4 +582,70 @@ export class TextArea extends InputBase {
   inputFocused(ev: UIEvent) {
     this.focus.emit(ev);
   }
+
+  /**
+   * @private
+   */
+  @Input() autocomplete: string;
+
+  /**
+   * @private
+   */
+  @Input() autocapitalize: string;
+
+  /**
+   * @private
+   */
+  get autofocus(): boolean {
+    return this._autofocus;
+  }
+  @Input() set autofocus(value: boolean) {
+    this._autofocus = isTrueProperty(value);
+  }
+
+  /**
+   * @private
+   */
+  @Input() maxlength: number = null;
+
+  /**
+   * @private
+   */
+  @Input() minlength: number = null;
+
+  /**
+   * @private
+   */
+  get readonly(): boolean {
+    return this._readonly;
+  }
+  @Input() set readonly(value: boolean) {
+    this._readonly = isTrueProperty(value);
+  }
+
+  /**
+   * @private
+   */
+  get required(): boolean {
+    return this._required;
+  }
+  @Input() set required(value: boolean) {
+    this._required = isTrueProperty(value);
+  }
+
+  /**
+   * @private
+   */
+  get spellcheck(): boolean {
+    return this._spellcheck;
+  }
+  @Input() set spellcheck(value: boolean) {
+    this._spellcheck = isTrueProperty(value);
+  }
+
+  /**
+   * @private
+   */
+  @Input() name: string = null;
+
 }

--- a/src/components/input/test/fixed-inline-labels/e2e.ts
+++ b/src/components/input/test/fixed-inline-labels/e2e.ts
@@ -1,1 +1,89 @@
+import { async, TestBed } from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {TextInput} from '../input';
+import {AppModule} from './app-module';
 
+import {DomElementSchemaRegistry} from '@angular/compiler/src/schema/dom_element_schema_registry';
+
+describe('TextInput', () => {
+  beforeEach(async(() => {
+    TestBed.configureTestingModule(AppModule);
+    TestBed.compileComponents();
+  }));
+
+  let inp_attrs = {
+    autocomplete: 'foo',
+    autocorrect: 'foo',
+    autocapitalize: 'foo',
+    list: 'foo',
+    name: 'foo',
+    max: 123,
+    maxlength: 123,
+    min: 123,
+    minlength: 123,
+    step: 123,
+    tabindex: 123,
+    autofocus: true,
+    readonly: true,
+    required: true,
+    spellcheck: true,
+    disabled: true,
+  };
+
+  let textarea_attrs = {
+    autocomplete: 'foo',
+    autocapitalize: 'foo',
+    name: 'foo',
+    maxlength: 123,
+    minlength: 123,
+    autofocus: true,
+    readonly: true,
+    required: true,
+    spellcheck: true,
+    disabled: true,
+  };
+
+  for (let k of inp_attrs) {
+    let v = inp_attrs[k];
+    it(`supports the ${k} attribute`, () => {
+      let fixture = TestBed.createComponent(TextInput);
+      let input: TextInput = fixture.debugElement.query(By.css('#attr_inp')).componentInstance;
+      console.log('input', input);
+      let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+      console.log('el', el);
+      fixture.detectChanges();
+      expect(el.getAttribute(k)).toEqual(null);
+      input[k] = v.toString();
+      fixture.detectChanges();
+      expect(el.getAttribute(k)).toEqual(v);
+    });
+  }
+
+);
+
+describe('DOMElementSchema', () => {
+  let registry: DomElementSchemaRegistry;
+  beforeEach(() => {
+    registry = new DomElementSchemaRegistry();
+  });
+
+  it('should detect properties on regular elements', () => {
+    expect(registry.hasProperty('input', 'autocomplete', [])).toBeFalsy();
+    expect(registry.hasProperty('input', 'autocorrect', [])).toBeFalsy();
+    expect(registry.hasProperty('input', 'autocapitalize', [])).toBeFalsy();
+    expect(registry.hasProperty('input', 'autofocus', [])).toBeTruthy();
+    expect(registry.hasProperty('input', 'disabled', [])).toBeTruthy();
+    expect(registry.hasProperty('input', 'list', [])).toBeFalsy();
+    expect(registry.hasProperty('input', 'max', [])).toBeFalsy();
+    expect(registry.hasProperty('input', 'maxlength', [])).toBeFalsy();
+    expect(registry.hasProperty('input', 'min', [])).toBeFalsy();
+    expect(registry.hasProperty('input', 'minlength', [])).toBeFalsy();
+    expect(registry.hasProperty('input', 'readonly', [])).toBeTruthy();
+    expect(registry.hasProperty('input', 'required', [])).toBeTruthy();
+    expect(registry.hasProperty('input', 'spellcheck', [])).toBeTruthy();
+    expect(registry.hasProperty('input', 'step', [])).toBeFalsy();
+    expect(registry.hasProperty('input', 'tabindex', [])).toBeFalsy();
+    expect(registry.hasProperty('input', 'name', [])).toBeFalsy();
+  });
+
+};

--- a/src/components/input/test/fixed-inline-labels/main.html
+++ b/src/components/input/test/fixed-inline-labels/main.html
@@ -89,6 +89,29 @@
       <ion-textarea value="To infinity and beyond"></ion-textarea>
     </ion-item>
 
+    <ion-item>
+      <ion-label fixed>Attributes</ion-label>
+      <!-- 
+      [autocomplete]="str"
+      [autocorrect]="str"
+      [autocapitalize]="str"
+      [list]="str"
+      [name]="str"
+      [max]="num"
+      [maxlength]="num"
+      [min]="num"
+      [minlength]="num"
+      [step]="num"
+      [tabindex]="num"
+      autofocus
+      readonly
+      required
+      spellcheck
+      disabled
+      -->
+      <ion-input #attrs id="attr_inp"></ion-input>
+    </ion-item>
+
   </ion-list>
 
   <p>{{url}}</p>

--- a/src/components/input/test/stacked-labels/app-module.ts
+++ b/src/components/input/test/stacked-labels/app-module.ts
@@ -1,4 +1,4 @@
-import { Component, NgModule } from '@angular/core';
+import { Component, NgModule, ViewChild } from '@angular/core';
 import { IonicApp, IonicModule } from '../../../..';
 
 
@@ -7,6 +7,8 @@ import { IonicApp, IonicModule } from '../../../..';
 })
 export class PageOne {
   gender = '';
+  str = 'foo';
+  num = 1;
 }
 
 


### PR DESCRIPTION
#### Short description of what this resolves:

feat(ion-input): incorporate HTML5 <input> attributes
#### Changes proposed in this pull request:

Pass the HTML5 <input> attributes through to ion-input, as done in md-input. The point here is that Angular 2 can use these attributes to match validator directives against, some of which come natively as part of @angular/forms itself. It feels kind of silly a regular <input> now gets more functionality out of the box than the pretty-by-default ion-input does.

**Ionic Version**: 2.x

**Fixes**: #

issue #8209

**Notes**:

So that BooleanFieldValue is useful. Should Material2 Core be added as a dependency instead for this?
