### PR TITLE
refactor(overlay): simplify focusOutActiveElement

### DIFF
--- a/src/components/action-sheet/action-sheet-component.ts
+++ b/src/components/action-sheet/action-sheet-component.ts
@@ -117,8 +117,6 @@ export class ActionSheetCmp {
   }
 
   ionViewDidEnter() {
-    this._plt.focusOutActiveElement();
-
     const focusableEle = this._elementRef.nativeElement.querySelector('button');
     if (focusableEle) {
       focusableEle.focus();

--- a/src/components/alert/alert-component.ts
+++ b/src/components/alert/alert-component.ts
@@ -194,18 +194,10 @@ export class AlertCmp {
   }
 
   ionViewDidLeave() {
-    this._plt.focusOutActiveElement();
     this.gestureBlocker.unblock();
   }
 
-  ionViewWillLeave() {
-    this._plt.focusOutActiveElement();
-  }
-
   ionViewDidEnter() {
-    // focus out of the active element
-    this._plt.focusOutActiveElement();
-
     // set focus on the first input or button in the alert
     // note that this does not always work and bring up the keyboard on
     // devices since the focus command must come from the user's touch event

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -241,7 +241,6 @@ export class App {
     // TODO: move _setNav() to the earlier stages of NavController. _queueTrns()
     enteringView._setNav(portal);
 
-    opts.keyboardClose = false;
     opts.direction = DIRECTION_FORWARD;
 
     if (!opts.animation) {
@@ -249,7 +248,7 @@ export class App {
     }
 
     enteringView.setLeavingOpts({
-      keyboardClose: false,
+      keyboardClose: opts.keyboardClose,
       direction: DIRECTION_BACK,
       animation: enteringView.getTransitionName(DIRECTION_BACK),
       ev: opts.ev

--- a/src/components/app/overlay-portal.ts
+++ b/src/components/app/overlay-portal.ts
@@ -5,7 +5,6 @@ import { Config } from '../../config/config';
 import { DeepLinker } from '../../navigation/deep-linker';
 import { DomController } from '../../platform/dom-controller';
 import { GestureController } from '../../gestures/gesture-controller';
-import { Keyboard } from '../../platform/keyboard';
 import { NavControllerBase } from '../../navigation/nav-controller-base';
 import { Platform } from '../../platform/platform';
 import { TransitionController } from '../../transitions/transition-controller';
@@ -22,7 +21,6 @@ export class OverlayPortal extends NavControllerBase {
     @Inject(forwardRef(() => App)) app: App,
     config: Config,
     plt: Platform,
-    keyboard: Keyboard,
     elementRef: ElementRef,
     zone: NgZone,
     renderer: Renderer,
@@ -34,7 +32,7 @@ export class OverlayPortal extends NavControllerBase {
     domCtrl: DomController,
     errHandler: ErrorHandler
   ) {
-    super(null, app, config, plt, keyboard, elementRef, zone, renderer, cfr, gestureCtrl, transCtrl, linker, domCtrl, errHandler);
+    super(null, app, config, plt, elementRef, zone, renderer, cfr, gestureCtrl, transCtrl, linker, domCtrl, errHandler);
     this._isPortal = true;
     this._init = true;
     this.setViewport(viewPort);

--- a/src/components/loading/loading-component.ts
+++ b/src/components/loading/loading-component.ts
@@ -79,8 +79,6 @@ export class LoadingCmp {
   }
 
   ionViewDidEnter() {
-    this._plt.focusOutActiveElement();
-
     // If there is a duration, dismiss after that amount of time
     if ( this.d && this.d.duration ) {
       this.durationTimeout = setTimeout(() => this.dismiss('backdrop'), this.d.duration);

--- a/src/components/nav/nav.ts
+++ b/src/components/nav/nav.ts
@@ -5,7 +5,6 @@ import { Config } from '../../config/config';
 import { DeepLinker } from '../../navigation/deep-linker';
 import { DomController } from '../../platform/dom-controller';
 import { GestureController } from '../../gestures/gesture-controller';
-import { Keyboard } from '../../platform/keyboard';
 import { Nav as INav } from '../../navigation/nav-interfaces';
 import { NavController } from '../../navigation/nav-controller';
 import { NavControllerBase } from '../../navigation/nav-controller-base';
@@ -66,7 +65,6 @@ export class Nav extends NavControllerBase implements AfterViewInit, RootNode, I
     app: App,
     config: Config,
     plt: Platform,
-    keyboard: Keyboard,
     elementRef: ElementRef,
     zone: NgZone,
     renderer: Renderer,
@@ -77,7 +75,7 @@ export class Nav extends NavControllerBase implements AfterViewInit, RootNode, I
     domCtrl: DomController,
     errHandler: ErrorHandler
   ) {
-    super(parent, app, config, plt, keyboard, elementRef, zone, renderer, cfr, gestureCtrl, transCtrl, linker, domCtrl, errHandler);
+    super(parent, app, config, plt, elementRef, zone, renderer, cfr, gestureCtrl, transCtrl, linker, domCtrl, errHandler);
 
     if (viewCtrl) {
       // an ion-nav can also act as an ion-page within a parent ion-nav

--- a/src/components/nav/test/nav.spec.ts
+++ b/src/components/nav/test/nav.spec.ts
@@ -1,7 +1,6 @@
 import { Nav } from '../nav';
 
 import { GestureController } from '../../../gestures/gesture-controller';
-import { Keyboard } from '../../../platform/keyboard';
 import {
   mockApp,
   mockConfig,
@@ -88,7 +87,6 @@ function getNav() {
   const app = mockApp(config, platform);
   const zone = mockZone();
   const dom = mockDomController(platform);
-  const keyboard = new Keyboard(config, platform, zone, dom);
   const elementRef = mockElementRef();
   const renderer = mockRenderer();
   const componentFactoryResolver: any = null;
@@ -101,7 +99,6 @@ function getNav() {
     app,
     config,
     platform,
-    keyboard,
     elementRef,
     zone,
     renderer,

--- a/src/components/picker/picker-component.ts
+++ b/src/components/picker/picker-component.ts
@@ -161,8 +161,6 @@ export class PickerCmp {
   }
 
   ionViewDidEnter() {
-    this._plt.focusOutActiveElement();
-
     let focusableEle = this._elementRef.nativeElement.querySelector('button');
     if (focusableEle) {
       focusableEle.focus();

--- a/src/components/popover/popover-component.ts
+++ b/src/components/popover/popover-component.ts
@@ -67,7 +67,6 @@ export class PopoverCmp {
   }
 
   ionViewPreLoad() {
-    this._plt.focusOutActiveElement();
     this._load(this._navParams.data.component);
   }
 

--- a/src/components/tabs/tab.ts
+++ b/src/components/tabs/tab.ts
@@ -6,7 +6,6 @@ import { DeepLinker } from '../../navigation/deep-linker';
 import { DomController } from '../../platform/dom-controller';
 import { GestureController } from '../../gestures/gesture-controller';
 import { isTrueProperty } from '../../util/util';
-import { Keyboard } from '../../platform/keyboard';
 import { Tab as ITab } from '../../navigation/nav-interfaces';
 import { NavControllerBase } from '../../navigation/nav-controller-base';
 import { NavOptions } from '../../navigation/nav-util';
@@ -255,7 +254,6 @@ export class Tab extends NavControllerBase implements ITab {
     app: App,
     config: Config,
     plt: Platform,
-    keyboard: Keyboard,
     elementRef: ElementRef,
     zone: NgZone,
     renderer: Renderer,
@@ -268,7 +266,7 @@ export class Tab extends NavControllerBase implements ITab {
     errHandler: ErrorHandler
   ) {
     // A Tab is a NavController for its child pages
-    super(parent, app, config, plt, keyboard, elementRef, zone, renderer, cfr, gestureCtrl, transCtrl, linker, _dom, errHandler);
+    super(parent, app, config, plt, elementRef, zone, renderer, cfr, gestureCtrl, transCtrl, linker, _dom, errHandler);
 
     this.id = parent.add(this);
     this._tabsHideOnSubPages = config.getBoolean('tabsHideOnSubPages');

--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -98,6 +98,7 @@ export class Toast extends ViewController {
    */
   present(navOptions: NavOptions = {}): Promise<any> {
     navOptions.disableApp = false;
+    navOptions.keyboardClose = false;
     return this._app.present(this, navOptions, PORTAL_TOAST);
   }
 

--- a/src/navigation/nav-controller-base.ts
+++ b/src/navigation/nav-controller-base.ts
@@ -12,7 +12,6 @@ import { GestureController } from '../gestures/gesture-controller';
 import { isBlank, isNumber, isPresent, isTrueProperty, assert, removeArrayItem } from '../util/util';
 import { isViewController, ViewController } from './view-controller';
 import { Ion } from '../components/ion';
-import { Keyboard } from '../platform/keyboard';
 import { NavController } from './nav-controller';
 import { NavParams } from './nav-params';
 import { Platform } from '../platform/platform';
@@ -63,7 +62,6 @@ export class NavControllerBase extends Ion implements NavController {
     public _app: App,
     public config: Config,
     public plt: Platform,
-    public _keyboard: Keyboard,
     elementRef: ElementRef,
     public _zone: NgZone,
     renderer: Renderer,
@@ -760,7 +758,7 @@ export class NavControllerBase extends Ion implements NavController {
       if (opts.keyboardClose !== false) {
         // the keyboard is still open!
         // no problem, let's just close for them
-        this._keyboard.close();
+        this.plt.focusOutActiveElement();
       }
     }
 

--- a/src/util/mock-providers.ts
+++ b/src/util/mock-providers.ts
@@ -10,7 +10,6 @@ import { DomController } from '../platform/dom-controller';
 import { GestureController } from '../gestures/gesture-controller';
 import { Haptic } from '../tap-click/haptic';
 import { IonicApp } from '../components/app/app-root';
-import { Keyboard } from '../platform/keyboard';
 import { Menu } from '../components/menu/menu';
 import { NavOptions } from '../navigation/nav-util';
 import { NavControllerBase } from '../navigation/nav-controller-base';
@@ -403,7 +402,6 @@ export function mockNavController(): NavControllerBase {
   let app = mockApp(config, platform);
   let zone = mockZone();
   let dom = mockDomController(platform);
-  let keyboard = new Keyboard(config, platform, zone, dom);
   let elementRef = mockElementRef();
   let renderer = mockRenderer();
   let componentFactoryResolver: any = null;
@@ -415,7 +413,6 @@ export function mockNavController(): NavControllerBase {
     app,
     config,
     platform,
-    keyboard,
     elementRef,
     zone,
     renderer,
@@ -447,7 +444,6 @@ export function mockNavController(): NavControllerBase {
 export function mockOverlayPortal(app: App, config: Config, plt: MockPlatform): OverlayPortal {
   let zone = mockZone();
   let dom = mockDomController(plt);
-  let keyboard = new Keyboard(config, plt, zone, dom);
   let elementRef = mockElementRef();
   let renderer = mockRenderer();
   let componentFactoryResolver: any = null;
@@ -460,7 +456,6 @@ export function mockOverlayPortal(app: App, config: Config, plt: MockPlatform): 
     app,
     config,
     plt,
-    keyboard,
     elementRef,
     zone,
     renderer,
@@ -480,7 +475,6 @@ export function mockTab(parentTabs: Tabs): Tab {
   let app = (<any>parentTabs)._app || mockApp(config, platform);
   let zone = mockZone();
   let dom = mockDomController(platform);
-  let keyboard = new Keyboard(config, platform, zone, dom);
   let elementRef = mockElementRef();
   let renderer = mockRenderer();
   let changeDetectorRef = mockChangeDetectorRef();
@@ -493,7 +487,6 @@ export function mockTab(parentTabs: Tabs): Tab {
     app,
     config,
     platform,
-    keyboard,
     elementRef,
     zone,
     renderer,


### PR DESCRIPTION
NavControllerBase is able to close the keyboard automatically, there is not a good point to call:
this.plt.focusOutActiveElement() on each overlay component (alert, actionsheet, picker, modal)