### PR TITLE
(reorder fixes:) https://github.com/driftyco/ionic/issues/7522

### DIFF
--- a/src/components/item/item-reorder.ts
+++ b/src/components/item/item-reorder.ts
@@ -256,7 +256,7 @@ export class ItemReorder {
    */
   reorderReset() {
     // remove temp bottom item.
-    this._element.querySelector('.ion-reorder-temp-item').remove()
+    this._element.querySelector('.ion-reorder-temp-item').remove();
 
     let children = this._element.children;
     let len = children.length;

--- a/src/components/item/item-reorder.ts
+++ b/src/components/item/item-reorder.ts
@@ -146,6 +146,9 @@ export class ItemReorder {
   _lastToIndex: number = -1;
 
   /** @private */
+  _lastDirection: number = 0;
+
+  /** @private */
   _element: HTMLElement;
 
   /**
@@ -221,6 +224,15 @@ export class ItemReorder {
    */
   reorderEmit(fromIndex: number, toIndex: number) {
     this.reorderReset();
+
+    // fixes bug: https://github.com/driftyco/ionic/issues/8782
+    let diff = fromIndex - toIndex;
+    if( this._lastDirection > 0 && diff === 1 ) {
+      toIndex = toIndex + 1
+    } else if ( this._lastDirection < 0 && diff === -1 ) {
+      toIndex = toIndex - 1
+    }
+
     if (fromIndex !== toIndex) {
       this._zone.run(() => {
         this.ionItemReorder.emit({
@@ -264,6 +276,8 @@ export class ItemReorder {
     if (this._lastToIndex === -1) {
       this._lastToIndex = fromIndex;
     }
+    //store last direction
+    this._lastDirection = this._lastToIndex > toIndex ? -1 : 1;
     let lastToIndex = this._lastToIndex;
     this._lastToIndex = toIndex;
 

--- a/src/components/item/item-reorder.ts
+++ b/src/components/item/item-reorder.ts
@@ -146,9 +146,6 @@ export class ItemReorder {
   _lastToIndex: number = -1;
 
   /** @private */
-  _lastDirection: number = 0;
-
-  /** @private */
   _element: HTMLElement;
 
   /**
@@ -204,6 +201,8 @@ export class ItemReorder {
    */
   reorderPrepare() {
     let ele = this._element;
+    // append child to allow reordering to bottom position
+    ele.insertAdjacentHTML('beforeend', '<div class="ion-reorder-temp-item item-block"></div>');
     let children: any = ele.children;
     for (let i = 0, ilen = children.length; i < ilen; i++) {
       var child = children[i];
@@ -227,9 +226,7 @@ export class ItemReorder {
 
     // fixes bug: https://github.com/driftyco/ionic/issues/8782
     let diff = fromIndex - toIndex;
-    if( this._lastDirection > 0 && diff === 1 ) {
-      toIndex = toIndex + 1
-    } else if ( this._lastDirection < 0 && diff === -1 ) {
+    if(diff < 0 ) {
       toIndex = toIndex - 1
     }
 
@@ -258,6 +255,9 @@ export class ItemReorder {
    * @private
    */
   reorderReset() {
+    // remove temp bottom item.
+    this._element.querySelector('.ion-reorder-temp-item').remove()
+
     let children = this._element.children;
     let len = children.length;
 
@@ -276,8 +276,6 @@ export class ItemReorder {
     if (this._lastToIndex === -1) {
       this._lastToIndex = fromIndex;
     }
-    //store last direction
-    this._lastDirection = this._lastToIndex > toIndex ? -1 : 1;
     let lastToIndex = this._lastToIndex;
     this._lastToIndex = toIndex;
 
@@ -290,16 +288,16 @@ export class ItemReorder {
     /********* DOM WRITE ********* */
     let transform = CSS.transform;
     if (toIndex >= lastToIndex) {
-      for (var i = lastToIndex; i <= toIndex; i++) {
+      for (var i = lastToIndex; i <= toIndex-1; i++) {
         if (i !== fromIndex) {
-          (<any>children[i]).style[transform] = (i > fromIndex)
+          (<any>children[i]).style[transform] = (i >= fromIndex)
             ? `translateY(${-itemHeight}px)` : '';
         }
       }
     }
 
-    if (toIndex <= lastToIndex) {
-      for (var i = toIndex; i <= lastToIndex; i++) {
+    if (toIndex < lastToIndex) {
+      for (var i = toIndex; i <= lastToIndex+1; i++) {
         if (i !== fromIndex) {
           (<any>children[i]).style[transform] = (i < fromIndex)
             ? `translateY(${itemHeight}px)` : '';


### PR DESCRIPTION
#### Short description of what this resolves:

https://github.com/driftyco/ionic/issues/7522
-items getting 'stuck together'
-items not getting the right .toIndex when dropped back in their original positions
#### Changes proposed in this pull request:
- sets right indexes
- needs temporary bottom item to get right index when dragged to bottom of list (probably there is a way around this, but I couldn't figure out a better way

**Ionic Version**: 2.x
