### PR TITLE
fix(nav-controller-base): set transitioning to false on non-animated transitions

### DIFF
--- a/src/navigation/nav-controller-base.ts
+++ b/src/navigation/nav-controller-base.ts
@@ -576,6 +576,7 @@ export class NavControllerBase extends Ion implements NavController {
       // they're inserting/removing the views somewhere in the middle or
       // beginning, so visually nothing needs to animate/transition
       // resolve immediately because there's no animation that's happening
+      this.setTransitioning(false);
       return Promise.resolve({
         hasCompleted: true,
         requiresTransition: false


### PR DESCRIPTION
#### Short description of what this resolves:
Subsequent navigation commands after calling `remove` do not work. This is due to `isTransitioning` not being set back to true when an animation is not required.

#### Changes proposed in this pull request:
- Set `isTransitioning` back to false when an animation is not needed

**Ionic Version**: 3.x

**Fixes**: #12410
