### PR TITLE
fix(list): remove margin of MD buttons in ion-item-options

### DIFF
--- a/src/components/list/list.md.scss
+++ b/src/components/list/list.md.scss
@@ -87,14 +87,14 @@ $list-md-header-color:           #757575 !default;
 }
 
 .list-md ion-item-options .button {
-  @include margin(1px, 0);
+  @include margin(0);
   @include border-radius(0);
 
   display: inline-flex;
 
   align-items: center;
 
-  height: calc(100% - 2px);
+  height: 100%;
 
   border: 0;
 


### PR DESCRIPTION
#### Short description of what this resolves:
Remove margin of MD buttons in ion-item-options to make it the same as iOS. I haven't found anything in the [material guidelines](https://material.io/guidelines/components/lists-controls.html#lists-controls-types-of-list-controls) that justifies this margin.



#### Changes proposed in this pull request:
(click image to enlarge)
![item-slide](https://user-images.githubusercontent.com/24232962/27867954-772040ba-619b-11e7-9441-dca26f4f0a41.png)

**Ionic Version**: 2.x / 3.x
