### PR TITLE
refactor(error-handler): remove use of deprecated param

### DIFF
--- a/src/util/ionic-error-handler.ts
+++ b/src/util/ionic-error-handler.ts
@@ -42,7 +42,7 @@ import { ErrorHandler } from '@angular/core';
  */
 export class IonicErrorHandler extends ErrorHandler {
   constructor() {
-    super(false);
+    super();
   }
   /**
    * @internal

--- a/src/util/ionic-error-handler.ts
+++ b/src/util/ionic-error-handler.ts
@@ -41,9 +41,6 @@ import { ErrorHandler } from '@angular/core';
  * More information about Angular's [`ErrorHandler`](https://angular.io/docs/ts/latest/api/core/index/ErrorHandler-class.html).
  */
 export class IonicErrorHandler extends ErrorHandler {
-  constructor() {
-    super();
-  }
   /**
    * @internal
    */


### PR DESCRIPTION
#### Short description of what this resolves:
> @deprecated since v4.0 parameter no longer has an effect, as ErrorHandler will never rethrow.

#### Changes proposed in this pull request:

- remove use of deprecated parameter
- remove explicit super constructor call

**Ionic Version**: 3.x
