### PR TITLE
feat(hooks): add lifecycle hook interfaces, just like in Angular core

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-
 export { IonicApp } from './components/app/app-root';
 export { MenuController } from './components/app/menu-controller';
 export { ActionSheet } from './components/action-sheet/action-sheet';
@@ -69,7 +68,7 @@ export { Option } from './components/option/option';
 export { Picker } from './components/picker/picker';
 export { PickerCmp } from './components/picker/picker-component';
 export { PickerColumnCmp } from './components/picker/picker-column';
-export { PickerController }  from './components/picker/picker-controller';
+export { PickerController } from './components/picker/picker-controller';
 export { PickerOptions, PickerColumn, PickerColumnOption } from './components/picker/picker-options';
 export { Popover } from './components/popover/popover';
 export { PopoverCmp } from './components/popover/popover-component';
@@ -143,18 +142,19 @@ export { Gesture } from './gestures/gesture';
 export { SlideEdgeGesture } from './gestures/slide-edge-gesture';
 export { SlideData, SlideGesture } from './gestures/slide-gesture';
 export {
-  BLOCK_ALL,
-  BlockerOptions,
-  GESTURE_GO_BACK_SWIPE,
-  GESTURE_MENU_SWIPE,
-  GESTURE_ITEM_SWIPE,
-  GESTURE_REFRESHER,
-  GESTURE_TOGGLE,
-  GestureOptions,
-  GestureController,
-  GestureDelegate,
-  BlockerDelegate,
-} from './gestures/gesture-controller';
+    BLOCK_ALL,
+    BlockerOptions,
+    GESTURE_GO_BACK_SWIPE,
+    GESTURE_MENU_SWIPE,
+    GESTURE_ITEM_SWIPE,
+    GESTURE_REFRESHER,
+    GESTURE_TOGGLE,
+    GestureOptions,
+    GestureController,
+    GestureDelegate,
+    BlockerDelegate,
+}
+from './gestures/gesture-controller';
 export { Events, setupEvents, setupProvideEvents } from './util/events';
 export { IonicErrorHandler } from './util/ionic-error-handler';
 export { Keyboard } from './platform/keyboard';
@@ -167,5 +167,13 @@ export { PlatformConfigToken } from './platform/platform-registry';
 export { registerModeConfigs } from './config/mode-registry';
 export { IonicGestureConfig } from './gestures/gesture-config';
 
-export { IonicModule, IonicPageModule, provideLocationStrategy } from './module';
+export { ViewCanEnter } from './navigation/lifecycle-hooks/view-can-enter';
+export { ViewCanLeave } from './navigation/lifecycle-hooks/view-can-leave';
+export { ViewDidEnter } from './navigation/lifecycle-hooks/view-did-enter';
+export { ViewDidLeave } from './navigation/lifecycle-hooks/view-did-leave';
+export { ViewDidLoad } from './navigation/lifecycle-hooks/view-did-load';
+export { ViewWillEnter } from './navigation/lifecycle-hooks/view-will-enter';
+export { ViewWillLeave } from './navigation/lifecycle-hooks/view-will-leave';
+export { ViewWillUnload } from './navigation/lifecycle-hooks/view-will-unload';
 
+export { IonicModule, IonicPageModule, provideLocationStrategy } from './module';

--- a/src/navigation/lifecycle-hooks/view-can-enter.ts
+++ b/src/navigation/lifecycle-hooks/view-can-enter.ts
@@ -1,0 +1,12 @@
+/**
+ * @hidden
+ * ionViewCanEnter interface
+ */
+export interface ViewCanEnter {
+    /**
+     * @function ionViewCanEnter
+     * @description
+     * Runs before the view can enter. This can be used as a sort of "guard" in authenticated views where you need to check permissions before the view can enter
+     */
+    ionViewCanEnter(): boolean | Promise <void> ;
+}

