### PR TITLE
fix(toggle) add display block to support IOS device and safari browser

### DIFF
--- a/src/components/toggle/toggle.ios.scss
+++ b/src/components/toggle/toggle.ios.scss
@@ -83,7 +83,8 @@ $toggle-ios-item-end-padding-start:    $item-ios-padding-start !default;
 
 .toggle-ios {
   position: relative;
-
+  display: block;
+  
   width: $toggle-ios-width;
   height: $toggle-ios-height;
 

--- a/src/components/toggle/toggle.md.scss
+++ b/src/components/toggle/toggle.md.scss
@@ -107,7 +107,8 @@ $toggle-md-item-end-padding-start:       $item-md-padding-start !default;
 
 .toggle-md {
   position: relative;
-
+  display: block;
+  
   width: $toggle-md-track-width;
   height: $toggle-md-track-height;
 

--- a/src/components/toggle/toggle.wp.scss
+++ b/src/components/toggle/toggle.wp.scss
@@ -100,7 +100,6 @@ $toggle-wp-item-end-padding-start:       $item-wp-padding-start !default;
   width: $toggle-wp-track-width;
   height: $toggle-wp-track-height;
   
-
   box-sizing: content-box;
 
   contain: strict;

--- a/src/components/toggle/toggle.wp.scss
+++ b/src/components/toggle/toggle.wp.scss
@@ -96,10 +96,10 @@ $toggle-wp-item-end-padding-start:       $item-wp-padding-start !default;
 .toggle-wp {
   position: relative;
   display: block;
-  
+
   width: $toggle-wp-track-width;
   height: $toggle-wp-track-height;
-  
+
   box-sizing: content-box;
 
   contain: strict;

--- a/src/components/toggle/toggle.wp.scss
+++ b/src/components/toggle/toggle.wp.scss
@@ -95,9 +95,11 @@ $toggle-wp-item-end-padding-start:       $item-wp-padding-start !default;
 
 .toggle-wp {
   position: relative;
-
+  display: block;
+  
   width: $toggle-wp-track-width;
   height: $toggle-wp-track-height;
+  
 
   box-sizing: content-box;
 


### PR DESCRIPTION
#### Short description of what this resolves:
if toggle used without`<ion-item>` it will be broken in IOS device and Safari browser. and I think [this due to the browser compatibility  for "**contain property**"  in ios devices and Safari ](https://developer.mozilla.org/en-US/docs/Web/CSS/contain#Browser_compatibility)

#### Changes proposed in this pull request:

- add display: block to toggle classes for both ios and md


**Ionic Version**: 
3.x

**Fixes**: 
#11815
#11470
