### PR TITLE
chore(dependencies): bump Angular

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
     "tsc": "tsc --outdir .tmp"
   },
   "dependencies": {
-    "@angular/common": "4.4.3",
-    "@angular/compiler": "4.4.3",
-    "@angular/compiler-cli": "4.4.3",
-    "@angular/core": "4.4.3",
-    "@angular/forms": "4.4.3",
-    "@angular/http": "4.4.3",
-    "@angular/platform-browser": "4.4.3",
-    "@angular/platform-browser-dynamic": "4.4.3",
+    "@angular/common": "4.4.4",
+    "@angular/compiler": "4.4.4",
+    "@angular/compiler-cli": "4.4.4",
+    "@angular/core": "4.4.4",
+    "@angular/forms": "4.4.4",
+    "@angular/http": "4.4.4",
+    "@angular/platform-browser": "4.4.4",
+    "@angular/platform-browser-dynamic": "4.4.4",
     "ionicons": "~3.0.0",
     "rxjs": "5.4.3",
     "zone.js": "0.8.18"
@@ -134,7 +134,7 @@
     "ts-node": "3.3.0",
     "tslint": "^5.4.3",
     "tslint-ionic-rules": "0.0.11",
-    "typescript": "~2.3.2",
+    "typescript": "~2.3.4",
     "vinyl": "1.2.0",
     "yargs": "5.0.0"
   },


### PR DESCRIPTION
#### Short description of what this resolves:
Updates the dependencies to the latest Angular release

#### Changes proposed in this pull request:

- Angular 4.4.4
- TypeScript 2.3.4
-

**Ionic Version**: 1.x / 2.x / 3.x
3.x
