### PR TITLE
Created config property for disable url in whole app

### DIFF
--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -32,6 +32,7 @@ export class App {
   private _rootNavs = new Map<string, NavigationContainer>();
   private _disableScrollAssist: boolean;
   private _didScroll = false;
+  private _urlDisabled: boolean;
 
   /**
    * @hidden
@@ -88,6 +89,7 @@ export class App {
     // register this back button action with a default priority
     _plt.registerBackButtonAction(this.goBack.bind(this));
     this._disableScrollAssist = _config.getBoolean('disableScrollAssist', false);
+    this._urlDisabled = _config.getBoolean('urlDisabled', false);
 
     const blurring = _config.getBoolean('inputBlurring', false);
     if (blurring) {
@@ -203,6 +205,14 @@ export class App {
       return false;
     }
     return true;
+  }
+
+  setUrlDisabled(urlDisabled: boolean) {
+    this._urlDisabled = urlDisabled;
+  }
+
+  isUrlDisabled(): boolean {
+    return this._urlDisabled;
   }
 
   /**

--- a/src/navigation/deep-linker.ts
+++ b/src/navigation/deep-linker.ts
@@ -199,22 +199,24 @@ export class DeepLinker {
    * @internal
    */
   _updateLocation(browserUrl: string, direction: string) {
-    if (this._indexAliasUrl === browserUrl) {
-      browserUrl = '/';
-    }
+    if (!this._app.isUrlDisabled()) {
+      if (this._indexAliasUrl === browserUrl) {
+        browserUrl = '/';
+      }
 
-    if (direction === DIRECTION_BACK && this._isBackUrl(browserUrl)) {
-      // this URL is exactly the same as the back URL
-      // it's safe to use the browser's location.back()
-      console.debug(`DeepLinker, location.back(), url: '${browserUrl}'`);
-      this._historyPop();
-      this._location.back();
+      if (direction === DIRECTION_BACK && this._isBackUrl(browserUrl)) {
+        // this URL is exactly the same as the back URL
+        // it's safe to use the browser's location.back()
+        console.debug(`DeepLinker, location.back(), url: '${browserUrl}'`);
+        this._historyPop();
+        this._location.back();
 
-    } else if (!this._isCurrentUrl(browserUrl)) {
-      // probably navigating forward
-      console.debug(`DeepLinker, location.go('${browserUrl}')`);
-      this._historyPush(browserUrl);
-      this._location.go(browserUrl);
+      } else if (!this._isCurrentUrl(browserUrl)) {
+        // probably navigating forward
+        console.debug(`DeepLinker, location.go('${browserUrl}')`);
+        this._historyPush(browserUrl);
+        this._location.go(browserUrl);
+      }
     }
   }
 


### PR DESCRIPTION
In IonicModule config object, you can pass urlDisabled property with true value to disable url in whole app. In App component there is also setUrlDisabled method for changing this property, when this method is used in app, url will stay at the last used one

#### Short description of what this resolves:
My issue 12439 - add property for disable url in app

#### Changes proposed in this pull request:

- In IonicApp config urlDisabled property added with default value false
- In App component added methods isUrlDisabled and SetUrlDisabled
- In DeepLinker method _updateLocation first checks if urlDisabled is false and then continues method

**Ionic Version**: 1.x / 2.x / 3.x
3.x

**Fixes**: #
