### PR TITLE
feat(input): add dir attribute for different language directions

### DIFF
--- a/src/components/alert/alert-component.ts
+++ b/src/components/alert/alert-component.ts
@@ -52,7 +52,7 @@ import { AlertButton, AlertInputOptions, AlertOptions } from './alert-options';
         '<ng-template ngSwitchDefault>' +
           '<div class="alert-input-group">' +
             '<div *ngFor="let i of d.inputs" class="alert-input-wrapper">' +
-              '<input [placeholder]="i.placeholder" [(ngModel)]="i.value" [type]="i.type" [min]="i.min" [max]="i.max" [attr.id]="i.id" class="alert-input">' +
+              '<input [placeholder]="i.placeholder" [(ngModel)]="i.value" [type]="i.type" dir="auto" [min]="i.min" [max]="i.max" [attr.id]="i.id" class="alert-input">' +
             '</div>' +
           '</div>' +
         '</ng-template>' +

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -101,6 +101,7 @@ import { Platform } from '../../platform/platform';
     '(focus)="onFocus($event)" ' +
     '(keydown)="onKeydown($event)" ' +
     '[type]="_type" ' +
+    'dir="auto" ' +
     '[attr.aria-labelledby]="_labelId" ' +
     '[attr.min]="min" ' +
     '[attr.max]="max" ' +

--- a/src/components/searchbar/searchbar.ts
+++ b/src/components/searchbar/searchbar.ts
@@ -35,6 +35,7 @@ import { Platform } from '../../platform/platform';
       '</button>' +
       '<div #searchbarIcon class="searchbar-search-icon"></div>' +
       '<input #searchbarInput class="searchbar-input" (input)="inputChanged($event)" (blur)="inputBlurred()" (focus)="inputFocused()" ' +
+        'dir="auto" ' +
         '[attr.placeholder]="placeholder" ' +
         '[attr.type]="type" ' +
         '[attr.autocomplete]="_autocomplete" ' +


### PR DESCRIPTION
#### Short description of what this resolves:
When having any input, no matter the direction of the app, writing ltr should be on the left, writing rtl should be on the right.

This is the behavior of most inputs across the web 

#### Changes proposed in this pull request:
- add `dir="auto"` to all of the inputs across the system

**Ionic Version**: 3.x
