### PR TITLE
add note about `Date().toISOString();`

### DIFF
--- a/src/components/datetime/datetime.ts
+++ b/src/components/datetime/datetime.ts
@@ -135,6 +135,9 @@ import {
  * to serialize and pass within JSON objects, and sending databases a standardized
  * format which it can be easily parsed if need be.
  *
+ * To create an ISO datetime string for the current date and time, e.g. use `currentDate: 
+ * String = new Date().toISOString();`.
+ *
  * An ISO format can be used as a simple year, or just the hour and minute, or get more
  * detailed down to the millisecond and timezone. Any of the ISO formats below can be used,
  * and after a user selects a new value, Ionic will continue to use the same ISO format


### PR DESCRIPTION
right now the docs is missing the information how to actually create such an ISO string in a simple way. This adds the most basic example possible.