### PR TITLE
fix(input): use all supported attributes on both textareas and inputs

### DIFF
--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -98,6 +98,8 @@ import { Platform } from '../../platform/platform';
     '[attr.max]="max" ' +
     '[attr.step]="step" ' +
     '[attr.maxlength]="maxlength" ' +
+    '[attr.autocomplete]="autocomplete" ' +
+    '[attr.autocorrect]="autocorrect" ' +
     '[attr.spellcheck]="spellcheck" ' +
     '[attr.autocapitalize]="autocapitalize" ' +
     '[placeholder]="placeholder" ' +
@@ -110,6 +112,11 @@ import { Platform } from '../../platform/platform';
     '(focus)="onFocus($event)" ' +
     '(keydown)="onKeydown($event)" ' +
     '[attr.name]="name" ' +
+    '[attr.maxlength]="maxlength" ' +
+    '[attr.autocomplete]="autocomplete" ' +
+    '[attr.autocorrect]="autocorrect" ' +
+    '[attr.spellcheck]="spellcheck" ' +
+    '[attr.autocapitalize]="autocapitalize" ' +
     '[placeholder]="placeholder" ' +
     '[disabled]="_disabled" ' +
     '[readonly]="_readonly"></textarea>' +


### PR DESCRIPTION
#### Short description of what this resolves:
Checking out the amazing keyboard/input refactor by @manucorporat, I came across some inconsistencies in the attributes that are supported for `ion-input` and `ion-textarea`.

#### Changes proposed in this pull request:

- Add `autocomplete` and `autocorrect` attributes for which the `Input()`s already exist.
- Add `maxlength`, `spellcheck` and `autocapitalize` on `ion-textarea`s as well.

**Ionic Version**: 3.x (nightly)
