### PR TITLE
feat(range): adding the resolution property for the range

### DIFF
--- a/src/components/range/range.ts
+++ b/src/components/range/range.ts
@@ -255,7 +255,6 @@ export class Range extends Ion implements AfterViewInit, ControlValueAccessor, O
    */
   @Input()
   get resolution(): number {
-    //console.log('retur')
     return this._resolution;
   }
   set resolution(val: number) {
@@ -619,8 +618,8 @@ export class Range extends Ion implements AfterViewInit, ControlValueAccessor, O
    * @private
    */
   ratioToValue(ratio: number) {
-    ratio = ((this._max - this._min) * ratio).toFixed(this.resolution);
-    ratio = ((ratio / this._step) * this._step + this._min).toFixed(this.resolution);
+    ratio = parseFloat(((this._max - this._min) * ratio).toFixed(this.resolution));
+    ratio = parseFloat(((ratio / this._step) * this._step + this._min).toFixed(this.resolution));
     return clamp(this._min, ratio, this._max);
   }
 

--- a/src/components/range/range.ts
+++ b/src/components/range/range.ts
@@ -215,6 +215,7 @@ export class Range extends Ion implements AfterViewInit, ControlValueAccessor, O
   _min: number = 0;
   _max: number = 100;
   _step: number = 1;
+  _resolution: number = 0;
   _snaps: boolean = false;
 
   _debouncer: TimeoutDebouncer = new TimeoutDebouncer(0);
@@ -250,6 +251,21 @@ export class Range extends Ion implements AfterViewInit, ControlValueAccessor, O
   id: string;
 
   /**
+   * @input {number} Resolution for the step. Defaults to `0`.
+   */
+  @Input()
+  get resolution(): number {
+    //console.log('retur')
+    return this._resolution;
+  }
+  set resolution(val: number) {
+    val = Math.round(val);
+    if (!isNaN(val)) {
+      this._resolution = val;
+    }
+  }
+
+  /**
    * @input {number} Minimum integer value of the range. Defaults to `0`.
    */
   @Input()
@@ -262,6 +278,7 @@ export class Range extends Ion implements AfterViewInit, ControlValueAccessor, O
       this._min = val;
     }
   }
+
 
   /**
    * @input {number} Maximum integer value of the range. Defaults to `100`.
@@ -602,8 +619,8 @@ export class Range extends Ion implements AfterViewInit, ControlValueAccessor, O
    * @private
    */
   ratioToValue(ratio: number) {
-    ratio = Math.round(((this._max - this._min) * ratio));
-    ratio = Math.round(ratio / this._step) * this._step + this._min;
+    ratio = ((this._max - this._min) * ratio).toFixed(this.resolution);
+    ratio = ((ratio / this._step) * this._step + this._min).toFixed(this.resolution);
     return clamp(this._min, ratio, this._max);
   }
 

--- a/src/components/range/test/basic/page1.html
+++ b/src/components/range/test/basic/page1.html
@@ -18,6 +18,11 @@
 <ion-content>
 
   <ion-list>
+    <ion-item>
+      <ion-label>step="0.01" max="10" min="0" pin="true" resolution="2"</ion-label>
+      <ion-range [(ngModel)]="singleValue" color="danger" pin="true" (ionChange)="rangeChange($event)" resolution="2" step="0.01" min="1" max="10"></ion-range>
+    </ion-item>
+
 
     <ion-item>
       <ion-label>step="5199" max="5199" min="2499" snaps="true"</ion-label>


### PR DESCRIPTION
#### Enhancement
Add of a resolution property in the ion-range component in order to select the number of decimals needed by the developper. 

**Ionic Version**: 2.x

**Issue**: #6812 

