### PR TITLE
fix(alert): change alert content max-height

### DIFF
--- a/src/components/alert/alert.md.scss
+++ b/src/components/alert/alert.md.scss
@@ -43,7 +43,7 @@ $alert-md-message-text-color:                 rgba(0, 0, 0, .5) !default;
 $alert-md-message-padding-empty:              0 !default;
 
 /// @prop - Maximum height of the alert content
-$alert-md-content-max-height:                 240px !default;
+$alert-md-content-max-height:                 200px !default;
 
 /// @prop - Border width of the alert input
 $alert-md-input-border-width:                 1px !default;


### PR DESCRIPTION
Alert dialog with some content pushes bottom buttons to out of screen. max-height should be set to a lower value to make sure the buttons stay visible as the content is scrollable.

**Ionic Version**: 3.x

**Fixes**: #6326