### PR TITLE
fix(referesher): fix a bug with browser

### DIFF
--- a/src/components/refresher/refresher.ts
+++ b/src/components/refresher/refresher.ts
@@ -470,7 +470,7 @@ export class Refresher {
 
     const content = this._content;
     const Css = this._plt.Css;
-    content.setScrollElementStyle(Css.transform, ((y > 0) ? 'translateY(' + y + 'px) translateZ(0px)' : 'translateZ(0px)'));
+    content.setScrollElementStyle(Css.transform, ((y > 0) ? 'translateY(' + y + 'px) translateZ(0px)' : ''));
     content.setScrollElementStyle(Css.transitionDuration, duration);
     content.setScrollElementStyle(Css.transitionDelay, delay);
     content.setScrollElementStyle('overflow', (overflowVisible ? 'hidden' : ''));


### PR DESCRIPTION
#### Short description of what this resolves:
Although I'm not sure about this but leaving `translateZ(0px);` in scroll content's style could make the content displaced as after it's being done the content now have scroll and in browsers as we know there's a scroll fitting left or right. (although this bug doesn't affect on LTR but you can see the problem on RTL on a browser), besides why leaving `translateZ(0px);` in css when things have done?

#### Changes proposed in this pull request:

- remove `translateZ(0px);` when there's no vertical transform

**Ionic Version**: 3.x

**Fixes**: maybe #11822?

**Screen shot**:

Before the fix
![screenshot 28](https://cloud.githubusercontent.com/assets/2679112/26597662/f6fb1970-4587-11e7-831f-5a1591bdebd9.jpg)

After the fix
![screenshot 27](https://cloud.githubusercontent.com/assets/2679112/26597666/fa18a01e-4587-11e7-88f5-fa4116009c8e.jpg)