### PR TITLE
Update documentation

### DIFF
--- a/src/util/events.ts
+++ b/src/util/events.ts
@@ -16,7 +16,7 @@ import { ScrollView } from './scroll-view';
  * constructor(public events: Events) {}
  * createUser(user) {
  *   console.log('User created!')
- *   events.publish('user:created', user, Date.now());
+ *   this.events.publish('user:created', user, Date.now());
  * }
  *
  *


### PR DESCRIPTION
Need to access member using `this` keyword outside constructor

#### Short description of what this resolves:
Fixes documentation

#### Changes proposed in this pull request:
Update documentation for Events. 
non static member cannot be accessed without using `this`

**Ionic Version**: 2.x

**Fixes**: #
