### PR TITLE
fix(select): make select with no options return undefined when OK is pressed

### DIFF
--- a/src/components/alert/alert-component.ts
+++ b/src/components/alert/alert-component.ts
@@ -322,7 +322,9 @@ export class AlertCmp {
     this.d.inputs.forEach(i => {
       values[i.name] = i.value;
     });
-    return values;
+
+    // if the values object is empty, that means there were not inputs at all
+    return Object.keys(values).length ? values : undefined;
   }
 
   ngOnDestroy() {

--- a/src/components/alert/alert-component.ts
+++ b/src/components/alert/alert-component.ts
@@ -316,15 +316,18 @@ export class AlertCmp {
       return this.d.inputs.filter(i => i.checked).map(i => i.value);
     }
 
+    if (this.d.inputs.length === 0) {
+      // this is an alert without any options/inputs at all
+      return undefined;
+    }
+
     // this is an alert with text inputs
     // return an object of all the values with the input name as the key
     const values: {[k: string]: string} = {};
     this.d.inputs.forEach(i => {
       values[i.name] = i.value;
     });
-
-    // if the values object is empty, that means there were not inputs at all
-    return Object.keys(values).length ? values : undefined;
+    return values;
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
#### Short description of what this resolves:
Opening a select without options in it and then pressing Okay resulted in the bound model being set to `{}`

#### Changes proposed in this pull request:
The current code instantiates an empty object and attempts to put values of any text inputs in that object. I've added a check to determine if that object has any properties in it and, if it does not, it returns `undefined` instead of that empty object. 

**Ionic Version**:3.x

**Fixes**: #10435
