### PR TITLE
fix(tabs): emit viewDidEnter and viewDidLeave on app during tab change. ≈

### DIFF
--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -452,8 +452,15 @@ export class Tabs extends Ion implements AfterViewInit, RootNode, ITabs, Navigat
     }
 
     // Fire didEnter/didLeave lifecycle events
-    selectedPage && selectedPage._didEnter();
-    currentPage && currentPage._didLeave();
+    if (selectedPage) {
+      selectedPage._didEnter();
+      this._app.viewDidEnter.emit(selectedPage);
+    }
+
+    if (currentPage) {
+      currentPage && currentPage._didLeave();
+      this._app.viewDidLeave.emit(currentPage);
+    }
 
     // track the order of which tabs have been selected, by their index
     // do not track if the tab index is the same as the previous


### PR DESCRIPTION
#### Short description of what this resolves:

During tab changes when there's no transition, `app` doesn't receive `viewDidEnter` or `viewDidLeave` which are only fired during a transition. This adds those calls to tabs after a selection has completed.

**Fixes**: #11694
