### PR TITLE
fix(ionSelect): support cssClass for popover interface

### DIFF
--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -309,7 +309,7 @@ export class Select extends BaseInput<any> implements OnDestroy {
       var popoverCssClass = 'select-popover';
 
       // If the user passed a cssClass for the select, add it
-      popoverCssClass += selectOptions.cssClass ? ' ' + selectOptions.cssClass : popoverCssClass;
+      popoverCssClass += selectOptions.cssClass ? ' ' + selectOptions.cssClass : '';
 
       overlay = new Popover(this._app, SelectPopover, {
         options: popoverOptions

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -306,10 +306,15 @@ export class Select extends BaseInput<any> implements OnDestroy {
         }
       }));
 
+      var popoverCssClass = 'select-popover';
+
+      // If the user passed a cssClass for the select, add it
+      popoverCssClass += selectOptions.cssClass ? ' ' + selectOptions.cssClass : popoverCssClass;
+
       overlay = new Popover(this._app, SelectPopover, {
         options: popoverOptions
       }, {
-        cssClass: 'select-popover'
+        cssClass: popoverCssClass
       }, this.config, this.deepLinker);
 
       // ev.target is readonly.


### PR DESCRIPTION
#### Short description of what this resolves:
When using ion-select with popover interface, it does not support the cssClass in "selectOptions" attribute.

#### Changes proposed in this pull request:
- support property cssClass in selectOptions 

**Ionic Version**: 3.x

**Fixes**: #
#11695 