### PR TITLE
refactor(menu): move lint disable inside multi-dir

### DIFF
--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -62,10 +62,6 @@ ion-menu[side=right] > .menu-inner {
   }
 }
 
-ion-menu[side=start] > .menu-inner {
-  @include position-horizontal(0, auto);
-}
-
 ion-menu[side=end] > .menu-inner {
   @include position-horizontal(auto, 0);
 }

--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -46,6 +46,14 @@ ion-menu.show-menu {
   position: absolute;
 }
 
+ion-menu[side=left] > .menu-inner {
+  @include multi-dir() {
+    // scss-lint:disable PropertySpelling
+    right: auto;
+    left: 0;
+  }
+}
+
 ion-menu[side=right] > .menu-inner {
   @include multi-dir() {
     // scss-lint:disable PropertySpelling

--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -47,8 +47,8 @@ ion-menu.show-menu {
 }
 
 ion-menu[side=right] > .menu-inner {
-  // scss-lint:disable PropertySpelling
   @include multi-dir() {
+    // scss-lint:disable PropertySpelling
     right: 0;
     left: auto;
   }


### PR DESCRIPTION
#### Changes proposed in this pull request:

- A better base case to show how to use `multi-dir` correctly on disabled properties

**Ionic Version**: 1.x / 2.x / 3.x

**Fixes**: #
