### PR TITLE
fix (input):  ng-touched applied to ion-input on blur

### DIFF
--- a/src/util/base-input.ts
+++ b/src/util/base-input.ts
@@ -254,7 +254,6 @@ export class BaseInput<T> extends Ion implements CommonInput<T> {
    */
   private onChange() {
     this._onChanged && this._onChanged(this._inputNgModelEvent());
-    this._onTouched && this._onTouched();
   }
 
   /**

--- a/src/util/base-input.ts
+++ b/src/util/base-input.ts
@@ -229,6 +229,7 @@ export class BaseInput<T> extends Ion implements CommonInput<T> {
     this._form && this._form.unsetAsFocused(this);
     this._setFocus(false);
     this.ionBlur.emit(this);
+    this._onTouched && this._onTouched();
   }
 
   /**


### PR DESCRIPTION
#### Short description of what this resolves:
Solve the problem of ng-touched is being applied only on keyup

**Ionic Version**: 3.4.x

**Fixes**: #12102 