### PR TITLE
chore(zone.js): fix ios9 error

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@angular/platform-browser-dynamic": "4.1.3",
     "ionicons": "~3.0.0",
     "rxjs": "5.4.0",
-    "zone.js": "0.8.11"
+    "zone.js": "0.8.12"
   },
   "devDependencies": {
     "@ionic/app-scripts": "1.3.7",


### PR DESCRIPTION
#### Short description of what this resolves:
zone.js 0.8.12 fixes some bugs and one especially for the ios platform
https://github.com/angular/zone.js/issues/802