### PR TITLE
fix(tabs): disable ios 3d touch peek and pop

### DIFF
--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -152,7 +152,7 @@ import { ViewController } from '../../navigation/view-controller';
   selector: 'ion-tabs',
   template:
     '<div class="tabbar" role="tablist" #tabbar>' +
-      '<a *ngFor="let t of _tabs" [tab]="t" class="tab-button" role="tab" href="#" (ionSelect)="select(t)"></a>' +
+      '<button *ngFor="let t of _tabs" [tab]="t" class="tab-button" role="tab" (ionSelect)="select(t)"></button>' +
       '<div class="tab-highlight"></div>' +
     '</div>' +
     '<ng-content></ng-content>' +


### PR DESCRIPTION
#### Short description of what this resolves:
When I force(3d) press on tabs in ios, ios treats it as a link and shows preview.

#### Changes proposed in this pull request:
ion-tab elements should not be anchor tags, and thus would not trigger 3D Touch.

**Ionic Version**: 3.x

**Fixes**: #11896 , #10462 
