### PR TITLE
 fix(sass): add default flag to variables / ignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "gulp-scss-lint": "0.4.0",
     "gulp-shell": "0.5.2",
     "gulp-strip-debug": "1.1.0",
+    "gulp-transform": "^2.0.0",
     "gulp-tslint": "6.1.1",
     "gulp-typescript": "2.13.6",
     "gulp-uglify": "2.0.0",

--- a/scripts/demos/variables.scss
+++ b/scripts/demos/variables.scss
@@ -3,7 +3,7 @@
 
 // Font path is used to include ionicons,
 // roboto, and noto sans fonts
-$font-path: "../assets/fonts";
+$font-path: "../assets/fonts"; // scss-lint:disable DefaultRule
 
 @import "ionic.globals";
 

--- a/scripts/e2e/variables.scss
+++ b/scripts/e2e/variables.scss
@@ -3,7 +3,7 @@
 
 // Font path is used to include ionicons,
 // roboto, and noto sans fonts
-$font-path: "../assets/fonts";
+$font-path: "../assets/fonts"; // scss-lint:disable DefaultRule
 
 @import "ionic.globals";
 

--- a/scripts/gulp/tasks/e2e.prod.ts
+++ b/scripts/gulp/tasks/e2e.prod.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'child_process';
-import { accessSync, readFileSync, writeFileSync } from 'fs';
+import { accessSync, readFileSync } from 'fs';
 import { dirname, join, relative } from 'path';
 
 import * as glob from 'glob';
@@ -11,7 +11,10 @@ import { argv } from 'yargs';
 
 
 import { DIST_E2E_COMPONENTS_ROOT, ES_2015, PROJECT_ROOT, SRC_ROOT, SRC_COMPONENTS_ROOT, SCRIPTS_ROOT } from '../constants';
-import { createTempTsConfig, createTimestamp, getFolderInfo, readFileAsync, runAppScriptsBuild, writeFileAsync, writePolyfills } from '../util';
+import {
+  createTempTsConfig, createTimestamp, getFolderInfo, readFileAsync, runAppScriptsBuild,
+  setSassIonicVersion, writeFileAsync, writePolyfills
+} from '../util';
 
 import * as pAll from 'p-all';
 
