### PR TITLE
feat(datetime): add default picker value input

### DIFF
--- a/src/components/datetime/datetime.ts
+++ b/src/components/datetime/datetime.ts
@@ -320,6 +320,14 @@ export class DateTime extends BaseInput<DateTimeData> implements AfterContentIni
   @Input() displayFormat: string;
 
   /**
+   * @input {string} The default datetime selected in picker modal if field value is empty.
+   * Value must be a date string following the
+   * [ISO 8601 datetime format standard](https://www.w3.org/TR/NOTE-datetime),
+   * `1996-12-19`.
+   */
+  @Input() pickerDefault: string;
+
+  /**
    * @input {string} The format of the date and time picker columns the user selects.
    * A datetime input can have one or many datetime parts, each getting their
    * own column which allow individual selection of that particular datetime part. For
@@ -596,7 +604,7 @@ export class DateTime extends BaseInput<DateTimeData> implements AfterContentIni
 
         // cool, we've loaded up the columns with options
         // preselect the option for this column
-        const optValue = getValueFromFormat(this.getValue(), format);
+        const optValue = getValueFromFormat(this.getValueOrDefault(), format);
         const selectedIndex = column.options.findIndex(opt => opt.value === optValue);
         if (selectedIndex >= 0) {
           // set the select index for this column's options
@@ -770,6 +778,18 @@ export class DateTime extends BaseInput<DateTimeData> implements AfterContentIni
    */
   getValue(): DateTimeData {
     return this._value;
+  }
+
+  /**
+   * @hidden
+   */
+  getValueOrDefault(): DateTimeData {
+    if (this.hasValue()) {
+      return this._value;
+    }
+    const _default = {};
+    updateDate(_default, this.pickerDefault);
+    return _default;
   }
 
   /**

--- a/src/components/datetime/test/basic/pages/root-page/root-page.html
+++ b/src/components/datetime/test/basic/pages/root-page/root-page.html
@@ -77,6 +77,11 @@
     <ion-datetime monthValues="6,7,8" yearValues="2014,2015" dayValues="01,02,03,04,05,06,08,09,10, 11, 12, 13, 14" displayFormat="DD/MMM/YYYY" [(ngModel)]="specificDaysMonthsYears"></ion-datetime>
   </ion-item>
 
+  <ion-item>
+    <ion-label>Default value</ion-label>
+    <ion-datetime max="2100" pickerDefault="2017-08-06" [(ngModel)]="defaultValue"></ion-datetime>
+  </ion-item>
+
   <p aria-hidden="true" padding>
     <code>monthOnly: {{monthOnly}}</code><br>
     <code>wwwInvented: {{wwwInvented}}</code><br>
@@ -88,6 +93,7 @@
     <code>time: {{time}}</code><br>
     <code>Leap year, summer months: {{leapYearsSummerMonths}}</code><br>
     <code>Specific days/months/years: {{specificDaysMonthsYears}}</code><br>
+    <code>Default value: {{defaultValue}}</code><br>
   </p>
 
   <p>

--- a/src/components/datetime/test/basic/pages/root-page/root-page.ts
+++ b/src/components/datetime/test/basic/pages/root-page/root-page.ts
@@ -17,6 +17,7 @@ export class RootPage {
   leapYearsSummerMonths = '';
   convertedDate = '';
   specificDaysMonthsYears = '';
+  defaultValue: any;
 
   leapYearsArray = [2020, 2016, 2008, 2004, 2000, 1996];
 

--- a/src/components/datetime/test/datetime.spec.ts
+++ b/src/components/datetime/test/datetime.spec.ts
@@ -252,8 +252,8 @@ describe('DateTime', () => {
       datetime.generate();
       var columns = picker.getColumns();
       
-            expect(columns.length).toEqual(2);
-            expect(columns[0].name).toEqual('month');
+      expect(columns.length).toEqual(2);
+      expect(columns[0].name).toEqual('month');
       expect(columns[0].options[0].value).toEqual(1);
       expect(columns[0].options[0].text).toEqual('jan');
     }));

--- a/src/components/datetime/test/datetime.spec.ts
+++ b/src/components/datetime/test/datetime.spec.ts
@@ -251,9 +251,9 @@ describe('DateTime', () => {
 
       datetime.generate();
       var columns = picker.getColumns();
-
-      expect(columns.length).toEqual(2);
-      expect(columns[0].name).toEqual('month');
+      
+            expect(columns.length).toEqual(2);
+            expect(columns[0].name).toEqual('month');
       expect(columns[0].options[0].value).toEqual(1);
       expect(columns[0].options[0].text).toEqual('jan');
     }));
@@ -297,6 +297,20 @@ describe('DateTime', () => {
       expect(columns[0].name).toEqual('day');
       expect(columns[0].options[0].value).toEqual(1);
       expect(columns[0].options[0].text).toEqual('1');
+    }));
+
+    it('should use pickerDefault if has no value', zoned(() => {
+      datetime.setValue(null);
+      datetime.max = '2100-12-31';
+      datetime.pickerFormat = 'DD MMMM YYYY';
+      datetime.pickerDefault = '2004-08-06';
+
+      datetime.generate();
+      var columns = picker.getColumns();
+
+      expect(columns[0].options[columns[0].selectedIndex].value).toEqual(6);
+      expect(columns[1].options[columns[1].selectedIndex].value).toEqual(8);
+      expect(columns[2].options[columns[2].selectedIndex].value).toEqual(2004);
     }));
 
     it('should generate MM DD YYYY pickerFormat with min/max', () => {

--- a/src/components/datetime/test/datetime.spec.ts
+++ b/src/components/datetime/test/datetime.spec.ts
@@ -251,7 +251,7 @@ describe('DateTime', () => {
 
       datetime.generate();
       var columns = picker.getColumns();
-      
+
       expect(columns.length).toEqual(2);
       expect(columns[0].name).toEqual('month');
       expect(columns[0].options[0].value).toEqual(1);


### PR DESCRIPTION
#### Short description of what this resolves:
When datetime input has max value greater than current date its by default selected when datetime picker is opened.

#### Changes proposed in this pull request:
Added **pickerDefault** input which is selected if datetime has no value.

**Ionic Version**: 1.x / 2.x / 3.x
3.x
