### PR TITLE
docs(modal): fix improper capitalization

### DIFF
--- a/src/components/modal/modal-controller.ts
+++ b/src/components/modal/modal-controller.ts
@@ -19,7 +19,7 @@ import { DeepLinker } from '../../navigation/deep-linker';
  *
  * When a modal (or any other overlay such as an alert or actionsheet) is
  * "presented" to a nav controller, the overlay is added to the app's root nav.
- * After the modal has been presented, from within the component instance The
+ * After the modal has been presented, from within the component instance, the
  * modal can later be closed or "dismissed" by using the ViewController's
  * `dismiss` method. Additionally, you can dismiss any overlay by using `pop`
  * on the root nav controller. Modals are not reusable. When a modal is dismissed


### PR DESCRIPTION
Fix very minor capitalization typo in the modal-controller documentation