### PR TITLE
Emit to ionPull on 'cancelling' state.

### DIFF
--- a/src/components/refresher/refresher.ts
+++ b/src/components/refresher/refresher.ts
@@ -432,6 +432,7 @@ export class Refresher {
    */
   cancel() {
     this._close(STATE_CANCELLING, '');
+    this.ionPull.emit(this);
   }
 
   _close(state: string, delay: string) {


### PR DESCRIPTION
#### Short description of what this resolves:

Allow developer have access to 'cancelling' event/state by output events with 'ionPull'.

#### Changes proposed in this pull request:

- Emit 'this' object by 'ionPull' on 'cancel' action.

**Ionic Version**: 3.x
