### PR TITLE
fix(navcontroller): don't set transitioning if no transition required

### DIFF
--- a/src/navigation/nav-controller-base.ts
+++ b/src/navigation/nav-controller-base.ts
@@ -343,7 +343,10 @@ export class NavControllerBase extends Ion implements NavController {
       }
       ti.enteringRequiresTransition = (ti.insertStart === viewsLength);
     }
-    this.setTransitioning(true);
+
+    if (ti.enteringRequiresTransition || ti.leavingRequiresTransition) {
+      this.setTransitioning(true);
+    }
     return Promise.resolve();
   }
 


### PR DESCRIPTION
#### Short description of what this resolves:
Inserting or removing a view other than the active view does not require a transition and navcontroller incorrectly sets itself to isTransitioning() true.

#### Changes proposed in this pull request:
Don't set transitioning true when not required.

**Ionic Version**: 3.5

**Fixes**: #12267
