### PR TITLE
docs(): rename Angular 2 to Angular

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -471,7 +471,7 @@ of ion-slides.
 #### Split Pane
 As part of our initiative to improve desktop support we have introduced a new component called [Split Pane](http://ionicframework.com/docs/v2/api/components/split-pane/SplitPane/). Split Pane makes it possible to easily create multi-view layouts. It allows elements, such as a menu or another navigation pane, to be displayed on large viewports. Split Pane can be used to achieve a layout similar to the Gmail (Android) or Mail (Apple) applications.
 
-#### Angular.4.8
+#### Angular 2.4.8
 Ionic has been updated to depend on Angular.4.8, which is the latest version that we have tested and confirmed to be compatible with Ionic. This means that updating to the 2.2.0 release of Ionic will automatically work with all of the performance updates, bug fixes and features in Angular.4.8!
 
 ### Ionic Storage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -471,8 +471,8 @@ of ion-slides.
 #### Split Pane
 As part of our initiative to improve desktop support we have introduced a new component called [Split Pane](http://ionicframework.com/docs/v2/api/components/split-pane/SplitPane/). Split Pane makes it possible to easily create multi-view layouts. It allows elements, such as a menu or another navigation pane, to be displayed on large viewports. Split Pane can be used to achieve a layout similar to the Gmail (Android) or Mail (Apple) applications.
 
-#### Angular 2.4.8
-Ionic has been updated to depend on Angular 2.4.8, which is the latest version that we have tested and confirmed to be compatible with Ionic. This means that updating to the 2.2.0 release of Ionic will automatically work with all of the performance updates, bug fixes and features in Angular 2.4.8!
+#### Angular.4.8
+Ionic has been updated to depend on Angular.4.8, which is the latest version that we have tested and confirmed to be compatible with Ionic. This means that updating to the 2.2.0 release of Ionic will automatically work with all of the performance updates, bug fixes and features in Angular.4.8!
 
 ### Ionic Storage
 
@@ -1286,7 +1286,7 @@ Select’s `alertOptions` input has been renamed to `selectOptions`. It now allo
 
 **Reason for this change:**
 - It was difficult to have custom buttons since buttons automatically received the Ionic styles. The user can now take advantage of adding their own styling to a button if they want it to behave differently than the Ionic button.
-Keeping the `<a>` and `<button>` element and adding `ion-button` as an attribute gives us the ability to take advantage of the native functionality and built-in accessibility of native elements. If Ionic provided an `<ion-button>` we’d have to copy over all the possible attributes and events to the real nested button/link (`type=submit`, `formnovalidate`, `value`, `autofocus`, `href`, `target`, `focus`/`blur`, `download`, `nofollow`, `ping`, etc). Additionally, Angular 2 does not have the "replace" directive where `<ion-button>` could be turned into `<a ion-button>`.
+Keeping the `<a>` and `<button>` element and adding `ion-button` as an attribute gives us the ability to take advantage of the native functionality and built-in accessibility of native elements. If Ionic provided an `<ion-button>` we’d have to copy over all the possible attributes and events to the real nested button/link (`type=submit`, `formnovalidate`, `value`, `autofocus`, `href`, `target`, `focus`/`blur`, `download`, `nofollow`, `ping`, etc). Additionally, Angular does not have the "replace" directive where `<ion-button>` could be turned into `<a ion-button>`.
 - Since `button` was already being used as an attribute to the `<a>` element, this is more consistent between the two.
 - If a navPush or navPop directive is on an `<a ion-button>`, Ionic can automatically add the `href` attribute.
 - [A few reasons why we didn’t create `<ion-button>`](https://www.youtube.com/watch?list=PLNYkxOF6rcICWx0C9LVWWVqvHlYJyqw7g&v=CZGqnp06DnI)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -472,7 +472,7 @@ of ion-slides.
 As part of our initiative to improve desktop support we have introduced a new component called [Split Pane](http://ionicframework.com/docs/v2/api/components/split-pane/SplitPane/). Split Pane makes it possible to easily create multi-view layouts. It allows elements, such as a menu or another navigation pane, to be displayed on large viewports. Split Pane can be used to achieve a layout similar to the Gmail (Android) or Mail (Apple) applications.
 
 #### Angular 2.4.8
-Ionic has been updated to depend on Angular.4.8, which is the latest version that we have tested and confirmed to be compatible with Ionic. This means that updating to the 2.2.0 release of Ionic will automatically work with all of the performance updates, bug fixes and features in Angular.4.8!
+Ionic has been updated to depend on Angular 2.4.8, which is the latest version that we have tested and confirmed to be compatible with Ionic. This means that updating to the 2.2.0 release of Ionic will automatically work with all of the performance updates, bug fixes and features in Angular 2.4.8!
 
 ### Ionic Storage
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "ionic2",
   "version": "3.3.0",
-  "description": "A powerful framework for building mobile and progressive web apps with JavaScript and Angular 2",
+  "description": "A powerful framework for building mobile and progressive web apps with JavaScript and Angular",
   "keywords": [
     "ionic",
     "framework",

--- a/scripts/polyfill/readme.md
+++ b/scripts/polyfill/readme.md
@@ -38,7 +38,7 @@ weak maps / weak sets
 
 ## polyfills.ng.js
 
-Only the required polyfill for Angular 2. This does not come with any ES6 polyfills. Note that all polyfill files listed here included the required polyfills for Angular 2 to work correctly.
+Only the required polyfill for Angular. This does not come with any ES6 polyfills. Note that all polyfill files listed here included the required polyfills for Angular to work correctly.
 
 ### Targets:
 

--- a/scripts/templates/provider/ts.tmpl
+++ b/scripts/templates/provider/ts.tmpl
@@ -6,7 +6,7 @@ import 'rxjs/add/operator/map';
   Generated class for the $CLASSNAME provider.
 
   See https://angular.io/docs/ts/latest/guide/dependency-injection.html
-  for more info on providers and Angular 2 DI.
+  for more info on providers and Angular DI.
 */
 @Injectable()
 export class $CLASSNAME {

--- a/src/components/segment/segment.ts
+++ b/src/components/segment/segment.ts
@@ -11,7 +11,7 @@ import { SegmentButton } from './segment-button';
  * @description
  * A Segment is a group of buttons, sometimes known as Segmented Controls, that allow the user to interact with a compact group of a number of controls.
  * Segments provide functionality similar to tabs, selecting one will unselect all others. You should use a tab bar instead of a segmented control when you want to let the user move back and forth between distinct pages in your app.
- * You could use Angular 2's `ngModel` or `FormBuilder` API. For an overview on how `FormBuilder` works, checkout [Angular 2 Forms](http://learnangular2.com/forms/), or [Angular FormBuilder](https://angular.io/docs/ts/latest/api/forms/index/FormBuilder-class.html)
+ * You could use Angular's `ngModel` or `FormBuilder` API. For an overview on how `FormBuilder` works, checkout [Angular Forms](http://learnangular2.com/forms/), or [Angular FormBuilder](https://angular.io/docs/ts/latest/api/forms/index/FormBuilder-class.html)
  *
  *
  * ```html
@@ -60,7 +60,7 @@ import { SegmentButton } from './segment-button';
  *
  * @demo /docs/demos/src/segment/
  * @see {@link /docs/components#segment Segment Component Docs}
- * @see [Angular 2 Forms](http://learnangular2.com/forms/)
+ * @see [Angular Forms](http://learnangular2.com/forms/)
  */
 @Directive({
   selector: 'ion-segment',

--- a/src/navigation/nav-controller.ts
+++ b/src/navigation/nav-controller.ts
@@ -270,7 +270,7 @@ import { ViewController } from './view-controller';
  * ## Nav Guards
  *
  * In some cases, a developer should be able to control views leaving and entering. To allow for this, NavController has the `ionViewCanEnter` and `ionViewCanLeave` methods.
- * Similar to Angular 2 route guards, but are more integrated with NavController. For example, if you wanted to prevent a user from leaving a view:
+ * Similar to Angular route guards, but are more integrated with NavController. For example, if you wanted to prevent a user from leaving a view:
  *
  * ```ts
  * export class MyClass{


### PR DESCRIPTION
#### Short description of what this resolves:
I want to eliminate the V2 Tag from Angular like we did with Ionic 2

