### PR TITLE
fix(tabs): change hardcoded $tabs-md-tab-color-inactive to use var

### DIFF
--- a/src/themes/ionic.theme.default.md.scss
+++ b/src/themes/ionic.theme.default.md.scss
@@ -33,7 +33,7 @@ $toolbar-md-inactive-color:           $toolbar-inactive-color !default;
 // --------------------------------------------------
 
 $tabs-md-background:                  $tabs-background !default;
-$tabs-md-tab-color-inactive:          #3c3c3c !default;
+$tabs-md-tab-color-inactive:          $tabs-tab-color-inactive !default;
 $tabs-md-tab-color-active:            $tabs-tab-color-active !default;
 
 


### PR DESCRIPTION
I'm new to all this, let me know if something is wrong.

#### Short description of what this resolves:
$tabs-md-tab-color-inactive is hardcoded instead of using $tabs-tab-color-inactive. It prevents from changing tabs color globally.

#### Changes proposed in this pull request:

- change the hardcoded $tabs-md-tab-color-inactive value to $tabs-tab-color-inactive

**Ionic Version**: 3.x

**Fixes**: #11847
