### PR TITLE
fix(refresher): border should only show when pulled

### DIFF
--- a/src/components/content/content.ts
+++ b/src/components/content/content.ts
@@ -212,6 +212,8 @@ export class Content extends Ion implements OnDestroy, AfterViewInit, IContent {
   /** @internal */
   _fullscreen: boolean;
   /** @internal */
+  _hasRefresher: boolean = false;
+  /** @internal */
   _footerEle: HTMLElement;
   /** @internal */
   _dirty: boolean;
@@ -780,6 +782,11 @@ export class Content extends Ion implements OnDestroy, AfterViewInit, IContent {
 
     } else if (this._tabsPlacement === 'bottom') {
       this._cBottom += this._tabbarHeight;
+    }
+
+    // Refresher uses a border which should be hidden unless pulled
+    if (this._hasRefresher === true) {
+      this._cTop -= 1;
     }
 
     // Fixed content shouldn't include content padding

--- a/src/components/content/content.ts
+++ b/src/components/content/content.ts
@@ -786,7 +786,7 @@ export class Content extends Ion implements OnDestroy, AfterViewInit, IContent {
     }
 
     // Refresher uses a border which should be hidden unless pulled
-    if (this._hasRefresher === true) {
+    if (this._hasRefresher) {
       this._cTop -= 1;
     }
 

--- a/src/components/content/content.ts
+++ b/src/components/content/content.ts
@@ -167,7 +167,8 @@ export class EventEmitterProxy<T> extends EventEmitter<T> {
     '</div>' +
     '<ng-content select="ion-refresher"></ng-content>',
   host: {
-    '[class.statusbar-padding]': 'statusbarPadding'
+    '[class.statusbar-padding]': 'statusbarPadding',
+    '[class.has-refresher]': '_hasRefresher'
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None

--- a/src/components/refresher/refresher.ts
+++ b/src/components/refresher/refresher.ts
@@ -203,7 +203,6 @@ export class Refresher {
   constructor(private _plt: Platform, @Host() private _content: Content, private _zone: NgZone, gestureCtrl: GestureController) {
     this._events = new UIEventManager(_plt);
     _content._hasRefresher = true;
-    _content.setElementClass('has-refresher', true);
     this._gesture = gestureCtrl.createGesture({
       name: GESTURE_REFRESHER,
       priority: GESTURE_PRIORITY_REFRESHER

--- a/src/components/refresher/refresher.ts
+++ b/src/components/refresher/refresher.ts
@@ -202,6 +202,7 @@ export class Refresher {
 
   constructor(private _plt: Platform, @Host() private _content: Content, private _zone: NgZone, gestureCtrl: GestureController) {
     this._events = new UIEventManager(_plt);
+    _content._hasRefresher = true;
     _content.setElementClass('has-refresher', true);
     this._gesture = gestureCtrl.createGesture({
       name: GESTURE_REFRESHER,

--- a/src/components/refresher/test/refresher.spec.ts
+++ b/src/components/refresher/test/refresher.spec.ts
@@ -224,6 +224,9 @@ describe('Refresher', () => {
 
   });
 
+  it('should set hasRefresher on content', () => {
+    expect(content._hasRefresher).toBeTruthy();
+  });
 
   let contentElementRef: any;
   let refresher: Refresher;


### PR DESCRIPTION
#### Short description of what this resolves:
See #10994

#### Changes proposed in this pull request:

- When `Content` has a `Refresher`, the calculated top margin is reduced by 1px to hide the border.

**Ionic Version**: 3.x

**Fixes**: #10994
