### PR TITLE
fix(slides): support reverse on rtl and ltr

### DIFF
--- a/src/components/slides/slides.ts
+++ b/src/components/slides/slides.ts
@@ -139,7 +139,7 @@ import { ViewController } from '../../navigation/view-controller';
 @Component({
   selector: 'ion-slides',
   template:
-    '<div class="swiper-container" [attr.dir]="_rtl? \'rtl\' : null">' +
+    '<div class="swiper-container" [attr.dir]="isRTL? \'rtl\' : \'ltr\'">' +
       '<div class="swiper-wrapper">' +
         '<ng-content></ng-content>' +
       '</div>' +
@@ -248,14 +248,6 @@ export class Slides extends Ion {
     this._pager = isTrueProperty(val);
   }
   private _pager = false;
-
-/**
- * @input {string} If dir attribute is equal to rtl, set interal _rtl to true;
- */
-  @Input()
-  set dir(val: string) {
-    this._rtl = (val.toLowerCase() === 'rtl');
-  }
 
   /**
    * @input {string}  Type of pagination. Possible values are:
@@ -823,8 +815,6 @@ export class Slides extends Ion {
   /** @internal */
   _renderedSize: number;
   /** @internal */
-  _rtl: boolean;
-  /** @internal */
   _slides: SlideElement[];
   /** @internal */
   _snapGrid: any;
@@ -862,7 +852,15 @@ export class Slides extends Ion {
   /** @hidden */
   prevButton: HTMLElement;
 
+  /**
+   * @input {'ltr' | 'rtl'} Sets an explicit direction for slides
+   */
+  @Input() dir = 'ltr';
 
+  /**
+   * @input {boolean} If true, reverses the slides direction
+   */
+  @Input() reverse = false;
 
   constructor(
     config: Config,
@@ -888,6 +886,10 @@ export class Slides extends Ion {
         this._initSlides();
       });
     }
+  }
+
+  get isRTL() {
+    return this.dir === 'rtl' || this.reverse !== this._plt.isRTL;
   }
 
   private _initSlides() {

--- a/src/components/slides/swiper/swiper-controller.ts
+++ b/src/components/slides/swiper/swiper-controller.ts
@@ -60,7 +60,7 @@ export const SWIPER_CONTROLLER = {
       // x is the Grid of the scrolled scroller and y will be the controlled scroller
       // it makes sense to create this only once and recall it for the interpolation
       // the function does a lot of value caching for performance
-      translate = c._rtl && isHorizontal(c) ? -s._translate : s._translate;
+      translate = c.isRTL && isHorizontal(c) ? -s._translate : s._translate;
       if (s.controlBy === 'slide') {
         SWIPER_CONTROLLER.getInterpolateFunction(s, plt, c);
         // i am not sure why the values have to be multiplicated this way, tried to invert the snapGrid

--- a/src/components/slides/swiper/swiper-effects.ts
+++ b/src/components/slides/swiper/swiper-effects.ts
@@ -70,7 +70,7 @@ export const SWIPER_EFFECTS: SlideEffects = {
           tx = 0;
           rotateX = -rotateY;
           rotateY = 0;
-        } else if (s._rtl) {
+        } else if (s.isRTL) {
           rotateY = -rotateY;
         }
 
@@ -161,7 +161,7 @@ export const SWIPER_EFFECTS: SlideEffects = {
         var slide = s._slides[i];
         var slideAngle = i * 90;
         var round = Math.floor(slideAngle / 360);
-        if (s._rtl) {
+        if (s.isRTL) {
           slideAngle = -slideAngle;
           round = Math.floor(-slideAngle / 360);
         }
@@ -180,7 +180,7 @@ export const SWIPER_EFFECTS: SlideEffects = {
           tx = - s._renderedSize;
           tz = 3 * s._renderedSize + s._renderedSize * 4 * round;
         }
-        if (s._rtl) {
+        if (s.isRTL) {
           tx = -tx;
         }
 
@@ -192,7 +192,7 @@ export const SWIPER_EFFECTS: SlideEffects = {
         var transformStr = 'rotateX(' + (isHorizontal(s) ? 0 : -slideAngle) + 'deg) rotateY(' + (isHorizontal(s) ? slideAngle : 0) + 'deg) translate3d(' + tx + 'px, ' + ty + 'px, ' + tz + 'px)';
         if (progress <= 1 && progress > -1) {
           wrapperRotate = i * 90 + progress * 90;
-          if (s._rtl) wrapperRotate = -i * 90 - progress * 90;
+          if (s.isRTL) wrapperRotate = -i * 90 - progress * 90;
         }
         transform(slide, transformStr);
 

--- a/src/components/slides/swiper/swiper-events.ts
+++ b/src/components/slides/swiper/swiper-events.ts
@@ -460,7 +460,7 @@ function onTouchMove(s: Slides, plt: Platform, ev: SlideUIEvent) {
   var diff = s._touches.diff = isHorizontal(s) ? s._touches.currentX - s._touches.startX : s._touches.currentY - s._touches.startY;
 
   diff = diff * s.touchRatio;
-  if (s._rtl) diff = -diff;
+  if (s.isRTL) diff = -diff;
 
   s.swipeDirection = diff > 0 ? 'prev' : 'next';
   currentTranslate = diff + startTranslate;
@@ -596,7 +596,7 @@ function onTouchEnd(s: Slides, plt: Platform, ev: SlideUIEvent) {
 
   var currentPos: number;
   if (s.followFinger) {
-    currentPos = s._rtl ? s._translate : -s._translate;
+    currentPos = s.isRTL ? s._translate : -s._translate;
   } else {
     currentPos = -currentTranslate;
   }
@@ -642,7 +642,7 @@ function onTouchEnd(s: Slides, plt: Platform, ev: SlideUIEvent) {
       var momentumDistance = s.velocity * momentumDuration;
 
       var newPosition = s._translate + momentumDistance;
-      if (s._rtl) newPosition = - newPosition;
+      if (s.isRTL) newPosition = - newPosition;
       var doBounce = false;
       var afterBouncePosition: number;
       var bounceAmount = Math.abs(s.velocity) * 20 * s.freeModeMomentumBounceRatio;
@@ -686,12 +686,12 @@ function onTouchEnd(s: Slides, plt: Platform, ev: SlideUIEvent) {
         } else {
           newPosition = s._snapGrid[nextSlide - 1];
         }
-        if (!s._rtl) newPosition = - newPosition;
+        if (!s.isRTL) newPosition = - newPosition;
       }
 
       // Fix duration
       if (s.velocity !== 0) {
-        if (s._rtl) {
+        if (s.isRTL) {
           momentumDuration = Math.abs((-newPosition - s._translate) / s.velocity);
         } else {
           momentumDuration = Math.abs((newPosition - s._translate) / s.velocity);

--- a/src/components/slides/swiper/swiper-index.ts
+++ b/src/components/slides/swiper/swiper-index.ts
@@ -3,7 +3,7 @@ import { updateClasses } from './swiper-classes';
 
 
 export function updateActiveIndex(s: Slides) {
-  var translate = s._rtl ? s._translate : -s._translate;
+  var translate = s.isRTL ? s._translate : -s._translate;
   var newActiveIndex: number;
   var i: number;
   var snapIndex: number;

--- a/src/components/slides/swiper/swiper-keyboard.ts
+++ b/src/components/slides/swiper/swiper-keyboard.ts
@@ -43,7 +43,7 @@ function handleKeyboard(s: Slides, plt: Platform, e: KeyboardEvent) {
     var windowHeight = plt.height();
     var swiperOffset = offset(s.container, plt);
 
-    if (s._rtl) {
+    if (s.isRTL) {
       swiperOffset.left = swiperOffset.left - s.container.scrollLeft;
     }
 
@@ -76,11 +76,11 @@ function handleKeyboard(s: Slides, plt: Platform, e: KeyboardEvent) {
       }
     }
 
-    if ((kc === 39 && !s._rtl) || (kc === 37 && s._rtl)) {
+    if ((kc === 39 && !s.isRTL) || (kc === 37 && s.isRTL)) {
       slideNext(s, plt);
     }
 
-    if ((kc === 37 && !s._rtl) || (kc === 39 && s._rtl)) {
+    if ((kc === 37 && !s.isRTL) || (kc === 39 && s.isRTL)) {
       slidePrev(s, plt);
     }
 

--- a/src/components/slides/swiper/swiper-parallax.ts
+++ b/src/components/slides/swiper/swiper-parallax.ts
@@ -9,7 +9,7 @@ function setParallaxTransform(s: Slides, el: HTMLElement, progress: number) {
   var p: string;
   var pX: string;
   var pY: string;
-  var rtlFactor = s._rtl ? -1 : 1;
+  var rtlFactor = s.isRTL ? -1 : 1;
 
   p = el.getAttribute('data-swiper-parallax') || '0';
   pX = el.getAttribute('data-swiper-parallax-x');

--- a/src/components/slides/swiper/swiper-progress.ts
+++ b/src/components/slides/swiper/swiper-progress.ts
@@ -48,7 +48,7 @@ function updateSlidesProgress(s: Slides, translate: number) {
   }
 
   var offsetCenter = -translate;
-  if (s._rtl) offsetCenter = translate;
+  if (s.isRTL) offsetCenter = translate;
 
   // Visible Slides
   removeClass(s._slides, CLS.slideVisible);
@@ -67,6 +67,6 @@ function updateSlidesProgress(s: Slides, translate: number) {
         s._slides[i].classList.add(CLS.slideVisible);
       }
     }
-    slide.progress = s._rtl ? -slideProgress : slideProgress;
+    slide.progress = s.isRTL ? -slideProgress : slideProgress;
   }
 }

--- a/src/components/slides/swiper/swiper-transition.ts
+++ b/src/components/slides/swiper/swiper-transition.ts
@@ -11,7 +11,7 @@ import { SWIPER_EFFECTS } from './swiper-effects';
 export function setWrapperTranslate(s: Slides, plt: Platform, translate: any, shouldUpdateActiveIndex?: boolean, byController?: Slides) {
   var x = 0, y = 0, z = 0;
   if (isHorizontal(s)) {
-    x = s._rtl ? -translate : translate;
+    x = s.isRTL ? -translate : translate;
   } else {
     y = translate;
   }
@@ -72,7 +72,7 @@ export function getTranslate(s: Slides, plt: Platform, el: HTMLElement, axis: st
   }
 
   if (s.virtualTranslate) {
-    return s._rtl ? -s._translate : s._translate;
+    return s.isRTL ? -s._translate : s._translate;
   }
 
   curStyle = plt.getElementComputedStyle(el);
@@ -118,7 +118,7 @@ export function getTranslate(s: Slides, plt: Platform, el: HTMLElement, axis: st
     }
   }
 
-  if (s._rtl && curTransform) {
+  if (s.isRTL && curTransform) {
     curTransform = -curTransform;
   }
 

--- a/src/components/slides/swiper/swiper-zoom.ts
+++ b/src/components/slides/swiper/swiper-zoom.ts
@@ -201,7 +201,7 @@ function onTouchMove(s: Slides, plt: Platform, ev: TouchEvent) {
 
     transition(z.gesture.imageWrap, 0);
 
-    if (s._rtl) {
+    if (s.isRTL) {
       z.image.startX = -z.image.startX;
       z.image.startY = -z.image.startY;
     }

--- a/src/components/slides/swiper/swiper.ts
+++ b/src/components/slides/swiper/swiper.ts
@@ -115,8 +115,7 @@ export function initSwiper(s: Slides, plt: Platform) {
   // }
 
   // RTL
-  s._rtl = isHorizontal(s) && (s.container.dir.toLowerCase() === 'rtl' || s.container.style.direction === 'rtl');
-  if (s._rtl) {
+  if (s.isRTL) {
     s._classNames.push(containerModifierClass + 'rtl');
   }
 
@@ -372,7 +371,7 @@ export function updateSlidesSize(s: Slides, plt: Platform) {
   s._virtualSize = -spaceBetween;
 
   // reset margins
-  if (s._rtl) {
+  if (s.isRTL) {
     inlineStyle(s._slides, { marginLeft: '', marginTop: '' });
   } else {
     inlineStyle(s._slides, { marginRight: '', marginBottom: '' });
@@ -492,7 +491,7 @@ export function updateSlidesSize(s: Slides, plt: Platform) {
   var newSlidesGrid: any[];
 
   if (
-    s._rtl && (s.effect === 'slide' || s.effect === 'coverflow')) {
+    s.isRTL && (s.effect === 'slide' || s.effect === 'coverflow')) {
     inlineStyle(s._wrapper, {width: s._virtualSize + s.spaceBetween + 'px'});
   }
   if (s.setWrapperSize) {
@@ -537,7 +536,7 @@ export function updateSlidesSize(s: Slides, plt: Platform) {
 
   if (s.spaceBetween !== 0) {
     if (isHorizontal(s)) {
-      if (s._rtl) {
+      if (s.isRTL) {
         inlineStyle(s._slides, {marginLeft: spaceBetween + 'px'});
       } else {
         inlineStyle(s._slides, {marginRight: spaceBetween + 'px'});
@@ -755,7 +754,7 @@ export function slideTo(s: Slides, plt: Platform, slideIndex?: number, speed?: n
   s._activeIndex = slideIndex;
   updateRealIndex(s);
 
-  if ((s._rtl && -translate === s._translate) || (!s._rtl && translate === s._translate)) {
+  if ((s.isRTL && -translate === s._translate) || (!s.isRTL && translate === s._translate)) {
     // Update Height
     if (s.autoHeight) {
       updateAutoHeight(s);

--- a/src/components/slides/test/reverse/app.module.ts
+++ b/src/components/slides/test/reverse/app.module.ts
@@ -1,5 +1,6 @@
 import { Component, ViewChild, NgModule } from '@angular/core';
 import { IonicApp, IonicModule, Slides } from  '../../../..';
+import { BrowserModule } from '@angular/platform-browser';
 
 
 @Component({
@@ -25,21 +26,22 @@ export class E2EPage {
 @Component({
   template: '<ion-nav [root]="root"></ion-nav>'
 })
-export class E2EApp {
+export class AppComponent {
   root = E2EPage;
 }
 
 @NgModule({
   declarations: [
-    E2EApp,
+    AppComponent,
     E2EPage
   ],
   imports: [
-    IonicModule.forRoot(E2EApp)
+    BrowserModule,
+    IonicModule.forRoot(AppComponent)
   ],
   bootstrap: [IonicApp],
   entryComponents: [
-    E2EApp,
+    AppComponent,
     E2EPage
   ]
 })

--- a/src/components/slides/test/reverse/main.html
+++ b/src/components/slides/test/reverse/main.html
@@ -3,7 +3,6 @@
             (ionSlideDidChange)="onSlideDidChange($event)"
             (ionSlideDrag)="onSlideDrag($event)"
             pager="true"
-            dir="rtl"
             effect="slide">
 
   <ion-slide style="background: red; color: white;">

--- a/src/components/slides/test/reverse/main.ts
+++ b/src/components/slides/test/reverse/main.ts
@@ -1,0 +1,5 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+
+import { AppModule } from './app.module';
+
+platformBrowserDynamic().bootstrapModule(AppModule);

--- a/src/components/snapshot/test/basic/pages/components/components.module.ts
+++ b/src/components/snapshot/test/basic/pages/components/components.module.ts
@@ -162,7 +162,7 @@ import {AppModule as SlidesImages} from '../../../../../slides/test/images/app.m
 import {AppModule as SlidesIntro} from '../../../../../slides/test/intro/app.module';
 import {AppModule as SlidesLoop} from '../../../../../slides/test/loop/app.module';
 import {AppModule as SlidesOptions} from '../../../../../slides/test/options/app.module';
-import {AppModule as SlidesRTL} from '../../../../../slides/test/rtl/app.module';
+import {AppModule as SlidesReverse} from '../../../../../slides/test/reverse/app.module';
 import {AppModule as SlidesScroll} from '../../../../../slides/test/scroll/app.module';
 
 import {AppModule as SpinnerBasic} from '../../../../../spinner/test/basic/app.module';
@@ -369,7 +369,7 @@ import {AppModule as VirtualScrollVariableSize} from '../../../../../virtual-scr
     SlidesIntro,
     SlidesLoop,
     SlidesOptions,
-    SlidesRTL,
+    SlidesReverse,
     SlidesScroll,
 
     SpinnerBasic,

--- a/src/components/snapshot/test/basic/pages/components/components.ts
+++ b/src/components/snapshot/test/basic/pages/components/components.ts
@@ -163,7 +163,7 @@ import { AppComponent as SlidesImages } from '../../../../../slides/test/images/
 import { AppComponent as SlidesIntro } from '../../../../../slides/test/intro/app.module';
 import { AppComponent as SlidesLoop } from '../../../../../slides/test/loop/app.module';
 import { AppComponent as SlidesOptions } from '../../../../../slides/test/options/app.module';
-import { E2EApp as SlidesRTL } from '../../../../../slides/test/rtl/app.module';
+import { AppComponent as SlidesReverse } from '../../../../../slides/test/reverse/app.module';
 import { AppComponent as SlidesScroll } from '../../../../../slides/test/scroll/app.module';
 
 import { AppComponent as SpinnerBasic } from '../../../../../spinner/test/basic/app.module';
@@ -197,11 +197,11 @@ import { AppComponent as TypographyBasic } from '../../../../../typography/test/
 import { AppComponent as VirtualScrollBasic } from '../../../../../virtual-scroll/test/basic/app.module';
 import { AppComponent as VirtualScrollCards } from '../../../../../virtual-scroll/test/cards/app.module';
 import { AppComponent as VirtualScrollImageGallery } from '../../../../../virtual-scroll/test/image-gallery/app.module';
-import { E2EApp as VirtualScrollInfiniteScroll } from '../../../../../virtual-scroll/test/infinite-scroll/app.module';
+import { AppComponent as VirtualScrollInfiniteScroll } from '../../../../../virtual-scroll/test/infinite-scroll/app.module';
 import { AppComponent as VirtualScrollList } from '../../../../../virtual-scroll/test/list/app.module';
 import { AppComponent as VirtualScrollMedia } from '../../../../../virtual-scroll/test/media/app/app.component';
 import { AppComponent as VirtualScrollSlidingItem } from '../../../../../virtual-scroll/test/sliding-item/app.module';
-import {  AppComponent as VirtualScrollVariableSize } from '../../../../../virtual-scroll/test/variable-size/app.module';
+import { AppComponent as VirtualScrollVariableSize } from '../../../../../virtual-scroll/test/variable-size/app.module';
 
 
 export type ComponentsGroup = { name: string, components: Array<{ name: string, component: any }> };
@@ -476,7 +476,7 @@ export class ComponentsPage {
         {name: 'basic', component: ShowHideWhenBasic}
       ]
     }, {
-      name: 'Show-hide-when',
+      name: 'Slides',
       components: [
         {name: 'basic', component: SlidesBasic},
         {name: 'control', component: SlidesControl},
@@ -485,7 +485,7 @@ export class ComponentsPage {
         {name: 'intro', component: SlidesIntro},
         {name: 'loop', component: SlidesLoop},
         {name: 'options', component: SlidesOptions},
-        {name: 'rtl', component: SlidesRTL},
+        {name: 'rtl', component: SlidesReverse},
         {name: 'scroll', component: SlidesScroll},
       ]
     }, {
@@ -520,11 +520,6 @@ export class ComponentsPage {
       components: []
     },  {
       name: 'Toast',
-      components: [
-        {name: 'basic', component: ToastBasic}
-      ]
-    },  {
-      name: 'Toggle',
       components: [
         {name: 'basic', component: ToastBasic}
       ]

--- a/src/components/virtual-scroll/test/infinite-scroll/app.module.ts
+++ b/src/components/virtual-scroll/test/infinite-scroll/app.module.ts
@@ -60,22 +60,22 @@ function getAsyncData(): Promise<any[]> {
 @Component({
   template: '<ion-nav [root]="root"></ion-nav>'
 })
-export class E2EApp {
+export class AppComponent {
   root = E2EPage;
 }
 
 
 @NgModule({
   declarations: [
-    E2EApp,
+    AppComponent,
     E2EPage
   ],
   imports: [
-    IonicModule.forRoot(E2EApp)
+    IonicModule.forRoot(AppComponent)
   ],
   bootstrap: [IonicApp],
   entryComponents: [
-    E2EApp,
+    AppComponent,
     E2EPage
   ]
 })


### PR DESCRIPTION
#### Short description of what this resolves:
Strict `dir="rtl"` is not good for multi-directional apps

#### Changes proposed in this pull request:
- Set direction based on platform direction
- Add `reverse` input to know if to reverse the slides
- Still support `dir="rtl"` as a strict thing (backwards compatibility)
-

**Ionic Version**: 3.x
