### PR TITLE
Fixed scrolling for Picker

### DIFF
--- a/src/components/picker/picker.scss
+++ b/src/components/picker/picker.scss
@@ -21,6 +21,8 @@ ion-picker-cmp {
   height: $picker-width;
 
   contain: strict;
+  
+  overflow:hidden;
 }
 
 .picker-toolbar {


### PR DESCRIPTION
#### Short description of what this resolves:
When User touches to the corner of Picker and scroll it to up, nothing will happen.

#### Changes proposed in this pull request:

I propose to add next style to  <ion-picker-cmp>: 
ion-picker-cmp{
 overflow: hidden;
}

**Ionic Version**: 1.x / 2.x

**Fixes**: #

I have faced with next problem:
When ion-datetime opens, User can touch to the corner of ion-datetime and scroll it to top of the screen device (The problem here: https://forum.ionicframework.com/t/ionic-2-rc-2-0-3-ion-datetime-has-scroll/72269)