### PR TITLE
fix(list): change dark theme color

### DIFF
--- a/src/themes/ionic.theme.dark.ios.scss
+++ b/src/themes/ionic.theme.dark.ios.scss
@@ -53,7 +53,7 @@ $tabs-ios-tab-color-active:            $tabs-tab-color-active !default;
 // --------------------------------------------------
 
 $list-ios-text-color:                  $list-text-color !default;
-$list-ios-border-color:                $list-border-color !default;
+$list-ios-border-color:                #dedede !default;
 $list-ios-background-color:            $list-background-color !default;
 $list-ios-activated-background-color:  #d9d9d9 !default;
 

--- a/src/themes/ionic.theme.default.ios.scss
+++ b/src/themes/ionic.theme.default.ios.scss
@@ -42,7 +42,7 @@ $tabs-ios-tab-color-active:            $tabs-tab-color-active !default;
 // --------------------------------------------------
 
 $list-ios-text-color:                  $list-text-color !default;
-$list-ios-border-color:                $list-border-color !default;
+$list-ios-border-color:                #dedede !default;
 $list-ios-background-color:            $list-background-color !default;
 $list-ios-activated-background-color:  #d9d9d9 !default;
 

--- a/src/themes/ionic.theme.default.ios.scss
+++ b/src/themes/ionic.theme.default.ios.scss
@@ -42,7 +42,7 @@ $tabs-ios-tab-color-active:            $tabs-tab-color-active !default;
 // --------------------------------------------------
 
 $list-ios-text-color:                  $list-text-color !default;
-$list-ios-border-color:                #dedede !default;
+$list-ios-border-color:                $list-border-color !default;
 $list-ios-background-color:            $list-background-color !default;
 $list-ios-activated-background-color:  #d9d9d9 !default;
 


### PR DESCRIPTION
#### Short description of what this resolves:
The dark theme list/note colors on iOS should be lighter.
I took the color from the MD dark mode, but it can be any light color.

#### Changes proposed in this pull request:

- Change variable `$list-ios-border-color` of dark mode to be lighter, like md

**Ionic Version**: 3.x

**Fixes**: didn't open an issue for this
