### PR TITLE
refactor(OpaqueToken): ready for Angular 4.2

### DIFF
--- a/src/components/app/app-root.ts
+++ b/src/components/app/app-root.ts
@@ -1,4 +1,4 @@
-import { Component, ComponentFactoryResolver, ElementRef, Inject, OnInit, OpaqueToken, Renderer, ViewChild, ViewContainerRef } from '@angular/core';
+import { Component, ComponentFactoryResolver, ElementRef, Inject, OnInit, InjectionToken, Renderer, ViewChild, ViewContainerRef } from '@angular/core';
 
 import { App } from './app';
 import { assert } from '../../util/util';
@@ -8,7 +8,7 @@ import { OverlayPortal } from './overlay-portal';
 import { Platform } from '../../platform/platform';
 import * as Constants from './app-constants';
 
-export const AppRootToken = new OpaqueToken('USERROOT');
+export const AppRootToken = new InjectionToken<string>('USERROOT');
 
 /**
  * @hidden

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,4 +1,4 @@
-import { OpaqueToken } from '@angular/core';
+import { InjectionToken } from '@angular/core';
 
 /**
 * @ngdoc service
@@ -413,4 +413,4 @@ export function setupConfig(userConfig: any, plt: Platform): Config {
 /**
  * @hidden
  */
-export const ConfigToken = new OpaqueToken('USERCONFIG');
+export const ConfigToken = new InjectionToken<string>('USERCONFIG');

--- a/src/navigation/url-serializer.ts
+++ b/src/navigation/url-serializer.ts
@@ -1,4 +1,4 @@
-import { OpaqueToken } from '@angular/core';
+import { InjectionToken } from '@angular/core';
 
 import { DeepLinkConfig, NavLink, NavSegment } from './nav-util';
 import { isArray, isBlank, isPresent } from '../util/util';
@@ -320,7 +320,7 @@ const URL_REPLACE_REG = /\s+|\?|\!|\$|\,|\.|\+|\"|\'|\*|\^|\||\/|\\|\[|\]|#|%|`|
 /**
  * @hidden
  */
-export const DeepLinkConfigToken = new OpaqueToken('USERLINKS');
+export const DeepLinkConfigToken = new InjectionToken<string>('USERLINKS');
 
 export function setupUrlSerializer(userDeepLinkConfig: any): UrlSerializer {
   return new UrlSerializer(userDeepLinkConfig);

--- a/src/platform/platform-registry.ts
+++ b/src/platform/platform-registry.ts
@@ -1,4 +1,4 @@
-import { OpaqueToken } from '@angular/core';
+import { InjectionToken } from '@angular/core';
 
 import { Platform, PlatformConfig } from './platform';
 import { isCordova, isElectron, isIos, isIosUIWebView } from './platform-utils';
@@ -241,7 +241,7 @@ export const PLATFORM_CONFIGS: { [key: string]: PlatformConfig } = {
 };
 
 
-export const PlatformConfigToken = new OpaqueToken('PLTCONFIG');
+export const PlatformConfigToken = new InjectionToken<string>('PLTCONFIG');
 
 export function providePlatformConfigs() {
   return PLATFORM_CONFIGS;

--- a/src/util/module-loader.ts
+++ b/src/util/module-loader.ts
@@ -1,10 +1,10 @@
-import { ComponentFactoryResolver, Injectable, Injector, NgModuleFactory, NgZone, OpaqueToken, Type } from '@angular/core';
+import { ComponentFactoryResolver, Injectable, Injector, NgModuleFactory, NgZone, InjectionToken, Type } from '@angular/core';
 import { Config } from '../config/config';
 import { DeepLinkConfig } from '../navigation/nav-util';
 import { NgModuleLoader } from './ng-module-loader';
 import { requestIonicCallback } from './util';
 
-export const LAZY_LOADED_TOKEN = new OpaqueToken('LZYCMP');
+export const LAZY_LOADED_TOKEN = new InjectionToken<string>('LZYCMP');
 
 
 


### PR DESCRIPTION
#### Short description of what this resolves:
Change OpaqueToken  to InjectionToken.

From the Angular 4.2 Beta 5 Changelog

`OpaqueToken `is now deprecated, use `InjectionToken<T>` instead.

#### Changes proposed in this pull request:
- Change OpaqueToken  import to InjectionToken
- Change new OpaqueToken('') to new InjectionToken<string>('');

**Ionic Version**: 1.x / 2.x / 3.x
3.x
