### PR TITLE
fix(VirtualScroll): stop from resizing while out of view

### DIFF
--- a/src/components/virtual-scroll/virtual-scroll.ts
+++ b/src/components/virtual-scroll/virtual-scroll.ts
@@ -610,6 +610,11 @@ export class VirtualScroll implements DoCheck, OnChanges, AfterContentInit, OnDe
       return;
     }
 
+    // check if component is rendered in the dom currently
+    if (this._elementRef.nativeElement.offsetParent === null) {
+      return;
+    }
+
     console.debug('virtual-scroll', 'resized window');
     this.calcDimensions();
     this.writeUpdate(false);


### PR DESCRIPTION
#### Short description of what this resolves:
When changing tab or navigate to a different page than the one containing a virtual scroll component, virtual scroll is still running and specifically the part that listens for window resize events. When you resize the window in the other screen for some reason (open keyboard, change orientation, resize browser), that event is triggered in virtual scroll and tries to re-calculate the virtual scroll component. Unfortunately all the numbers that it takes into account then are wrong, as it is not visible.

#### Changes proposed in this pull request:
Stop calculating virtual scroll dimensions while it is out of view. This is the first step into a more complete approach, as when virtual scroll gets back into view, resize should be triggered then in case the viewport is still altered by the previous resize events.

**Ionic Version**: 3.x

**Fixes**: #13132
