### PR TITLE
fix(select): reset placeholder text when no value is selected (#10439)

### DIFF
--- a/demos/src/select/pages/page-one/page-one.html
+++ b/demos/src/select/pages/page-one/page-one.html
@@ -22,7 +22,8 @@
 
     <ion-item>
       <ion-label>Gaming</ion-label>
-      <ion-select [(ngModel)]="gaming" okText="Okay" cancelText="Dismiss">
+      <ion-select [(ngModel)]="gaming" okText="Okay" cancelText="Dismiss" placeholder="None">
+        <ion-option value="">None</ion-option>
         <ion-option value="nes">NES</ion-option>
         <ion-option value="n64">Nintendo64</ion-option>
         <ion-option value="ps">PlayStation</ion-option>
@@ -78,7 +79,8 @@
 
     <ion-item>
       <ion-label>Gaming</ion-label>
-      <ion-select [(ngModel)]="gaming" okText="Okay" cancelText="Dismiss" interface="popover">
+      <ion-select [(ngModel)]="gaming" okText="Okay" cancelText="Dismiss" interface="popover" placeholder="None">
+        <ion-option value="">None</ion-option>
         <ion-option value="nes">NES</ion-option>
         <ion-option value="n64">Nintendo64</ion-option>
         <ion-option value="ps">PlayStation</ion-option>
@@ -142,7 +144,7 @@
 
     <ion-item>
       <ion-label>Pets</ion-label>
-      <ion-select [(ngModel)]="pets" multiple="true" [selectOptions]="petAlertOpts">
+      <ion-select [(ngModel)]="pets" multiple="true" [selectOptions]="petAlertOpts" placeholder="None">
         <ion-option *ngFor="let o of petData" [value]="o.value">{{o.text}}</ion-option>
       </ion-select>
     </ion-item>

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -455,7 +455,7 @@ export class Select extends BaseInput<any> implements OnDestroy {
           return isCheckedProperty(selectValue, option.value);
         });
 
-        if (option.selected) {
+        if (option.selected && option.value) {
           this._texts.push(option.text);
         }
       });

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -9,7 +9,7 @@ import { Config } from '../../config/config';
 import { DeepLinker } from '../../navigation/deep-linker';
 import { Form } from '../../util/form';
 import { BaseInput } from '../../util/base-input';
-import { isCheckedProperty, isTrueProperty, deepCopy, deepEqual, assert } from '../../util/util';
+import { isPresent, isCheckedProperty, isTrueProperty, deepCopy, deepEqual, assert } from '../../util/util';
 import { Item } from '../item/item';
 import { Option } from '../option/option';
 import { SelectPopover, SelectPopoverOption } from './select-popover-component';
@@ -455,7 +455,7 @@ export class Select extends BaseInput<any> implements OnDestroy {
           return isCheckedProperty(selectValue, option.value);
         });
 
-        if (option.selected && option.value) {
+        if (option.selected && isPresent(option.value) && option.value !== '') {
           this._texts.push(option.text);
         }
       });


### PR DESCRIPTION
#### Short description of what this resolves:
When selecting an option with no value (`ion-option value=""`) placeholder text was not reset

#### Changes proposed in this pull request:
When adding the option's text to the text array, first check to see if the option has a value. If it doesn't, do not add it to the text. This will result in an empty string for `_text`, resulting in the placeholder text reappearing.

**Ionic Version**: 3.x

**Fixes**: #10439