@@ -21,7 +24,7 @@ task('e2e.prepare', (done: Function) => {
 
 task('e2e.prepareSass', (done: Function) => {
   const version = `E2E-${createTimestamp()}`;
-  writeFileSync(join(SRC_ROOT, 'themes/version.scss'), `$ionic-version: "${version}";`);
+  setSassIonicVersion(version);
   done();
 });
 

--- a/scripts/gulp/tasks/lint.ts
+++ b/scripts/gulp/tasks/lint.ts
@@ -2,6 +2,9 @@ import { task, src } from 'gulp';
 import * as scsslint from 'gulp-scss-lint';
 import * as tslint from 'gulp-tslint';
 
+// These packages lack of types.
+const gulpTransform = require('gulp-transform');
+
 task('lint', ['lint.sass', 'lint.ts']);
 
 task('lint.ts', () => {
@@ -20,6 +23,19 @@ task('lint.sass', function() {
       '!src/util/test/*',
       '!src/themes/normalize.scss',
     ])
+    .pipe(defaultVariables())
     .pipe(scsslint())
     .pipe(scsslint.failReporter());
 });
+
+function defaultVariables() {
+  return gulpTransform(contents => {
+    const defaultExp = /(?!.*?( !default))^\$.*\;(?!.*(scss-lint:disable DefaultRule))/gm;
+
+    let matches;
+    while (matches = defaultExp.exec(contents))
+      console.warn('Variable', matches[0], 'Is missing !default');
+
+    return contents;
+  });
+}

--- a/scripts/gulp/util.ts
+++ b/scripts/gulp/util.ts
@@ -144,7 +144,7 @@ export function compileSass(destinationPath: string) {
 }
 
 export function setSassIonicVersion(version: string) {
-  writeFileSync(join(SRC_ROOT, 'themes/version.scss'), `$ionic-version: "${version}";`);
+  writeFileSync(join(SRC_ROOT, 'themes/version.scss'), `$ionic-version: "${version}"; // scss-lint:disable DefaultRule`);
 }
 
 export function copyFile(srcPath: string, destPath: string) {

--- a/src/components/split-pane/split-pane.ios.scss
+++ b/src/components/split-pane/split-pane.ios.scss
@@ -5,13 +5,13 @@
 // --------------------------------------------------
 
 /// @prop - Minimum width of the split-pane's side pane
-$split-pane-ios-side-min-width: $split-pane-side-min-width;
+$split-pane-ios-side-min-width: $split-pane-side-min-width !default;
 
 /// @prop - Maximum width of the split-pane's side pane
-$split-pane-ios-side-max-width: $split-pane-side-max-width;
+$split-pane-ios-side-max-width: $split-pane-side-max-width !default;
 
 /// @prop - Border style of the side pane
-$split-pane-ios-border: $hairlines-width solid $list-ios-border-color;
+$split-pane-ios-border: $hairlines-width solid $list-ios-border-color !default;
 
 .split-pane-ios.split-pane-visible >.split-pane-side {
   min-width: $split-pane-ios-side-min-width;

--- a/src/components/split-pane/split-pane.md.scss
+++ b/src/components/split-pane/split-pane.md.scss
@@ -5,13 +5,13 @@
 // --------------------------------------------------
 
 /// @prop - Minimum width of the split-pane's side pane
-$split-pane-md-side-min-width: $split-pane-side-min-width;
+$split-pane-md-side-min-width: $split-pane-side-min-width !default;
 
 /// @prop - Maximum width of the split-pane's side pane
-$split-pane-md-side-max-width: $split-pane-side-max-width;
+$split-pane-md-side-max-width: $split-pane-side-max-width !default;
 
 /// @prop - Border style of the side pane
-$split-pane-md-border: 1px solid $list-md-border-color;
+$split-pane-md-border: 1px solid $list-md-border-color !default;
 
 .split-pane-md.split-pane-visible >.split-pane-side {
   min-width: $split-pane-md-side-min-width;

--- a/src/components/split-pane/split-pane.wp.scss
+++ b/src/components/split-pane/split-pane.wp.scss
@@ -5,13 +5,13 @@
 // --------------------------------------------------
 
 /// @prop - Minimum width of the split-pane's side pane
-$split-pane-wp-side-min-width: $split-pane-side-min-width;
+$split-pane-wp-side-min-width: $split-pane-side-min-width !default;
 
 /// @prop - Maximum width of the split-pane's side pane
-$split-pane-wp-side-max-width: $split-pane-side-max-width;
+$split-pane-wp-side-max-width: $split-pane-side-max-width !default;
 
 /// @prop - Border style of the side pane
-$split-pane-wp-border: 1px solid $list-wp-border-color;
+$split-pane-wp-border: 1px solid $list-wp-border-color !default;
 
 .split-pane-wp.split-pane-visible >.split-pane-side {
   min-width: $split-pane-wp-side-min-width;

--- a/src/components/virtual-scroll/virtual-scroll.ts
+++ b/src/components/virtual-scroll/virtual-scroll.ts
@@ -4,7 +4,7 @@ import { adjustRendered, calcDimensions, estimateHeight, initReadNodes, processR
 import { Config } from '../../config/config';
 import { Content, ScrollEvent } from '../content/content';
 import { DomController } from '../../platform/dom-controller';
-import { isBlank, isFunction, isPresent, assert } from '../../util/util';
+import { isFunction, isPresent, assert } from '../../util/util';
 import { Platform } from '../../platform/platform';
 import { ViewController } from '../../navigation/view-controller';
 import { VirtualCell, VirtualData, VirtualNode } from './virtual-util';

--- a/src/themes/ionic.build.dark.scss
+++ b/src/themes/ionic.build.dark.scss
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-$ionic-theme: "Dark";
+$ionic-theme: "Dark"; // scss-lint:disable DefaultRule
 @import "./version";
 @import "./license";
 @import "./ionic.theme.dark";

--- a/src/themes/ionic.build.default.scss
+++ b/src/themes/ionic.build.default.scss
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-$ionic-theme: "Default";
+$ionic-theme: "Default"; // scss-lint:disable DefaultRule
 @import "./version";
 @import "./license";
 @import "./ionic.theme.default";

--- a/src/themes/ionic.globals.scss
+++ b/src/themes/ionic.globals.scss
@@ -31,20 +31,20 @@ $hairlines-width: .55px !default;
 // --------------------------------------------------
 // Grouped by elements which would be siblings
 
-$z-index-menu-overlay:           80;
-$z-index-overlay:                1000;
-$z-index-click-block:            99999;
+$z-index-menu-overlay:           80; // scss-lint:disable DefaultRule
+$z-index-overlay:                1000; // scss-lint:disable DefaultRule
+$z-index-click-block:            99999; // scss-lint:disable DefaultRule
 
-$z-index-fixed-content:          999;
-$z-index-scroll-content:         1;
-$z-index-refresher:              0;
+$z-index-fixed-content:          999; // scss-lint:disable DefaultRule
+$z-index-scroll-content:         1; // scss-lint:disable DefaultRule
+$z-index-refresher:              0; // scss-lint:disable DefaultRule
 
-$z-index-page-container:         0;
-$z-index-toolbar:                10;
-$z-index-toolbar-background:     -1;
+$z-index-page-container:         0; // scss-lint:disable DefaultRule
+$z-index-toolbar:                10; // scss-lint:disable DefaultRule
+$z-index-toolbar-background:     -1; // scss-lint:disable DefaultRule
 
-$z-index-backdrop:               2;
-$z-index-overlay-wrapper:        10;
+$z-index-backdrop:               2; // scss-lint:disable DefaultRule
+$z-index-overlay-wrapper:        10; // scss-lint:disable DefaultRule
 
-$z-index-item-options:           1;
-$z-index-item-divider:          100;
+$z-index-item-options:           1; // scss-lint:disable DefaultRule
+$z-index-item-divider:           100; // scss-lint:disable DefaultRule


### PR DESCRIPTION
#### Short description of what this resolves:
- Some more `!default` options for each platform for split pane
- Hard ignore for variables that shouldn't be overridden.

#### Changes proposed in this pull request:

- Add some missing `!default`
- Use flag: `scss-lint:disable DefaultRule` when wanting to not have `!default` intentionally. The name of this comment might be confusing as it is not a scss-lint rule, suggestions are welcomed

#### Note:
To find stuff without default and without the ignore comment, use regex: `(?!.*?( \!default))^\$.*\;(?!.*(scss-lint:disable DefaultRule))`, see example [here](https://regex101.com/r/ncBDHp/3)

**Ionic Version**:  3.x
