### PR TITLE
fix(split-pane): correct split-pane menu side order

### DIFF
--- a/src/components/split-pane/split-pane.scss
+++ b/src/components/split-pane/split-pane.scss
@@ -73,6 +73,34 @@ $split-pane-side-max-width: 28% !default;
   }
 }
 
+.split-pane-visible >.split-pane-side[side=start] {
+  @include multi-dir() {
+    order: -1;
+  }
+}
+
+.split-pane-visible >.split-pane-side[side=end] {
+  @include multi-dir() {
+    order: 1;
+  }
+}
+
+.split-pane-visible >.split-pane-side[side=left] {
+  @include ltr() {
+    order: -1;
+  }
+
+  @include rtl() {
+    order: 1;
+  }
+}
+
 .split-pane-visible >.split-pane-side[side=right] {
-  order: 1;
+  @include ltr() {
+    order: 1;
+  }
+
+  @include rtl() {
+    order: -1;
+  }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
side=left always on left
side=start dynamically on start
side=end dynamically on end
side=right always on right

**Ionic Version**:  3.x

**Fixes**: #
