### PR TITLE
docs(): remove constructor params from docs

### DIFF
--- a/scripts/docs/dgeni-config.js
+++ b/scripts/docs/dgeni-config.js
@@ -20,6 +20,7 @@ module.exports = function(currentVersion, initialVersionBuild) {
 .processor(require('./processors/latest-version'))
 .processor(require('./processors/index-page'))
 .processor(require('./processors/remove-private-members'))
+.processor(require('./processors/remove-params'))
 .processor(require('./processors/jekyll'))
 .processor(require('./processors/hide-private-api'))
 .processor(require('./processors/collect-inputs-outputs'))

--- a/scripts/docs/processors/remove-params.js
+++ b/scripts/docs/processors/remove-params.js
@@ -1,0 +1,28 @@
+var console = require('better-console');
+module.exports = function removeParams() {
+  return {
+    name: 'remove-params',
+    description: 'Prevent class params from being rendered',
+    $runAfter: ['paths-computed'],
+    $runBefore: ['rendering-docs'],
+    $process: function(docs) {
+      docs.forEach(function(doc) {
+        if (doc.constructorDoc) {
+          const constructorDoc = doc.constructorDoc;
+          if (doc.members) {
+            doc.members = doc.members.filter(function(method) {
+              constructorDoc.parameters.forEach(function(param) {
+                if (param.indexOf(method.name) > -1) {
+                  return true;
+                } else {
+                  return false;
+                }
+              });
+            });
+          }
+        }
+      });
+      return docs;
+    }
+  };
+};

--- a/scripts/docs/processors/remove-params.js
+++ b/scripts/docs/processors/remove-params.js
@@ -1,4 +1,3 @@
-var console = require('better-console');
 module.exports = function removeParams() {
   return {
     name: 'remove-params',

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -295,6 +295,7 @@ export class TextInput extends BaseInput<string> implements IonicFormInput {
     }
   }
 
+  /** @hidden */
   ngAfterContentInit() { }
 
   /**


### PR DESCRIPTION
#### Short description of what this resolves:
Removes constructor params from dgeni docs

#### Changes proposed in this pull request:

- Add new process to filter out any members that are params 