### PR TITLE
refactor(config): make set method strongly typed

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -309,29 +309,15 @@ export class Config {
    * @param {string} [key] - The key used to look up the value at a later point in time.
    * @param {string} [value] - The config value being stored.
    */
-  set(...args: any[]) {
-    const arg0 = args[0];
-    const arg1 = args[1];
-
-    switch (args.length) {
-      case 2:
-        // set('key', 'value') = set key/value pair
-        // arg1 = value
-        this._s[arg0] = arg1;
-        delete this._c[arg0]; // clear cache
-        break;
-
-      case 3:
-        // setting('ios', 'key', 'value') = set key/value pair for platform
-        // arg0 = platform
-        // arg1 = key
-        // arg2 = value
-        this._s.platforms = this._s.platforms || {};
-        this._s.platforms[arg0] = this._s.platforms[arg0] || {};
-        this._s.platforms[arg0][arg1] = args[2];
-        delete this._c[arg1]; // clear cache
-        break;
-
+  set(key: string, value: any, platform?: string) {
+    if (!platform) {
+      this._s[key] = value;
+      delete this._c[key]; // clear cache
+    } else {
+      this._s.platforms = this._s.platforms || {};
+      this._s.platforms[platform] = this._s.platforms[platform] || {};
+      this._s.platforms[platform][key] = value;
+      delete this._c[key]; // clear cache
     }
 
     return this;

--- a/src/config/test/config.spec.ts
+++ b/src/config/test/config.spec.ts
@@ -235,7 +235,7 @@ describe('Config', () => {
     config.init(null, plt);
 
     config.set('tabsPlacement', 'bottom');
-    config.set('ios', 'tabsPlacement', 'top');
+    config.set('tabsPlacement', 'top', 'ios');
 
     expect(config.get('tabsPlacement')).toEqual('top');
   });


### PR DESCRIPTION
#### Short description of what this resolves:
Config `set` method was not strongly typed.

#### Changes proposed in this pull request:
Make it strongly typed.

**Ionic Version**: 3.x

**Fixes**: #9539 
