### PR TITLE
Added RadioButton to emitted event

### DIFF
--- a/src/components/radio/radio-button.ts
+++ b/src/components/radio/radio-button.ts
@@ -201,7 +201,7 @@ export class RadioButton extends Ion implements IonicTapInput, OnDestroy, OnInit
     ev.stopPropagation();
 
     this.checked = true;
-    this.ionSelect.emit(this.value);
+    this.ionSelect.emit(this.value, this);
   }
 
   /**


### PR DESCRIPTION
This allows to update the checked state manually via the event process.

#### Short description of what this resolves:
A problem by manually set the checked state of radio buttons.

The main problem is that I want to uncheck a radio button within a radio-group if its clicked and not required. But currently it stays checked. I want if its not required that its unchecked then like a checkbox. But then I lose the ability to check one radio button at the same time.

#### Changes proposed in this pull request:

- Added second parameter to event emitter of radio button with `this` value (first parameter is `this.value`)

**Ionic Version**: 1.x / 2.x
2.x

**Fixes**: #
-/-
