### PR TITLE
to allow non-breaking updates for npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,17 +26,17 @@
     "tsc": "tsc --outdir .tmp"
   },
   "dependencies": {
-    "@angular/common": "4.1.3",
-    "@angular/compiler": "4.1.3",
-    "@angular/compiler-cli": "4.1.3",
-    "@angular/core": "4.1.3",
-    "@angular/forms": "4.1.3",
-    "@angular/http": "4.1.3",
-    "@angular/platform-browser": "4.1.3",
-    "@angular/platform-browser-dynamic": "4.1.3",
+    "@angular/common": "^4.1.3",
+    "@angular/compiler": "^4.1.3",
+    "@angular/compiler-cli": "^4.1.3",
+    "@angular/core": "^4.1.3",
+    "@angular/forms": "^4.1.3",
+    "@angular/http": "^4.1.3",
+    "@angular/platform-browser": "^4.1.3",
+    "@angular/platform-browser-dynamic": "^4.1.3",
     "ionicons": "~3.0.0",
-    "rxjs": "5.4.0",
-    "zone.js": "0.8.12"
+    "rxjs": "^5.4.0",
+    "zone.js": "^0.8.12"
   },
   "devDependencies": {
     "@ionic/app-scripts": "^1.3.11",


### PR DESCRIPTION
#### Short description of what this resolves:
To allow non-breaking updates for npm dependencies

#### Changes proposed in this pull request:

- changed npm dependencies from on angular packages from "4.1.3" to "^4.1.3"
- changed npm dependencies of rxjs and ngzeon from exact version to ^prefix-version

**Ionic Version**: 1.x / 2.x / [3.x]

**Fixes**: #
- package.json