### PR TITLE
fix(content): scroll content should inherit background

### DIFF
--- a/src/components/content/content.scss
+++ b/src/components/content/content.scss
@@ -60,6 +60,10 @@ ion-content.js-scroll > .scroll-content {
   touch-action: none;
 }
 
+ion-content.has-refresher > .scroll-content {
+  background-color: inherit;
+}
+
 
 // Fixed Content (ion-fixed and ion-fab)
 // --------------------------------------------------


### PR DESCRIPTION
#### Short description of what this resolves:
You can see the `ion-refresher` text when you're not supposed to see it. It happens when a page has `ion-refresher` and the content is really small (in this example, a single `ion-item`),

Examples:
![android-before](https://cloud.githubusercontent.com/assets/13794420/25598604/f53e203c-2ea3-11e7-8806-b5c9c2a011b0.gif)
![ios-before](https://cloud.githubusercontent.com/assets/13794420/25598605/f63255f8-2ea3-11e7-9ea3-97d425a68949.gif)


#### Changes proposed in this pull request:

Inherit background from parent to hide the content behind `.scroll-content` (i.e Refresher, Infinite Scroll.. etc). 

The fix is only for `ion-content.has-refresher > .scroll-content`. It might be a good idea to apply this fix to the `.scroll-content` selector.

Here's what it looks like with the fix:
![android-after](https://cloud.githubusercontent.com/assets/13794420/25598602/f2f7e1be-2ea3-11e7-89ff-e6cbc268b77c.gif)

**Ionic Version**:  3.x

