### PR TITLE
Add import information

### DIFF
--- a/src/components/toast/toast-controller.ts
+++ b/src/components/toast/toast-controller.ts
@@ -37,6 +37,8 @@ import { ToastOptions } from './toast-options';
  *
  * @usage
  * ```ts
+ * import { ToastController } from 'ionic-angular';
+ *
  * constructor(private toastCtrl: ToastController) {
  *
  * }


### PR DESCRIPTION
Cannot use ToastController without knowing from where to import it

#### Short description of what this resolves:
The doc is incomplete because this code won't work without first importing the class.  This is a common occurrence across virtually all of the Ionic docs.  This is the one that got me today, so I thought I'd fix it.

#### Changes proposed in this pull request:

- add import to code example in doc

