### PR TITLE
fix(select): ion-select activated incorrectly

### DIFF
--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -244,6 +244,9 @@ export class Select extends BaseInput<any> implements OnDestroy {
 
   @HostListener('click', ['$event'])
   _click(ev: UIEvent) {
+    if (ev.detail == 0) {
+      return;
+    }
     ev.preventDefault();
     ev.stopPropagation();
     this.open(ev);


### PR DESCRIPTION
#### Short description of what this resolves:
ion-select element incorrectly activated when pressing enter key in other input element.
issue #12202


**Ionic Version**:  3.x

**Fixes**: #12202
