### PR TITLE
docs(demos): add event target to searchbar demo

### DIFF
--- a/demos/src/searchbar/pages/page-one/page-one.ts
+++ b/demos/src/searchbar/pages/page-one/page-one.ts
@@ -16,7 +16,7 @@ export class PageOne {
 
   filterItems(ev: any) {
     this.setItems();
-    let val = ev.value;
+    let val = ev.target.value;
 
     if (val && val.trim() !== '') {
       this.items = this.items.filter(function(item) {


### PR DESCRIPTION
To get value from search input, it must be ev.target.value

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x / 3.x

**Fixes**: #