--- a/src/navigation/lifecycle-hooks/view-can-leave.ts
+++ b/src/navigation/lifecycle-hooks/view-can-leave.ts
@@ -1,0 +1,12 @@
+/**
+ * @hidden
+ * ionViewCanLeave interface
+ */
+export interface ViewCanLeave {
+    /**
+     * @function ionViewCanLeave
+     * @description
+     * Runs before the view can leave. This can be used as a sort of "guard" in authenticated views where you need to check permissions before the view can leave
+     */
+    ionViewCanLeave(): boolean | Promise <void> ;
+}

--- a/src/navigation/lifecycle-hooks/view-did-enter.ts
+++ b/src/navigation/lifecycle-hooks/view-did-enter.ts
@@ -1,0 +1,12 @@
+/**
+ * @hidden
+ * ionViewDidEnter interface
+ */
+export interface ViewDidEnter {
+    /**
+     * @function ionViewDidEnter
+     * @description
+     * Runs when the page has fully entered and is now the active page. This event will fire, whether it was the first load or a cached page.
+     */
+    ionViewDidEnter(): void;
+}

--- a/src/navigation/lifecycle-hooks/view-did-leave.ts
+++ b/src/navigation/lifecycle-hooks/view-did-leave.ts
@@ -1,0 +1,12 @@
+/**
+ * @hidden
+ * ionViewDidLeave interface
+ */
+export interface ViewDidLeave {
+    /**
+     * @function ionViewDidLeave
+     * @description
+     * Runs when the page has finished leaving and is no longer the active page.
+     */
+    ionViewDidLeave(): void;
+}

--- a/src/navigation/lifecycle-hooks/view-did-load.ts
+++ b/src/navigation/lifecycle-hooks/view-did-load.ts
@@ -1,0 +1,12 @@
+/**
+ * @hidden
+ * ionViewDidLoad interface
+ */
+export interface ViewDidLoad {
+    /**
+     * @function ionViewDidLoad
+     * @description
+     * Runs when the page has loaded. This event only happens once per page being created. If a page leaves but is cached, then this event will not fire again on a subsequent viewing. The ionViewDidLoad event is good place to put your setup code for the page.
+     */
+    ionViewDidLoad(): void;
+}

--- a/src/navigation/lifecycle-hooks/view-will-enter.ts
+++ b/src/navigation/lifecycle-hooks/view-will-enter.ts
@@ -1,0 +1,12 @@
+/**
+ * @hidden
+ * ionViewWillEnter interface
+ */
+export interface ViewWillEnter {
+    /**
+     * @function ionViewWillEnter
+     * @description
+     * Runs when the page is about to enter and become the active page.
+     */
+    ionViewWillEnter(): void;
+}

--- a/src/navigation/lifecycle-hooks/view-will-leave.ts
+++ b/src/navigation/lifecycle-hooks/view-will-leave.ts
@@ -1,0 +1,12 @@
+/**
+ * @hidden
+ * ionViewWillLeave interface
+ */
+export interface ViewWillLeave {
+    /**
+     * @function ionViewWillLeave
+     * @description
+     * Runs when the page is about to leave and no longer be the active page.
+     */
+    ionViewWillLeave(): void;
+}

--- a/src/navigation/lifecycle-hooks/view-will-unload.ts
+++ b/src/navigation/lifecycle-hooks/view-will-unload.ts
@@ -1,0 +1,12 @@
+/**
+ * @hidden
+ * ionViewWillUnload interface
+ */
+export interface ViewWillUnload {
+    /**
+     * @function ionViewWillUnload
+     * @description
+     * Runs when the page is about to be destroyed and have its elements removed.
+     */
+    ionViewWillUnload(): void;
+}


### PR DESCRIPTION
#### Short description of what this resolves:
Adds support for lifecycle hook interfaces, just like Angular. By adding `implements ViewDidLoad`, classes can have access to the lifecycle hooks.

#### Changes proposed in this pull request:

- add lifecycle hook interfaces
-
-

**Ionic Version**: 3.x

**Fixes**: #7512
