### PR TITLE
refactor(tabs): place tabs top on android

### DIFF
--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -272,7 +272,11 @@ export class Tabs extends Ion implements AfterViewInit, RootNode, ITabs {
    * @internal
    */
   ngAfterViewInit() {
-    this._setConfig('tabsPlacement', 'bottom');
+    if(this._plt.is('android')) {
+      this._setConfig('tabsPlacement', 'top');
+    } else {
+      this._setConfig('tabsPlacement', 'bottom');
+    }    
     this._setConfig('tabsLayout', 'icon-top');
     this._setConfig('tabsHighlight', this.tabsHighlight);
 


### PR DESCRIPTION
#### Short description of what this resolves:
Place tabs top if the platform is Android

#### Changes proposed in this pull request:
As you can read here: https://material.io/guidelines/components/tabs.html#tabs-usage the default placement of tabs should be at the top.

**Ionic Version**: 1.x / 2.x / 3.x
3.x
