### PR TITLE
docs(content): fix typo "need" in docs

### DIFF
--- a/src/components/content/content.ts
+++ b/src/components/content/content.ts
@@ -31,7 +31,7 @@ export class EventEmitterProxy<T> extends EventEmitter<T> {
  * The Content component provides an easy to use content area with
  * some useful methods to control the scrollable area. There should
  * only be one content in a single view component. If additional scrollable
- * elements are need, use [ionScroll](../../scroll/Scroll).
+ * elements are needed, use [ionScroll](../../scroll/Scroll).
  *
  *
  * The content area can also implement pull-to-refresh with the


### PR DESCRIPTION
#### Short description of what this resolves:
A simple, easily missed typo in `ion-content` docs: simply adds correct tense to "need" in description, first paragraph.

#### Changes proposed in this pull request:
- replace "need" with "needed"


**Ionic Version**: 2.x / 3.x
