### PR TITLE
fix(input): slightly longer delay for autofocus

### DIFF
--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -324,7 +324,7 @@ export class TextInput extends BaseInput<string> implements IonicFormInput {
         case 'delay':
           // config says to chill out a bit and focus on the input after transitions
           // works best on desktop
-          this._plt.timeout(() => nativeInputEle.focus(), 650);
+          this._plt.timeout(() => nativeInputEle.focus(), 800);
           break;
       }
       // traditionally iOS has big issues with autofocus on actual devices


### PR DESCRIPTION
#### Short description of what this resolves:
Really nice to see autofocus has arrived in Ionic! I've been using a directive for this until now. In that directive I'm using a delay of 800ms, which works consistently every time.

Trying the latest nightly I found the autofocus fails about one third of the times with iOS transitions. Changing it to 800ms fixes it for me.

It could also be nice to make this a config setting, because someone might be using custom transitions that take longer.

#### Changes proposed in this pull request:

- Change autofocus delay from 650ms to 800ms

**Ionic Version**: 3.x (nightly)