### PR TITLE
docs(input): correct the `autocomplete` and `autocorrect` description

### DIFF
--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -211,12 +211,12 @@ export class TextInput extends BaseInput<string> implements IonicFormInput {
   @ViewChild('textInput', { read: ElementRef }) _native: ElementRef;
 
   /**
-   * @input {string} Instructional text that shows before the input has a value.
+   * @input {string} Set the input's autocomplete property. Values: `"on"`, `"off"`. Default `"off"`.
    */
   @Input() autocomplete: string = '';
 
   /**
-   * @input {string} Instructional text that shows before the input has a value.
+   * @input {string} Set the input's autocorrect property. Values: `"on"`, `"off"`. Default `"off"`.
    */
   @Input() autocorrect: string = '';
 


### PR DESCRIPTION
#### Short description of what this resolves:
Currently, the documentation for `autocomplete` and `autocorrect` is incorrectly set to the same as the `placeholder` documentation with the incorrect description: 

```
@input {string} Instructional text that shows before the input has a value.
```

#### Changes proposed in this pull request:

- Correct the documentation for both `@Input` attributes.
- `autocomplete`: `@input {string} Set the input's autocomplete property. Values: `"on"`, `"off"`.`
- `autocorrect`: `@input {string} Set the input's autocorrect property. Values: `"on"`, `"off"`.`

**Ionic Version**: 3.x

**Fixes**: #12609