### PR TITLE
fix(swiper): add safe-guards when user tries to zoom a slide without …

### DIFF
--- a/src/components/slides/swiper/swiper-zoom.ts
+++ b/src/components/slides/swiper/swiper-zoom.ts
@@ -90,14 +90,16 @@ function onGestureStart(s: Slides, _plt: Platform, ev: TouchEvent) {
     }
 
     z.gesture.image = <HTMLElement>z.gesture.slide.querySelector('img, svg, canvas, ion-img');
-    z.gesture.imageWrap = <HTMLElement>z.gesture.image.closest('.' + CLS.zoomContainer);
+    if (z.gesture.image) {
+      z.gesture.imageWrap = <HTMLElement>z.gesture.image.closest('.' + CLS.zoomContainer);
 
-    if (!z.gesture.imageWrap) {
-      z.gesture.image = undefined;
-      return;
+      if (!z.gesture.imageWrap) {
+        z.gesture.image = undefined;
+        return;
+      }
+
+      z.gesture.zoomMax = parseInt(z.gesture.imageWrap.getAttribute('data-swiper-zoom') || <any>s.zoomMax, 10);
     }
-
-    z.gesture.zoomMax = parseInt(z.gesture.imageWrap.getAttribute('data-swiper-zoom') || <any>s.zoomMax, 10);
   }
 
   transition(z.gesture.image, 0);
@@ -349,10 +351,10 @@ function toggleZoom(s: Slides, plt: Platform) {
   if (!z.gesture.slide) {
     z.gesture.slide = s.clickedSlide ? s.clickedSlide : s._slides[s._activeIndex];
     z.gesture.image = <HTMLElement>z.gesture.slide.querySelector('img, svg, canvas, ion-img');
-    z.gesture.imageWrap = <HTMLElement>z.gesture.image.closest('.' + CLS.zoomContainer);
+    z.gesture.imageWrap = z.gesture.image && <HTMLElement>z.gesture.image.closest('.' + CLS.zoomContainer);
   }
 
-  if (!z.gesture.image) return;
+  if (!z.gesture.imageWrap) return;
 
   var touchX: number;
   var touchY: number;


### PR DESCRIPTION
Fixes #12861

#### Short description of what this resolves:

OP found this issue by forgetting to put image in slides with zoom="true", but in resolving this, I discovered that you would have the same issue if you had some slides with zoomable image and some slides without and the user accidentally did a zoom gesture on the slides without.

#### Changes proposed in this pull request:

- Adds safeguards around the querying of the image and the container to make sure we actually have them before trying to do things with them

**Ionic Version**: 3.x (not sure if we would need to fix (or how) in 4.x as we are changing this a lot)

**Fixes**: #12861
