### PR TITLE
docs(slides): clarify how zooming works

### DIFF
--- a/src/components/slides/slides.ts
+++ b/src/components/slides/slides.ts
@@ -106,6 +106,34 @@ import { ViewController } from '../../navigation/view-controller';
  * }
  * ```
  *
+ * ### Zooming
+ * If your slides contain images, you can enable zooming on them by setting `zoom="true" and
+ * wrapping each image in a `div` with the class `swiper-zoom-container`. Zoom supports
+ * `img`, `svg`, `canvas`, and `ion-img`.
+ *
+ * ```html
+ * <ion-slidesj zoom="true">
+ *   <ion-slide>
+ *     <div class="swiper-zoom-container">
+ *       <img src="assets/img/dog.jpg">
+ *     </div>
+ *     <ion-label>Woof</ion-label>
+ *   </ion-slide>
+ *   <ion-slide>
+ *     <div class="swiper-zoom-container">
+ *       <img src="assets/img/cat.jpg">
+ *     </div>
+ *     <ion-label>Meow</ion-label>
+ *   </ion-slide>
+ *   <ion-slide>
+ *     <div class="swiper-zoom-container">
+ *       <img src="assets/img/fish.jpg">
+ *     </div>
+ *     <ion-label>Just keep swimming</ion-label>
+ *   </ion-slide>
+ * </ion-slides>
+ * ```
+ *
  * @advanced
  *
  * There are several options available to create customized slides. Ionic exposes


### PR DESCRIPTION
#### Short description of what this resolves:

Clarify how zoom works so users do not have to dig through the swiper docs in order to figure it out.

#### Changes proposed in this pull request:

- Clarify how zoom works

**Ionic Version**: 3.x

**Fixes**: # 12861