### PR TITLE
fix(swiper): use correct length for nested slides

### DIFF
--- a/src/components/slides/swiper/swiper.ts
+++ b/src/components/slides/swiper/swiper.ts
@@ -354,7 +354,8 @@ export function updateContainerSize(s: Slides, plt: Platform) {
 }
 
 export function updateSlidesSize(s: Slides, plt: Platform) {
-  s._slides = (<any>s._wrapper.querySelectorAll('.' + CLS.slide));
+  s._slides = (<any>Array.from(s._wrapper.children)
+    .filter(el => el.classList.contains(CLS.slide)));
   s._snapGrid = [];
   s._slidesGrid = [];
   s._slidesSizesGrid = [];


### PR DESCRIPTION
#### Short description of what this resolves:

length() incorrectly includes the total number of nested slides in its result, allowing the user to swipe past the final slide and getting the slides "stuck".

#### Changes proposed in this pull request:

- Only include immediate children in the length() calculation

**Ionic Version**:  3.x

**Fixes**: #10195
