### PR TITLE
feat(range): rtl support

### DIFF
--- a/src/components/fab/fab.scss
+++ b/src/components/fab/fab.scss
@@ -93,8 +93,8 @@ ion-fab {
   }
 
   &[right] {
-    // scss-lint:disable PropertySpelling
     @include multi-dir() {
+      // scss-lint:disable PropertySpelling
       right: $fab-content-margin;
     }
   }
@@ -108,8 +108,8 @@ ion-fab {
   }
 
   &[left] {
-    // scss-lint:disable PropertySpelling
     @include multi-dir() {
+      // scss-lint:disable PropertySpelling
       left: $fab-content-margin;
     }
   }

--- a/src/components/range/range.ios.scss
+++ b/src/components/range/range.ios.scss
@@ -103,7 +103,7 @@ $range-ios-pin-padding-start:                 $range-ios-pin-padding-end !defaul
 }
 
 .range-ios .range-bar {
-  @include position(($range-ios-slider-height / 2), null, null, 0);
+  @include position(($range-ios-slider-height / 2), null, null, null);
   @include border-radius(1px);
 
   position: absolute;
@@ -116,14 +116,6 @@ $range-ios-pin-padding-start:                 $range-ios-pin-padding-end !defaul
   pointer-events: none;
 }
 
-.range-ios.range-pressed .range-bar-active {
-  will-change: left, right;
-}
-
-.range-ios.range-pressed .range-knob-handle {
-  will-change: left;
-}
-
 .range-ios .range-bar-active {
   bottom: 0;
 
@@ -133,14 +125,16 @@ $range-ios-pin-padding-start:                 $range-ios-pin-padding-end !defaul
 }
 
 .range-ios .range-knob-handle {
-  @include position(($range-ios-slider-height / 2), null, null, 0);
-  @include margin(-($range-ios-hit-height / 2), null, null, -($range-ios-hit-width / 2));
-  @include text-align(center);
-
-  position: absolute;
+  @include position(($range-ios-slider-height / 2), null, null, null);
+  @include margin(-($range-ios-hit-height / 2), null, null, null);
 
   width: $range-ios-hit-width;
   height: $range-ios-hit-height;
+
+  @include multi-dir() {
+    // scss-lint:disable PropertySpelling
+    margin-left: -($range-ios-hit-width / 2);
+  }
 }
 
 .range-ios .range-knob {
@@ -180,9 +174,7 @@ $range-ios-pin-padding-start:                 $range-ios-pin-padding-end !defaul
 }
 
 .range-ios .range-pin {
-  @include text-align(center);
   @include border-radius(50px);
-  @include transform(translate3d(0, 28px, 0), scale(.01));
 
   position: relative;
   top: -20px;
@@ -201,10 +193,6 @@ $range-ios-pin-padding-start:                 $range-ios-pin-padding-end !defaul
   @include deprecated-variable(padding, $range-ios-pin-padding) {
     @include padding($range-ios-pin-padding-top, $range-ios-pin-padding-end, $range-ios-pin-padding-bottom, $range-ios-pin-padding-start);
   }
-}
-
-.range-ios .range-knob-pressed .range-pin {
-  @include transform(translate3d(0, 0, 0), scale(1));
 }
 
 .range-ios.range-disabled {

--- a/src/components/range/range.md.scss
+++ b/src/components/range/range.md.scss
@@ -97,7 +97,7 @@ $range-md-pin-min-background-color:          $range-md-bar-background-color !def
 }
 
 .range-md .range-bar {
-  @include position(($range-md-slider-height / 2), null, null, 0);
+  @include position(($range-md-slider-height / 2), null, null, null);
 
   position: absolute;
 
@@ -109,14 +109,6 @@ $range-md-pin-min-background-color:          $range-md-bar-background-color !def
   pointer-events: none;
 }
 
