### PR TITLE
chore(package): bump angular and rxjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
     "tsc": "tsc --outdir .tmp"
   },
   "dependencies": {
-    "@angular/common": "4.4.4",
-    "@angular/compiler": "4.4.4",
-    "@angular/compiler-cli": "4.4.4",
-    "@angular/core": "4.4.4",
-    "@angular/forms": "4.4.4",
-    "@angular/http": "4.4.4",
-    "@angular/platform-browser": "4.4.4",
-    "@angular/platform-browser-dynamic": "4.4.4",
+    "@angular/common": "4.4.6",
+    "@angular/compiler": "4.4.6",
+    "@angular/compiler-cli": "4.4.6",
+    "@angular/core": "4.4.6",
+    "@angular/forms": "4.4.6",
+    "@angular/http": "4.4.6",
+    "@angular/platform-browser": "4.4.6",
+    "@angular/platform-browser-dynamic": "4.4.6",
     "ionicons": "~3.0.0",
     "rxjs": "5.5.0",
     "zone.js": "0.8.18"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@angular/platform-browser": "4.4.6",
     "@angular/platform-browser-dynamic": "4.4.6",
     "ionicons": "~3.0.0",
-    "rxjs": "5.5.0",
+    "rxjs": "5.5.2",
     "zone.js": "0.8.18"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@angular/platform-browser": "4.4.4",
     "@angular/platform-browser-dynamic": "4.4.4",
     "ionicons": "~3.0.0",
-    "rxjs": "5.4.3",
+    "rxjs": "5.5.0",
     "zone.js": "0.8.18"
   },
   "devDependencies": {


### PR DESCRIPTION
#### Short description of what this resolves:
Upgrades the rxjs dep to 5.5.0. No breaking changes!
Upgrades Angular to the latest release

fix #13266