### PR TITLE
fix(content): hide scrollbar on desktop platform when content doesn't need to scroll

### DIFF
--- a/src/components/content/content.scss
+++ b/src/components/content/content.scss
@@ -37,7 +37,7 @@ a {
   display: block;
 
   overflow-x: hidden;
-  overflow-y: scroll;
+  overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   will-change: scroll-position;
 

--- a/src/components/content/content.scss
+++ b/src/components/content/content.scss
@@ -44,6 +44,10 @@ a {
   contain: size style layout;
 }
 
+.platform-core .scroll-content {
+  overflow-y: auto;
+}
+
 ion-content.js-scroll > .scroll-content {
   position: relative;
 


### PR DESCRIPTION
#### Short description of what this resolves:

By default content always display an horizontal scrollbar even if the content doesn't need to scroll.
This fix is mainly usefull on desktop browser

#### Changes proposed in this pull request:

- overflow-y from *scroll* to *auto*

**Ionic Version**: 2.x

**Fixes**: #
![scrollbar](https://cloud.githubusercontent.com/assets/659811/22920377/19cda86e-f295-11e6-9119-515c8a7618d6.JPG)
