### PR TITLE
fix(events): fixes publishing of platform specific events

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -418,7 +418,7 @@ export class IonicModule {
 
         // useFactory: ionic app initializers
         { provide: APP_INITIALIZER, useFactory: registerModeConfigs, deps: [ Config ], multi: true },
-        { provide: APP_INITIALIZER, useFactory: setupProvideEvents, deps: [ Platform, DomController ], multi: true },
+        { provide: APP_INITIALIZER, useFactory: setupProvideEvents, deps: [ Events, Platform, DomController ], multi: true },
         { provide: APP_INITIALIZER, useFactory: setupTapClick, deps: [ Config, Platform, DomController, App, GestureController ], multi: true },
         { provide: APP_INITIALIZER, useFactory: setupPreloading, deps: [ Config, DeepLinkConfigToken, ModuleLoader, NgZone ], multi: true },
 

--- a/src/util/events.ts
+++ b/src/util/events.ts
@@ -111,8 +111,7 @@ export class Events {
 /**
  * @hidden
  */
-export function setupEvents(plt: Platform, dom: DomController): Events {
-  const events = new Events();
+export function setupEvents(events: Events, plt: Platform, dom: DomController): Events {
   const win = plt.win();
   const doc = plt.doc();
 
@@ -175,8 +174,8 @@ export function setupEvents(plt: Platform, dom: DomController): Events {
 /**
  * @hidden
  */
-export function setupProvideEvents(plt: Platform, dom: DomController) {
+export function setupProvideEvents(events: Events, plt: Platform, dom: DomController) {
   return function() {
-    return setupEvents(plt, dom);
+    return setupEvents(events, plt, dom);
   };
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Currently it's not possible to subscribe to `app:offline`, `app:rotated` and other platform specific events via `Events` service

#### Changes proposed in this pull request:
It's due the fact that `Events` was passed as a separate provider in module configuration. And another `Events` instance was created in https://github.com/ionic-team/ionic/blob/master/src/util/events.ts#L115 . So, eventually there are 2 `Events` instances, one is created by Angular Injector and another one created inside `setupEvents` function

Instead I injected `Events` service in `setupProvideEvents` method via Angular dependency injection

**Ionic Version**:  3.x

**Fixes**: #11773