-.range-md.range-pressed .range-bar-active {
-  will-change: left, right;
-}
-
-.range-md.range-pressed .range-knob-handle {
-  will-change: left;
-}
-
 .range-md .range-bar-active {
   bottom: 0;
 
@@ -126,14 +118,16 @@ $range-md-pin-min-background-color:          $range-md-bar-background-color !def
 }
 
 .range-md .range-knob-handle {
-  @include position(($range-md-slider-height / 2), null, null, 0);
-  @include margin(-($range-md-hit-height / 2), null, null, -($range-md-hit-width / 2));
-  @include text-align(center);
-
-  position: absolute;
+  @include position(($range-md-slider-height / 2), null, null, null);
+  @include margin(-($range-md-hit-height / 2), null, null, null);
 
   width: $range-md-hit-width;
   height: $range-md-hit-height;
+
+  @include multi-dir() {
+    // scss-lint:disable PropertySpelling
+    margin-left: -($range-md-hit-width / 2);
+  }
 }
 
 .range-md .range-knob {
@@ -182,9 +176,7 @@ $range-md-pin-min-background-color:          $range-md-bar-background-color !def
 
 .range-md .range-pin {
   @include padding($range-md-pin-padding-vertical, $range-md-pin-padding-horizontal);
-  @include text-align(center);
   @include border-radius(50%);
-  @include transform(translate3d(0, 28px, 0), scale(.01));
 
   position: relative;
   top: -20px;
@@ -203,7 +195,6 @@ $range-md-pin-min-background-color:          $range-md-bar-background-color !def
 
   &::before {
     @include position(3px, null, null, 50%);
-    @include border-radius(50%, 50%, 50%, 0);
     @include margin-horizontal(-13px, null);
 
     position: absolute;
@@ -218,15 +209,16 @@ $range-md-pin-min-background-color:          $range-md-bar-background-color !def
     content: "";
     transform: rotate(-45deg);
     transition: background-color 120ms ease;
+
+    @include multi-dir() {
+      // scss-lint:disable PropertySpelling
+      border-radius: 50% 50% 50% 0;
+    }
   }
 }
 
-.range-md .range-knob-pressed .range-pin {
-  @include transform(translate3d(0, 0, 0), scale(1));
-}
-
 .range-md:not(.range-has-pin) .range-knob-pressed .range-knob {
-  transform: scale(1);
+  @include transform(flip-scale(1));
 }
 
 @mixin md-range-min() {

--- a/src/components/range/range.scss
+++ b/src/components/range/range.scss
@@ -49,4 +49,43 @@ ion-range ion-icon {
   flex: 1;
 
   cursor: pointer;
+
+  @include rtl() {
+    transform: scaleX(-1);
+  }
+}
+
+.range-pressed .range-bar-active {
+  will-change: left, right;
+}
+
+.range-pressed .range-knob-handle {
+  will-change: left;
+}
+
+.range-knob-handle {
+  @include text-align(center);
+
+  position: absolute;
+
+  @include multi-dir() {
+    // scss-lint:disable PropertySpelling
+    left: 0;
+  }
+}
+
+.range-bar {
+  @include multi-dir() {
+    // scss-lint:disable PropertySpelling
+    left: 0;
+  }
+}
+
+.range-pin {
+  @include text-align(center);
+  @include transform(translate3d(0, 28px, 0), flip-scale(.01));
+}
+
+.range-knob-pressed .range-pin {
+  @include transform(translate3d(0, 0, 0), flip-scale(1));
 }

--- a/src/components/range/range.ts
+++ b/src/components/range/range.ts
@@ -509,10 +509,11 @@ export class Range extends BaseInput<any> implements AfterContentInit, ControlVa
 
   /** @internal */
   _valueToRatio(value: number) {
-    value = ((value - this._min) / this._step) * this._step;
+    value = (value - this._min) / this._step;
     if (this.snaps) {
       value = Math.round(value);
     }
+    value *= this._step;
     value = value / (this._max - this._min);
     return clamp(0, value, 1);
   }

--- a/src/components/range/range.ts
+++ b/src/components/range/range.ts
@@ -117,7 +117,7 @@ export class Range extends BaseInput<any> implements AfterContentInit, ControlVa
   _min = 0;
   _max = 100;
   _step = 1;
-  _snaps: boolean;
+  _snaps: boolean = false;
 
   _valA = 0;
   _valB = 0;
@@ -285,6 +285,12 @@ export class Range extends BaseInput<any> implements AfterContentInit, ControlVa
   }
 
   /** @internal */
+  _calcRatio(current: PointerCoordinates, rect: ClientRect): number {
+    let ratio = clamp(0, (current.x - rect.left) / (rect.width), 1);
+    return this._plt.isRTL ? 1 - ratio : ratio;
+  }
+
+  /** @internal */
   _pointerDown(ev: UIEvent): boolean {
     // TODO: we could stop listening for events instead of checking this._disabled.
     // since there are a lot of events involved, this solution is
@@ -307,7 +313,7 @@ export class Range extends BaseInput<any> implements AfterContentInit, ControlVa
     const rect = this._rect = this._plt.getElementBoundingClientRect(this._slider.nativeElement);
 
     // figure out which knob they started closer to
-    const ratio = clamp(0, (current.x - rect.left) / (rect.width), 1);
+    const ratio = this._calcRatio(current, rect);
     this._activeB = this._dual && (Math.abs(ratio - this._ratioA) > Math.abs(ratio - this._ratioB));
 
     // update the active knob's position
@@ -363,13 +369,8 @@ export class Range extends BaseInput<any> implements AfterContentInit, ControlVa
   _update(current: PointerCoordinates, rect: ClientRect, isPressed: boolean) {
     // figure out where the pointer is currently at
     // update the knob being interacted with
-    let ratio = clamp(0, (current.x - rect.left) / (rect.width), 1);
-    let val = this._ratioToValue(ratio);
-
-    if (this._snaps) {
-      // snaps the ratio to the current value
-      ratio = this._valueToRatio(val);
-    }
+    let val = this._ratioToValue(this._calcRatio(current, rect));
+    let ratio = this._valueToRatio(val);
 
     // update which knob is pressed
     this._pressed = isPressed;
@@ -508,7 +509,10 @@ export class Range extends BaseInput<any> implements AfterContentInit, ControlVa
 
   /** @internal */
   _valueToRatio(value: number) {
-    value = Math.round((value - this._min) / this._step) * this._step;
+    value = ((value - this._min) / this._step) * this._step;
+    if (this.snaps) {
+      value = Math.round(value);
+    }
     value = value / (this._max - this._min);
     return clamp(0, value, 1);
   }

--- a/src/components/range/range.ts
+++ b/src/components/range/range.ts
@@ -509,11 +509,11 @@ export class Range extends BaseInput<any> implements AfterContentInit, ControlVa
 
   /** @internal */
   _valueToRatio(value: number) {
-    value = (value - this._min) / this._step;
+    value = value - this._min;
     if (this.snaps) {
-      value = Math.round(value);
+      // snaps the ratio to the current value
+      value = Math.round(value / this._step) * this._step;
     }
-    value *= this._step;
     value = value / (this._max - this._min);
     return clamp(0, value, 1);
   }

--- a/src/components/range/range.wp.scss
+++ b/src/components/range/range.wp.scss
@@ -100,7 +100,7 @@ $range-wp-pin-padding-start:                 $range-wp-pin-padding-end !default;
 }
 
 .range-wp .range-bar {
-  @include position(($range-wp-slider-height / 2), null, null, 0);
+  @include position(($range-wp-slider-height / 2), null, null, null);
 
   position: absolute;
 
@@ -112,14 +112,6 @@ $range-wp-pin-padding-start:                 $range-wp-pin-padding-end !default;
   pointer-events: none;
 }
 
-.range-wp.range-pressed .range-bar-active {
-  will-change: left, right;
-}
-
-.range-wp.range-pressed .range-knob-handle {
-  will-change: left;
-}
-
 .range-wp .range-bar-active {
   bottom: 0;
 
@@ -129,14 +121,16 @@ $range-wp-pin-padding-start:                 $range-wp-pin-padding-end !default;
 }
 
 .range-wp .range-knob-handle {
-  @include position(($range-wp-slider-height / 2), null, null, 0);
-  @include margin(-($range-wp-hit-height / 2), null, null, -($range-wp-hit-width / 2));
-  @include text-align(center);
-
-  position: absolute;
+  @include position(($range-wp-slider-height / 2), null, null, null);
+  @include margin(-($range-wp-hit-height / 2), null, null, null);
 
   width: $range-wp-hit-width;
   height: $range-wp-hit-height;
+
+  @include multi-dir() {
+    // scss-lint:disable PropertySpelling
+    margin-left: -($range-wp-hit-width / 2);
+  }
 }
 
 .range-wp .range-knob {
@@ -174,9 +168,7 @@ $range-wp-pin-padding-start:                 $range-wp-pin-padding-end !default;
 }
 
 .range-wp .range-pin {
-  @include text-align(center);
   @include border-radius(50px);
-  @include transform(translate3d(0, 28px, 0), scale(.01));
 
   position: relative;
   top: -24px;
@@ -195,10 +187,6 @@ $range-wp-pin-padding-start:                 $range-wp-pin-padding-end !default;
   @include deprecated-variable(padding, $range-wp-pin-padding) {
     @include padding($range-wp-pin-padding-top, $range-wp-pin-padding-end, $range-wp-pin-padding-bottom, $range-wp-pin-padding-start);
   }
-}
-
-.range-wp .range-knob-pressed .range-pin {
-  @include transform(translate3d(0, 0, 0), scale(1));
 }
 
 .range-wp.range-disabled {

--- a/src/themes/ionic.mixins.scss
+++ b/src/themes/ionic.mixins.scss
@@ -496,16 +496,12 @@
 // Add transform for all directions
 // @param {string} $transforms - comma separated list of transforms
 @mixin transform($transforms...) {
-  $extra: null;
-
-  $x: null;
-  $ltr-translate: null;
-  $rtl-translate: null;
+  $ltr-transform: null;
+  $rtl-transform: null;
 
   @each $transform in $transforms {
-    @if (str-index($transform, translate3d)) {
-      $transform: str-replace($transform, 'translate3d(');
-      $transform: str-replace($transform, ')');
+    @if (str-index($transform, 'translate3d')) {
+      $transform: str-extract($transform, 'translate3d(', ')');
 
       $coordinates: str-split($transform, ',');
 
@@ -513,28 +509,46 @@
       $y: nth($coordinates, 2);
       $z: nth($coordinates, 3);
 
-      $ltr-translate: translate3d($x, $y, $z);
-      $rtl-translate: translate3d(calc(-1 * #{$x}), $y, $z);
-    } @else {
-      @if $extra == null {
-        $extra: $transform;
+      $translate: translate3d($x, $y, $z);
+
+      $ltr-transform: $ltr-transform $translate;
+
+      @if $x == '0' {
+        $rtl-transform: $rtl-transform $translate;
       } @else {
-        $extra: $extra $transform;
+        $rtl-transform: $rtl-transform translate3d(calc(-1 * #{$x}), $y, $z);
       }
+    } @else if (str-index($transform, 'flip-scale')) {
+      $scale: str-extract($transform, 'flip-scale(', ')');
+
+      $scales: str-split($scale, ',');
+
+      $x: nth($scales, 1);
+      $y: $x;
+
+      @if length($scales) > 1 {
+        $y: nth($scales, 2);
+      }
+
+      $ltr-transform: $ltr-transform scale($x, $y);
+      $rtl-transform: $rtl-transform scale(-#{$x}, $y);
+    } @else {
+      $ltr-transform: $ltr-transform $transform;
+      $rtl-transform: $rtl-transform $transform;
     }
   }
 
-  @if $x == '0' or $x == null {
+  @if $ltr-transform == $rtl-transform {
     @include multi-dir() {
-      transform: $ltr-translate $extra;
+      transform: $ltr-transform;
     }
   } @else {
     @include ltr() {
-      transform: $ltr-translate $extra;
+      transform: $ltr-transform;
     }
 
     @include rtl() {
-      transform: $rtl-translate $extra;
+      transform: $rtl-transform;
     }
   }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Ranges or RTL

#### Changes proposed in this pull request:
I took a very odd approach. instead of logically fitting it to RTL (which will be a pain to always change style properties on the fly, and will have no real time support), I decided to make all the logic in CSS.

RTL range bar is the same as LTR, but with `scaleX(-1)`. Typescript only has one "change", which is to flip the X coordinate, (but easier is to flip the `ratio` which is already normalised)

I know this is bordering stupidity, but I think this might be to stupid, so it  just loops around to be genius.

**Ionic Version**: 3.x

**closes:** https://github.com/ionic-team/ionic/issues/12151
