### PR TITLE
feat(datetime): add day of the week values filter

### DIFF
--- a/src/components/datetime/datetime.ts
+++ b/src/components/datetime/datetime.ts
@@ -354,6 +354,16 @@ export class DateTime extends BaseInput<DateTimeData> implements AfterContentIni
   @Input() dayValues: any;
 
   /**
+   * @input {array | string} Values used to create the list of selectable weekdays. By default
+   * the weekday values range from `0` to `6`. However, to control exactly which days of the week to
+   * display, the `weekdayValues` input can take either an array of numbers, or string of
+   * comma separated numbers. For example, if only weekend days should be shown, then this
+   * input value would be `weekdayValues="0,6"`. Note that weekday numbers do have a
+   * zero-based index, meaning Sunday's value is `0`, and Saturday's is `6`.
+   */
+  @Input() weekdayValues: any;
+
+  /**
    * @input {array | string} Values used to create the list of selectable hours. By default
    * the hour values range from `0` to `23` for 24-hour, or `1` to `12` for 12-hour. However,
    * to control exactly which hours to display, the `hourValues` input can take either an
@@ -628,6 +638,23 @@ export class DateTime extends BaseInput<DateTimeData> implements AfterContentIni
     const options = column.options;
     let indexMin = options.length - 1;
     let indexMax = 0;
+    let filteredDays: any[] = []; // Contains the days that will show.
+
+    if (name === 'day' && ub[0] === lb[0] && ub[1] === lb[1] && isPresent(this.weekdayValues)) {
+      var weekdays = convertToArrayOfNumbers(this.weekdayValues, 'weekday');
+      // Find the day of the week that the month starts on (months are 0 indexed in the date object)
+      var firstDay = new Date(ub[0], ub[1] - 1, 1).getDay();
+      for (var i = 0; i < weekdays.length; i++) {
+        // Date is the first day that matches the weekday values
+        var date = 1 + weekdays[i] - firstDay;
+        if (date < 0) date += 7;
+
+        while (date <= 31) {
+          filteredDays.push(date);
+          date += 7;
+        }
+      }
+    }
 
     for (var i = 0; i < options.length; i++) {
       var opt = options[i];
@@ -639,7 +666,8 @@ export class DateTime extends BaseInput<DateTimeData> implements AfterContentIni
         value < lowerBounds[index] ||
         value > upperBounds[index] ||
         dateSortValue(ub[0], ub[1], ub[2], ub[3], ub[4]) < min ||
-        dateSortValue(lb[0], lb[1], lb[2], lb[3], lb[4]) > max
+        dateSortValue(lb[0], lb[1], lb[2], lb[3], lb[4]) > max ||
+        (name === 'day' && isPresent(this.weekdayValues) && filteredDays.indexOf(value) === -1)
       );
       if (!disabled) {
         indexMin = Math.min(indexMin, i);

--- a/src/components/datetime/test/datetime.spec.ts
+++ b/src/components/datetime/test/datetime.spec.ts
@@ -140,6 +140,40 @@ describe('DateTime', () => {
       expect(columns[1].options[12].disabled).toEqual(true);
     });
 
+    it('should enable the weekday values given', () => {
+      datetime.monthValues = '6,7,8';
+      datetime.dayValues = '01,02,03,04,05,06,08,09,10, 11, 12, 13, 31';
+      datetime.yearValues = '2014,2015';
+      datetime.weekdayValues = '1,2,3,4,5'; // Monday - Friday
+
+      datetime.pickerFormat = 'MM DD YYYY';
+
+      datetime.generate();
+
+      var columns = picker.getColumns();
+
+      // Days will vary based on the month and year chosen.
+      columns[2].selectedIndex = 0; // 2014
+      datetime.validate();
+      columns[0].selectedIndex = 1; // July
+      datetime.validate();
+
+      // July 2014 has 23 weekdays starting on Tuesday July 1
+      var JulyWeekDays = [1, 2, 3, 4, 7, 8, 9, 10, 11, 14, 15, 16, 17, 18, 21, 22, 23, 24, 25, 28, 29, 30, 31];
+      for (var i = 0; i < columns[1].options.length; i++) {
+        expect(columns[1].options[i].disabled).toEqual(JulyWeekDays.indexOf(columns[1].options[i].value) === -1);
+      }
+
+      columns[0].selectedIndex = 0; // June
+      datetime.validate();
+
+      // June 2014 has 21 weekdays starting on Monday June 2.
+      var JuneWeekDays = [2, 3, 4, 5, 6, 9, 10, 11, 12, 13, 16, 17, 18, 19, 20, 23, 24, 25, 26, 27, 30];
+      for (var i = 0; i < columns[1].options.length; i++) {
+        expect(columns[1].options[i].disabled).toEqual(JuneWeekDays.indexOf(columns[1].options[i].value) === -1);
+      }
+    });
+
     it('should always return a string', () => {
       datetime.monthValues = '6,7,8';
       datetime.dayValues = '01,02,03,04,05,06,08,09,10, 11, 12, 13, 31';


### PR DESCRIPTION
#### Short description of what this resolves:
This extends ion-datetime to add the ability to filter based on days of the week.

#### Changes proposed in this pull request:

- Adds a weekdayValues attribute to the ion-datetime component

**Ionic Version**: 3.x

**Fixes**: #11628
