### PR TITLE
docs(modal): Updated with Lazy Loading

### DIFF
--- a/src/components/modal/modal-controller.ts
+++ b/src/components/modal/modal-controller.ts
@@ -43,12 +43,13 @@ import { DeepLinker } from '../../navigation/deep-linker';
  *  }
  *
  *  presentProfileModal() {
- *    let profileModal = this.modalCtrl.create(Profile, { userId: 8675309 });
+ *    let profileModal = this.modalCtrl.create('Profile', { userId: 8675309 });
  *    profileModal.present();
  *  }
  *
  * }
- *
+ * 
+ * @IonicPage()
  * @Component(...)
  * class Profile {
  *
@@ -84,12 +85,12 @@ import { DeepLinker } from '../../navigation/deep-linker';
  *  }
  *
  *  presentContactModal() {
- *    let contactModal = this.modalCtrl.create(ContactUs);
+ *    let contactModal = this.modalCtrl.create('ContactUs');
  *    contactModal.present();
  *  }
  *
  *  presentProfileModal() {
- *    let profileModal = this.modalCtrl.create(Profile, { userId: 8675309 });
+ *    let profileModal = this.modalCtrl.create('Profile', { userId: 8675309 });
  *    profileModal.onDidDismiss(data => {
  *      console.log(data);
  *    });
@@ -98,6 +99,7 @@ import { DeepLinker } from '../../navigation/deep-linker';
  *
  * }
  *
+ * @IonicPage
  * @Component(...)
  * class Profile {
  *


### PR DESCRIPTION
The given examples how to use modals won't work with the newest Ionic combined with Lazy Loading.

#### Short description of what this resolves:
 Resolves the given examples not working with the newest Ionic versions involving lazy loading
#### Changes proposed in this pull request:

- Adding @IonicPage to components examples and made strings of the component names 

**Ionic Version**:  3.x

**Fixes**: #
