### PR TITLE
docs(input): correct the `autocomplete` and `autocorrect` description

### DIFF
--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -211,12 +211,12 @@ export class TextInput extends BaseInput<string> implements IonicFormInput {
   @ViewChild('textInput', { read: ElementRef }) _native: ElementRef;
 
   /**
-   * @input {string} Instructional text that shows before the input has a value.
+   * @input {string} Set the input's autocomplete property. Values: `"on"`, `"off"`.
    */
   @Input() autocomplete: string = '';
 
   /**
-   * @input {string} Instructional text that shows before the input has a value.
+   * @input {string} Set the input's autocorrect property. Values: `"on"`, `"off"`.
    */
   @Input() autocorrect: string = '';
 

--- a/src/components/searchbar/searchbar.ts
+++ b/src/components/searchbar/searchbar.ts
@@ -39,6 +39,7 @@ import { Platform } from '../../platform/platform';
         '[attr.type]="type" ' +
         '[attr.autocomplete]="_autocomplete" ' +
         '[attr.autocorrect]="_autocorrect" ' +
+        '[attr.autocapitalize]="autocapitalize" ' +
         '[attr.spellcheck]="_spellcheck">' +
       '<button ion-button clear class="searchbar-clear-icon" [mode]="_mode" (click)="clearInput($event)" (mousedown)="clearInput($event)" type="button"></button>' +
     '</div>' +
@@ -114,6 +115,11 @@ export class Searchbar extends BaseInput<string> {
   set autocorrect(val: string) {
     this._autocorrect = (val === '' || val === 'on') ? 'on' : this._config.get('autocorrect', 'off');
   }
+
+  /**
+   * @input {string} Set the input's autocapitalize property. Values: `"none"`, `"sentences"`, `"words"`, `"characters"`. Default `"sentences"`.
+   */
+  @Input() autocapitalize: string = 'sentences';
 
   /**
    * @input {string|boolean} Set the input's spellcheck property. Values: `true`, `false`. Default `false`.

--- a/src/components/searchbar/test/basic/pages/root-page/root-page.html
+++ b/src/components/searchbar/test/basic/pages/root-page/root-page.html
@@ -10,14 +10,14 @@
   </p>
 
   <h5 padding-left> Search - Custom Placeholder </h5>
-  <ion-searchbar [autocorrect]="isAutocorrect" showCancelButton="true" [autocomplete]="isAutocomplete" [spellcheck]="isSpellcheck" type="number" placeholder="Filter Schedules" [(ngModel)]="customPlaceholder" (ionChange)="changedInput($event)" (ionInput)="triggerInput($event)" (ionCancel)="onCancelSearchbar($event)" (ionClear)="onClearSearchbar($event)"></ion-searchbar>
+  <ion-searchbar [autocorrect]="isAutocorrect" showCancelButton="true" [autocomplete]="isAutocomplete" [autocapitalize]="isAutocapitalize" [spellcheck]="isSpellcheck" type="number" placeholder="Filter Schedules" [(ngModel)]="customPlaceholder" (ionChange)="changedInput($event)" (ionInput)="triggerInput($event)" (ionCancel)="onCancelSearchbar($event)" (ionClear)="onClearSearchbar($event)"></ion-searchbar>
 
   <p padding-left>
     customPlaceholder: <b>{{ customPlaceholder }}</b>
   </p>
 
   <h5 padding-left> Search - No Cancel Button </h5>
-  <ion-searchbar autocorrect="off" autocomplete="off" spellcheck="true" type="text" [(ngModel)]="defaultCancel" showCancelButton="false" (ionChange)="changedInput($event)" (ionInput)="triggerInput($event)" (ionCancel)="onCancelSearchbar($event)" (ionClear)="onClearSearchbar($event)"></ion-searchbar>
+  <ion-searchbar autocorrect="off" autocomplete="off" autocapitalize="none" spellcheck="true" type="text" [(ngModel)]="defaultCancel" showCancelButton="false" (ionChange)="changedInput($event)" (ionInput)="triggerInput($event)" (ionCancel)="onCancelSearchbar($event)" (ionClear)="onClearSearchbar($event)"></ion-searchbar>
 
   <p padding-left>
     defaultCancel: <b>{{ defaultCancel }}</b>

--- a/src/components/searchbar/test/basic/pages/root-page/root-page.ts
+++ b/src/components/searchbar/test/basic/pages/root-page/root-page.ts
@@ -12,6 +12,7 @@ export class RootPage {
 
   isAutocorrect: string = 'on';
   isAutocomplete: string = 'on';
+  isAutocapitalize: string = 'sentences';
   isSpellcheck: boolean = true;
   activeTab = '';
 

--- a/src/util/dom.ts
+++ b/src/util/dom.ts
@@ -94,7 +94,7 @@ export function isTextInput(ele: any) {
 export const NON_TEXT_INPUT_REGEX = /^(radio|checkbox|range|file|submit|reset|color|image|button)$/i;
 
 
-const SKIP_INPUT_ATTR = ['value', 'checked', 'disabled', 'readonly', 'placeholder', 'type', 'class', 'style', 'id', 'autofocus', 'autocomplete', 'autocorrect'];
+const SKIP_INPUT_ATTR = ['value', 'checked', 'disabled', 'readonly', 'placeholder', 'type', 'class', 'style', 'id', 'autofocus', 'autocomplete', 'autocorrect', 'autocapitalize'];
 export function copyInputAttributes(srcElement: HTMLElement, destElement: HTMLElement) {
   // copy attributes from one element to another
   // however, skip over a few of them as they're already


### PR DESCRIPTION
#### Short description of what this resolves:
Currently, the documentation for `autocomplete` and `autocorrect` is incorrectly set to the same as the `placeholder` documentation with the incorrect description: 

```
@input {string} Instructional text that shows before the input has a value.
```

#### Changes proposed in this pull request:

- Correct the documentation for both `@Input` attributes.
- `autocomplete`: `@input {string} Set the input's autocomplete property. Values: `"on"`, `"off"`.`
- `autocorrect`: `@input {string} Set the input's autocorrect property. Values: `"on"`, `"off"`.`

**Ionic Version**: 3.x

**Fixes**: #12609
