### PR TITLE
fix(native-input): add correct translate3d for rtl

### DIFF
--- a/src/components/input/native-input.ts
+++ b/src/components/input/native-input.ts
@@ -121,8 +121,8 @@ export class NativeInput {
           // move the native input to a location safe to receive focus
           // according to the browser, the native input receives focus in an
           // area which doesn't require the browser to scroll the input into place
-          const tx = this._plt.dir().toLowerCase() === 'rtl' ? 9999 : -9999;
-          (<any>focusedInputEle.style)[this._plt.Css.transform] =  `translate3d(${tx}px,${inputRelativeY}px,0)`;
+          const tx = this._plt.isRTL ? 9999 : -9999;
+          (<any>focusedInputEle.style)[this._plt.Css.transform] = `translate3d(${tx}px,${inputRelativeY}px,0)`;
           focusedInputEle.style.opacity = '0';
         }
 

--- a/src/components/input/native-input.ts
+++ b/src/components/input/native-input.ts
@@ -121,7 +121,8 @@ export class NativeInput {
           // move the native input to a location safe to receive focus
           // according to the browser, the native input receives focus in an
           // area which doesn't require the browser to scroll the input into place
-          (<any>focusedInputEle.style)[this._plt.Css.transform] = `translate3d(-9999px,${inputRelativeY}px,0)`;
+          const tx = this._plt.dir().toLowerCase() === 'rtl' ? 9999 : -9999;
+          (<any>focusedInputEle.style)[this._plt.Css.transform] =  `translate3d(${tx}px,${inputRelativeY}px,0)`;
           focusedInputEle.style.opacity = '0';
         }
 


### PR DESCRIPTION
#### Short description of what this resolves:
_"On a IOS devices and RTL Direction"_ when a user moves from input element to another input element, the cursor get appeared in the middle of the page, also the label gets flicker.

**this PR fixes:**
- Input Cursor bug in RTL in IOS device
- Lable Flicker bug  in RTL in IOS device

**IOS Device before the fix**
<img src="https://media.giphy.com/media/xUA7b70mprD7y6kZlS/giphy.gif"/>

**Android Device before the fix "not effected"**
![](https://media.giphy.com/media/xUA7bgVua8WdiUjFPq/giphy.gif)

#### Changes proposed in this pull request:

- Check the _platform.Dir_ before setting the translate3d
- The _tx_ in _translate3d_  in RTL should be 9999, while in LTR  -9999

**IOS Devie after the fix**
![](https://media.giphy.com/media/l4FGncRG5Vsw5iyOs/giphy.gif)

**Android Device after the fix**
![](https://media.giphy.com/media/3o7btP9dz74frsxAhW/giphy.gif)

**NOTE: the Android does not have this bug,  but I'm showing the Android device to confirm the fix has not changed any behaver of input in Android.

**Ionic Version**:
3.x
**Fixes**: 
#11745 (most of it)
#11211
