### PR TITLE
fix(escape-key-event) handle fast and double event 

### DIFF
--- a/src/components/action-sheet/action-sheet-component.ts
+++ b/src/components/action-sheet/action-sheet-component.ts
@@ -51,6 +51,7 @@ export class ActionSheetCmp {
   enabled: boolean;
   hdrId: string;
   id: number;
+  isEscape: boolean;
   mode: string;
   gestureBlocker: BlockerDelegate;
 
@@ -65,6 +66,7 @@ export class ActionSheetCmp {
   ) {
     this.gestureBlocker = gestureCtrl.createBlocker(BLOCK_ALL);
     this.d = params.data;
+    this.isEscape = false;
     this.mode = config.get('mode');
     renderer.setElementClass(_elementRef.nativeElement, `action-sheet-${this.mode}`, true);
 
@@ -131,6 +133,7 @@ export class ActionSheetCmp {
     if (this.enabled && ev.keyCode === KEY_ESCAPE && this._viewCtrl.isLast()) {
       console.debug('actionsheet, escape button');
       this.bdClick();
+      this.isEscape = true;
     }
   }
 
@@ -169,7 +172,16 @@ export class ActionSheetCmp {
     const opts: NavOptions = {
       minClickBlockDuration: 400
     };
-    return this._viewCtrl.dismiss(null, role, opts);
+    let p = this._viewCtrl.dismiss(null, role, opts);
+
+    if (this.isEscape) {
+      p.then(() => {
+        this.isEscape = false;
+      }).catch( (err) => {
+        console.debug(err);
+      });
+    }
+    return p;
   }
 
   ngOnDestroy() {

--- a/src/components/alert/alert-component.ts
+++ b/src/components/alert/alert-component.ts
@@ -81,6 +81,7 @@ export class AlertCmp {
   id: number;
   inputType: string;
   lastClick: number;
+  isEscape: boolean;
   msgId: string;
   subHdrId: string;
   mode: string;
@@ -109,6 +110,7 @@ export class AlertCmp {
     }
 
     this.id = (++alertIds);
+    this.isEscape = false;
     this.descId = '';
     this.hdrId = 'alert-hdr-' + this.id;
     this.subHdrId = 'alert-subhdr-' + this.id;
@@ -231,7 +233,8 @@ export class AlertCmp {
 
       } else if (ev.keyCode === KEY_ESCAPE) {
         console.debug(`alert, escape button`);
-        this.bdClick();
+        this.isEscape = true;
+         this.bdClick();
       }
     }
   }
@@ -299,7 +302,17 @@ export class AlertCmp {
     const opts: NavOptions = {
       minClickBlockDuration: 400
     };
-    return this._viewCtrl.dismiss(this.getValues(), role, opts);
+
+    let p = this._viewCtrl.dismiss(this.getValues(), role, opts);
+    if (this.isEscape) {
+      p.then(() => {
+        this.isEscape = false;
+      })
+      .catch((err) => {
+        console.warn(err);
+      });
+    }
+    return p;
   }
 
   getValues(): any {

--- a/src/components/modal/modal-component.ts
+++ b/src/components/modal/modal-component.ts
@@ -106,7 +106,9 @@ export class ModalCmp {
   @HostListener('body:keyup', ['$event'])
   _keyUp(ev: KeyboardEvent) {
     if (this._enabled && this._viewCtrl.isLast() && ev.keyCode === KEY_ESCAPE) {
-      this._bdClick();
+        this._bdClick().catch((err) => {
+          console.warn(err);
+        });
     }
   }
 

--- a/src/components/picker/picker-component.ts
+++ b/src/components/picker/picker-component.ts
@@ -45,6 +45,7 @@ export class PickerCmp {
   d: PickerOptions;
   enabled: boolean;
   lastClick: number;
+  isEscape: boolean;
   id: number;
   mode: string;
   _gestureBlocker: BlockerDelegate;
@@ -60,6 +61,7 @@ export class PickerCmp {
   ) {
     this._gestureBlocker = gestureCtrl.createBlocker(BLOCK_ALL);
     this.d = params.data;
+    this.isEscape = false;
     this.mode = config.get('mode');
     renderer.setElementClass(_elementRef.nativeElement, `picker-${this.mode}`, true);
 
@@ -155,6 +157,7 @@ export class PickerCmp {
 
       } else if (ev.keyCode === KEY_ESCAPE) {
         console.debug('picker, escape button');
+        this.isEscape = true;
         this.bdClick();
       }
     }
@@ -206,7 +209,18 @@ export class PickerCmp {
   }
 
   dismiss(role: string): Promise<any> {
-    return this._viewCtrl.dismiss(this.getSelected(), role);
+    let p = this._viewCtrl.dismiss(this.getSelected(), role);
+
+    if (this.isEscape) {
+      p.then(() => {
+        this.isEscape = false;
+      })
+      .catch((err) => {
+        console.warn(err);
+      });
+    }
+
+    return p;
   }
 
   getSelected(): any {

--- a/src/components/popover/popover-component.ts
+++ b/src/components/popover/popover-component.ts
@@ -112,7 +112,9 @@ export class PopoverCmp {
   @HostListener('body:keyup', ['$event'])
   _keyUp(ev: KeyboardEvent) {
     if (this._enabled && ev.keyCode === KEY_ESCAPE && this._viewCtrl.isLast()) {
-      this._bdClick();
+      this._bdClick().catch((err) => {
+        console.warn(err);
+      });
     }
   }
 


### PR DESCRIPTION
#### Short description of what this resolves:
some components listen for ESCAPE KEY event to dismiss the view. When a user try to click the escape key more than one time and fast, ionic app will throw "Runtime Error Uncaught (in promise)". 
The bug can be found in the following :

- Model 
- Popover
- Picker
- Action Sheet
- Alert

please see issue #11776 

#### Changes proposed in this pull request:

Since the developer has no control over views that dismissed by Escape Key Event. The dismiss promise should be handled internally in the component by:
- handle promises "catch" part, with console.worn() or empty catch.
- add a flag to determine if the escape key event has fired the dismiss() method or user click.

**Ionic Version**:  3.x

**Fixes**: #
fix(Fast-Escape-Event):
- Model 
- Popover
- Picker
- Action Sheet
- Alert