### PR TITLE
feat(show-hide-when): add support for mode, media queries

### DIFF
--- a/src/components/show-hide-when/display-when.ts
+++ b/src/components/show-hide-when/display-when.ts
@@ -1,46 +1,134 @@
-import { NgZone } from '@angular/core';
+import { Input, NgZone } from '@angular/core';
 
+import { Config } from '../../config/config';
 import { Platform } from '../../platform/platform';
 
+const QUERY: { [key: string]: string }  = {
+  xs: '(min-width: 0px)',
+  sm: '(min-width: 576px)',
+  md: '(min-width: 768px)',
+  lg: '(min-width: 992px)',
+  xl: '(min-width: 1200px)'
+};
 
 /**
  * @hidden
  */
 export class DisplayWhen {
+  private _resizeObs: any;
+  private _query: string;
+  private _rmListener: any;
+
   isMatch: boolean = false;
   conditions: string[];
-  resizeObs: any;
 
-  constructor(conditions: string, public _plt: Platform, public zone: NgZone) {
+  @Input()
+  set when(query: string) {
+    if (typeof query === 'boolean') {
+      this.isMatch = this._query = query;
+    } else {
+      query = this._query = query.toLowerCase();
+      this.checkConditions(query);
+    }
+  }
+
+  get when(): string {
+    return this._query;
+  }
+
+  constructor(conditions: string, public _config: Config, public _plt: Platform, public zone: NgZone) {
+    // this.checkConditions(conditions);
+  }
+
+  checkConditions(conditions: string): void {
     if (!conditions) return;
 
-    this.conditions = conditions.replace(/\s/g, '').split(',');
+    // Split the conditions on commas, unless the comma is inside of parantheses
+    // because this means it is inside of a media query
+    this.conditions = conditions.replace(/\s/g, '').split(/\,(?![^\(]*\))/g);
+    console.log('conditions', this.conditions);
 
     // check if its one of the matching platforms first
     // a platform does not change during the life of an app
     for (let i = 0; i < this.conditions.length; i++) {
-      if (this.conditions[i] && _plt.is(this.conditions[i])) {
-        this.isMatch = true;
-        return;
+      console.log('condition', this.conditions[i]);
+
+      // media: xs, media: (min-width: 44px), media: print and (min-width: 450px)
+      if (this.conditions[i] && this.conditions[i].indexOf('media') > -1) {
+        this.compareMedia(this.conditions[i]);
+      }
+
+      // mode: ios, mode: wp, mode: md
+      if (this.conditions[i] && this.conditions[i].indexOf('mode') > -1) {
+        this.compareMode(this.conditions[i]);
+      }
+
+      // platform: ios, platform: android, platform: iphone
+      // The expression after the OR statement is for backwards-compatibility
+      if (this.conditions[i] && (this.conditions[i].indexOf('platform') > -1) || (this._plt.is(this.conditions[i]))) {
+        this.comparePlatform(this.conditions[i]);
       }
     }
 
+    // orientation: portrait, orientation: landscape
     if (this.orientation()) {
       // add window resize listener
-      this.resizeObs = _plt.resize.subscribe(this.orientation.bind(this));
+      this._resizeObs = this._plt.resize.subscribe(this.orientation.bind(this));
+    }
+  }
+
+  compareMedia(condition: string): void {
+    condition = condition.replace('media:', '');
+
+    let query = QUERY[condition];
+    query = (query) ? query : condition;
+
+    if (query.indexOf(',') > -1 || query.indexOf('and') > -1) {
+      console.log('remove outside parens');
+      // query = query.substring(1, query.length - 1);
     }
 
+    if (query && query.length > 0) {
+      // Listen
+      const callback = (query: MediaQueryList) => this.isMatch = query.matches;
+      const mediaList = this._plt.win().matchMedia(query);
+
+      console.log('mediaList', mediaList);
+
+      mediaList.addListener(callback);
+      this.isMatch = mediaList.matches;
+      this._rmListener = function () {
+        mediaList.removeListener(callback);
+      };
+    }
+  }
+
+  compareMode(condition: string): void {
+    condition = condition.replace('mode:', '');
+    if (condition === this._config.get('mode')) {
+      this.isMatch = true;
+      return;
+    }
+  }
+
+  comparePlatform(condition: string): void {
+    condition = condition.replace('platform:', '');
+    if (this._plt.is(condition)) {
+      this.isMatch = true;
+      return;
+    }
   }
 
   orientation(): boolean {
     for (let i = 0; i < this.conditions.length; i++) {
+      let condition = this.conditions[i].replace('orientation:', '');
 
-      if (this.conditions[i] === 'portrait') {
+      if (condition === 'portrait') {
         this.isMatch = this._plt.isPortrait();
         return true;
       }
 
-      if (this.conditions[i] === 'landscape') {
+      if (condition === 'landscape') {
         this.isMatch = this._plt.isLandscape();
         return true;
       }
@@ -49,7 +137,7 @@ export class DisplayWhen {
   }
 
   ngOnDestroy() {
-    this.resizeObs && this.resizeObs.unsubscribe();
-    this.resizeObs = null;
+    this._resizeObs && this._resizeObs.unsubscribe();
+    this._resizeObs = null;
   }
 }

--- a/src/components/show-hide-when/hide-when.ts
+++ b/src/components/show-hide-when/hide-when.ts
@@ -1,5 +1,6 @@
-import { Attribute, Directive, NgZone } from '@angular/core';
+import { Attribute, Directive, Input, NgZone } from '@angular/core';
 
+import { Config } from '../../config/config';
 import { Platform } from '../../platform/platform';
 
 import { DisplayWhen } from './display-when';
@@ -52,13 +53,25 @@ import { DisplayWhen } from './display-when';
   }
 })
 export class HideWhen extends DisplayWhen {
+  /**
+   * @hidden
+   */
+  @Input()
+  set hideWhen(value: string) {
+    this.when = value;
+  }
+
+  get hideWhen(): string {
+    return this.when;
+  }
 
   constructor(
     @Attribute('hideWhen') hideWhen: string,
+    config: Config,
     plt: Platform,
     zone: NgZone
   ) {
-    super(hideWhen, plt, zone);
+    super(hideWhen, config, plt, zone);
   }
 
 }

--- a/src/components/show-hide-when/show-when.ts
+++ b/src/components/show-hide-when/show-when.ts
@@ -1,7 +1,8 @@
-import { Attribute, Directive, NgZone } from '@angular/core';
+import { Attribute, Directive, Input, NgZone } from '@angular/core';
 
 import { DisplayWhen } from './display-when';
 
+import { Config } from '../../config/config';
 import { Platform } from '../../platform/platform';
 
 
@@ -54,12 +55,25 @@ import { Platform } from '../../platform/platform';
 })
 export class ShowWhen extends DisplayWhen {
 
+  /**
+   * @hidden
+   */
+  @Input()
+  set showWhen(value: any) {
+    this.when = value;
+  }
+
+  get showWhen(): any {
+    return this.when;
+  }
+
   constructor(
     @Attribute('showWhen') showWhen: string,
+    config: Config,
     plt: Platform,
     zone: NgZone
   ) {
-    super(showWhen, plt, zone);
+    super(showWhen, config, plt, zone);
   }
 
   // ngOnDestroy is implemented in DisplayWhen

--- a/src/components/show-hide-when/test/advanced/app.module.ts
+++ b/src/components/show-hide-when/test/advanced/app.module.ts
@@ -1,0 +1,46 @@
+import { Component, NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { IonicApp, IonicModule } from '../../../..';
+
+
+@Component({
+  templateUrl: 'main.html'
+})
+export class E2EPage {
+  toggle = true;
+
+  isTrue = true;
+
+  showWhenValidOptions = {
+    mode: 'ios'
+  };
+
+  showWhenInvalidOptions = {
+    invalid: 'ios'
+  };
+}
+
+
+@Component({
+  template: '<ion-nav [root]="root"></ion-nav>'
+})
+export class AppComponent {
+  root = E2EPage;
+}
+
+@NgModule({
+  declarations: [
+    AppComponent,
+    E2EPage
+  ],
+  imports: [
+    BrowserModule,
+    IonicModule.forRoot(AppComponent)
+  ],
+  bootstrap: [IonicApp],
+  entryComponents: [
+    AppComponent,
+    E2EPage
+  ]
+})
+export class AppModule {}

--- a/src/components/show-hide-when/test/advanced/main.html
+++ b/src/components/show-hide-when/test/advanced/main.html
@@ -1,0 +1,256 @@
+<ion-header>
+
+  <ion-toolbar>
+    <ion-title showWhen="ios">iOS Platform</ion-title>
+    <ion-title showWhen="windows">Windows Platform</ion-title>
+    <ion-title showWhen="android">Android Platform</ion-title>
+    <ion-buttons end>
+      <button ion-button (click)="toggle = !toggle">Toggle</button>
+    </ion-buttons>
+  </ion-toolbar>
+
+</ion-header>
+
+
+<ion-content padding class="show-when-demo">
+  <p>Checkmarks will show up when <code>showWhen</code> is a match.</p>
+  <ion-grid>
+    <ion-row>
+      <ion-col>
+        <div padding-top>media: xs</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="media: xs" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>media: SM</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="media: SM" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>mEdia: md</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="mEdia: md" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>media: lg</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="media: lg" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>media: xl</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="media: xl" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+    </ion-row>
+
+    <ion-row>
+      <ion-col>
+        <div padding-top>media: (min-width: 100px)</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="media: (min-width: 100px)" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>media: ( (min-width: 400px), print ), mode: ios</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="media: ( (min-width: 400px), print ), mode: ios" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>media: (min-width: 500px)</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="media: (min-width: 500px)" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>media: (min-width: 700px)</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="media: (min-width: 700px)" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>media: (min-width: 900px)</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="media: (min-width: 900px)" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+    </ion-row>
+
+    <ion-row>
+      <ion-col>
+        <div padding-top>true</div>
+        <div class="icon-wrapper">
+          <ion-icon [showWhen]="true" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>false</div>
+        <div class="icon-wrapper">
+          <ion-icon [showWhen]="false" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>toggle</div>
+        <div class="icon-wrapper">
+          <ion-icon [showWhen]="toggle" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+    </ion-row>
+
+    <ion-row>
+      <ion-col>
+        <div padding-top>core</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="core" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>ios</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="ios" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>android</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="android" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>windows</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="windows" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+    </ion-row>
+
+    <ion-row>
+      <ion-col>
+        <div padding-top>portrait</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="portrait" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>landscape</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="landscape" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>media: (orientation: portrait)</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="media: (orientation: portrait)" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>media: (orientation: landscape)</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="media: (orientation: landscape)" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+    </ion-row>
+
+    <ion-row>
+      <ion-col>
+        <div padding-top>mode: ios</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="mode: ios" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>mode: md</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="mode: md" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>mode: wp</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="mode: wp" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+    </ion-row>
+
+    <ion-row>
+      <ion-col>
+        <div padding-top>mode:ios, mode: wp</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="mode:ios, mode: wp" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>mode: md,mode: ios</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="mode: md,mode: ios" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>mode: wp, mode: md</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="mode: wp, mode: md" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+    </ion-row>
+
+    <ion-row>
+      <ion-col>
+        <div padding-top>platform: ios</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="platform: ios" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>platform: android</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="platform: android" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>platform: windows</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="platform: windows" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+    </ion-row>
+
+    <ion-row>
+      <ion-col>
+        <div padding-top>orientation: portrait</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="orientation: portrait" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+      <ion-col>
+        <div padding-top>orientation: landscape</div>
+        <div class="icon-wrapper">
+          <ion-icon showWhen="orientation: landscape" color="secondary" name="checkmark"></ion-icon>
+        </div>
+      </ion-col>
+    </ion-row>
+
+  </ion-grid>
+
+</ion-content>
+
+<style>
+  .show-when-demo .col {
+    background: #f6f6f6;
+    text-align: center;
+    border: 1px solid #ddd;
+  }
+
+  .show-when-demo ion-icon {
+    font-size: 44px;
+    line-height: 28px;
+  }
+
+  .show-when-demo .icon-wrapper {
+    min-height: 40px;
+  }
+</style>

--- a/src/components/show-hide-when/test/advanced/main.ts
+++ b/src/components/show-hide-when/test/advanced/main.ts
@@ -1,0 +1,5 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+
+import { AppModule } from './app.module';
+
+platformBrowserDynamic().bootstrapModule(AppModule);


### PR DESCRIPTION
WIP DO NOT MERGE.

Known issues:
- When the screen resizes and it checks the media query it does not check the other condition in the OR, for example `media: ( (min-width: 400px), print ), mode: ios` should evaluate to true if it matches the `media` or `mode` but if it matches the media then you resize and it no longer does it will not be a match even if `mode` is `ios`. I'm sure there are many more edge cases like this.
- We should be sharing the QUERY constant with split pane
- The syntax for media is being checked in a weird way right now so that it will not be split on `,` inside of the media.
- Could probably do a split on `:` and then a switch statement on the key.
- The `and` is not implemented yet. 