### PR TITLE
feat(datetime): Use current date/time in datetime picker if it's empty

### DIFF
--- a/src/components/datetime/datetime.ts
+++ b/src/components/datetime/datetime.ts
@@ -9,7 +9,7 @@ import { Form } from '../../util/form';
 import { BaseInput } from '../../util/base-input';
 import { Item } from '../item/item';
 import { deepCopy, isBlank, isPresent, isArray, isObject, isString, assert, clamp } from '../../util/util';
-import { dateValueRange, renderDateTime, renderTextFormat, convertDataToISO, convertFormatToKey, getValueFromFormat, parseTemplate, parseDate, updateDate, DateTimeData, daysInMonth, dateSortValue, dateDataSortValue, LocaleData } from '../../util/datetime-util';
+import { dateValueRange, renderDateTime, renderTextFormat, convertDataToISO, convertFormatToKey, getValueFromFormat, parseTemplate, parseDate, updateDate, DateTimeData, daysInMonth, dateSortValue, dateDataSortValue, LocaleData, nowDateTimeData } from '../../util/datetime-util';
 
 /**
  * @name DateTime
@@ -584,7 +584,11 @@ export class DateTime extends BaseInput<DateTimeData> implements AfterContentIni
 
         // cool, we've loaded up the columns with options
         // preselect the option for this column
-        const optValue = getValueFromFormat(this.getValue(), format);
+        let optValue = getValueFromFormat(this.getValue(), format);
+        if (!isPresent(optValue)) {
+          // Default to current date/time
+          optValue = getValueFromFormat(nowDateTimeData(), format);
+        }
         const selectedIndex = column.options.findIndex(opt => opt.value === optValue);
         if (selectedIndex >= 0) {
           // set the select index for this column's options

--- a/src/components/datetime/test/basic/pages/root-page/root-page.html
+++ b/src/components/datetime/test/basic/pages/root-page/root-page.html
@@ -114,4 +114,9 @@
     <ion-datetime [(ngModel)]="noFormatDate"></ion-datetime>
   </ion-item>
 
+  <ion-item>
+    <ion-label>Default selected values in picker</ion-label>
+    <ion-datetime displayFormat="MMM DD, YYYY HH:mm"></ion-datetime>
+  </ion-item>
+
 </ion-content>

--- a/src/components/datetime/test/datetime.spec.ts
+++ b/src/components/datetime/test/datetime.spec.ts
@@ -335,6 +335,22 @@ describe('DateTime', () => {
       expect(columns[0].options[10].value).toEqual(2000);
     });
 
+    it('should default to current date/time if there is no selected value', () => {
+      datetime.max = '2100-01-01';
+      datetime.min = '2000-01-01';
+      datetime.pickerFormat = 'YYYY MM DD HH mm';
+
+      datetime.generate();
+      var columns = picker.getColumns();
+
+      var now = new Date();
+      expect(columns[0].options[columns[0].selectedIndex].value).toEqual(now.getFullYear());
+      expect(columns[1].options[columns[1].selectedIndex].value).toEqual(now.getMonth() + 1);
+      expect(columns[2].options[columns[2].selectedIndex].value).toEqual(now.getDate());
+      expect(columns[3].options[columns[3].selectedIndex].value).toEqual(now.getHours());
+      expect(columns[4].options[columns[4].selectedIndex].value).toEqual(now.getMinutes());
+    });
+
   });
 
   describe('calcMinMax', () => {

--- a/src/util/datetime-util.ts
+++ b/src/util/datetime-util.ts
@@ -390,6 +390,20 @@ export function convertDataToISO(data: DateTimeData): string {
   return rtn;
 }
 
+export function nowDateTimeData(): DateTimeData {
+  const now = new Date();
+  return {
+    year: now.getFullYear(),
+    month: now.getMonth() + 1,
+    day: now.getDate(),
+    hour: now.getHours(),
+    minute: now.getMinutes(),
+    second: now.getSeconds(),
+    millisecond: now.getMilliseconds(),
+    tzOffset: now.getTimezoneOffset(),
+  };
+}
+
 function twoDigit(val: number): string {
   return ('0' + (isPresent(val) ? Math.abs(val) : '0')).slice(-2);
 }


### PR DESCRIPTION
#### Short description of what this resolves:
If a datetime doesn't have a value, the picker used to pre-select the first value (usually the max year). Now it will pre-select the current date/time.

#### Changes proposed in this pull request:
- Make datetime picker pre-select current date/time if it has no value.

**Ionic Version**: 1.x / 2.x / 3.x
3.x

**Fixes**: (partially) #9846
