### PR TITLE
docs(toolbar): fix a spelling error for toolbar-header

### DIFF
--- a/src/components/toolbar/toolbar-header.ts
+++ b/src/components/toolbar/toolbar-header.ts
@@ -9,7 +9,7 @@ import { ViewController } from '../../navigation/view-controller';
  * @name Header
  * @description
  * Header is a parent component that holds the navbar and toolbar component.
- * It's important to note that `ion-header` needs to be the one of the three root elements of a page
+ * It's important to note that `ion-header` needs to be one of the three root elements of a page
  *
  * @usage
  *


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes a spelling error in the description

#### Changes proposed in this pull request:

- remove the word 'the' where it shouldn't be

**Ionic Version**: 1.x / 2.x / 3.x
3.x
