### PR TITLE
feat(directions): concept - let user know when direction is not loaded

### DIFF
--- a/src/platform/platform.ts
+++ b/src/platform/platform.ts
@@ -1199,6 +1199,14 @@ export function setupPlatform(doc: HTMLDocument, platformConfigs: {[key: string]
 
   plt.init();
 
+  // add direction enforcement if dev server exists
+  if ((<any>win)['IonicDevServer']) {
+    let enforcer = doc.createElement('div');
+    enforcer.classList.add('direction-enforcer');
+    enforcer.innerText = 'Direction is not loaded in SCSS';
+    doc.querySelector('body').appendChild(enforcer);
+  }
+
   // add the platform obj to the window
   (<any>win)['Ionic'] = (<any>win)['Ionic'] || {};
   (<any>win)['Ionic']['platform'] = plt;

--- a/src/themes/ionic.globals.scss
+++ b/src/themes/ionic.globals.scss
@@ -47,4 +47,6 @@ $z-index-backdrop:               2; // scss-lint:disable DefaultRule
 $z-index-overlay-wrapper:        10; // scss-lint:disable DefaultRule
 
 $z-index-item-options:           1; // scss-lint:disable DefaultRule
-$z-index-item-divider:          100; // scss-lint:disable DefaultRule
+$z-index-item-divider:           100; // scss-lint:disable DefaultRule
+
+$z-index-dir-enforcer:            999999; // scss-lint:disable DefaultRule

--- a/src/themes/util.scss
+++ b/src/themes/util.scss
@@ -68,3 +68,25 @@ ion-input :focus {
 .click-block-active {
   @include transform(translate3d(0, 0, 0));
 }
+
+
+.direction-enforcer {
+  @include position(0, 0, 0, 0);
+  @include text-align(center);
+
+  position: absolute;
+  z-index: $z-index-dir-enforcer;
+
+  display: none;
+
+  background-color: white;
+}
+
+
+@each $dir in ltr, rtl {
+  [dir="#{$dir}"] .direction-enforcer {
+    @if $app-direction != $dir and $app-direction != null {
+      display: block;
+    }
+  }
+}


### PR DESCRIPTION
#### Short description of what this resolves:
People that want to use rtl, or that already use rtl, if they don't use `multi` or `rtl` they will get a nice error.

This is just a concept. I am sure there is a better way.

**Ionic Version**:  3.x

If for example I use ltr, but my `$app-direction` is `rtl`, it shows:
![image](https://user-images.githubusercontent.com/5757359/27255288-f57cfe68-53a3-11e7-9fc6-d2a07d0f10c4.png)

