### PR TITLE
Fix unguarded unregistration

### DIFF
--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -265,7 +265,7 @@ export class Tabs extends Ion implements AfterViewInit, RootNode, ITabs {
 
   ngOnDestroy() {
     this._resizeObs && this._resizeObs.unsubscribe();
-    this.parent.unregisterChildNav(this);
+    this.parent && this.parent.unregisterChildNav && this.parent.unregisterChildNav(this);
   }
 
   /**


### PR DESCRIPTION
#### Short description of what this resolves:
Not having this guard in place forces awkward testing practices, such as injecting NavControllers with mocked register/unregister methods just so the ngOnDestroy doesn't throw exceptions.
#### Changes proposed in this pull request:
Put guards against null parent

**Ionic Version**: 3.x

This bug is also present in Ionic 2.x but a separate pull request will be created.