### PR TITLE
block all gestures in the modals

### DIFF
--- a/src/components/modal/modal-component.ts
+++ b/src/components/modal/modal-component.ts
@@ -4,7 +4,7 @@ import { KEY_ESCAPE } from '../../platform/key';
 import { NavParams } from '../../navigation/nav-params';
 import { NavOptions } from '../../navigation/nav-util';
 import { ViewController } from '../../navigation/view-controller';
-import { BlockerDelegate, GESTURE_GO_BACK_SWIPE, GESTURE_MENU_SWIPE,  GestureController } from '../../gestures/gesture-controller';
+import { BlockerDelegate, BLOCK_ALL, GestureController } from '../../gestures/gesture-controller';
 import { ModuleLoader } from '../../util/module-loader';
 import { assert } from '../../util/util';
 
@@ -40,9 +40,7 @@ export class ModalCmp {
     let opts = _navParams.get('opts');
     assert(opts, 'modal data must be valid');
 
-    this._gestureBlocker = gestureCtrl.createBlocker({
-      disable: [GESTURE_MENU_SWIPE, GESTURE_GO_BACK_SWIPE]
-    });
+    this._gestureBlocker = gestureCtrl.createBlocker(BLOCK_ALL);
     this._bdDismiss = opts.enableBackdropDismiss;
 
     if (opts.cssClass) {


### PR DESCRIPTION
#### Short description of what this resolves:

block all gestures in the modal like the alerts to prevent scroll ability of the page that appear behind the modal specially in the big screens

#### Changes proposed in this pull request:

- use BLOCK_ALL instead of "{ disable: [GESTURE_MENU_SWIPE, GESTURE_GO_BACK_SWIPE] }"

**Ionic Version**: 3.x
