### PR TITLE
fix(datetime): use spread operator to copy pickerOptions

### DIFF
--- a/src/components/datetime/datetime.ts
+++ b/src/components/datetime/datetime.ts
@@ -522,7 +522,7 @@ export class DateTime extends BaseInput<DateTimeData> implements AfterContentIni
 
     console.debug('datetime, open picker');
 
-    // the user may have assigned some options specifically for the alert
+    // the user may have assigned some options specifically for the picker
     const pickerOptions = {...this.pickerOptions};
 
     // Configure picker under the hood

--- a/src/components/datetime/datetime.ts
+++ b/src/components/datetime/datetime.ts
@@ -523,7 +523,7 @@ export class DateTime extends BaseInput<DateTimeData> implements AfterContentIni
     console.debug('datetime, open picker');
 
     // the user may have assigned some options specifically for the alert
-    const pickerOptions = deepCopy(this.pickerOptions);
+    const pickerOptions = {...this.pickerOptions};
 
     // Configure picker under the hood
     const picker = this._picker = this._pickerCtrl.create(pickerOptions);

--- a/src/components/datetime/test/basic/pages/root-page/root-page.html
+++ b/src/components/datetime/test/basic/pages/root-page/root-page.html
@@ -16,7 +16,7 @@
 
   <ion-item>
     <ion-label>MM DD YY</ion-label>
-    <ion-datetime pickerFormat="YYYY-MM-DDThh:mm" [(ngModel)]="placeholderDate" placeholder="Select Date"></ion-datetime>
+    <ion-datetime pickerFormat="YYYY-MM-DDThh:mm" [pickerOptions]="customOptions" [(ngModel)]="placeholderDate" placeholder="Select Date"></ion-datetime>
   </ion-item>
 
   <ion-item>

--- a/src/components/datetime/test/basic/pages/root-page/root-page.ts
+++ b/src/components/datetime/test/basic/pages/root-page/root-page.ts
@@ -31,6 +31,16 @@ export class RootPage {
     'l\u00f8r'
   ];
 
+  customOptions: any = {
+    buttons: [{
+      text: 'Save',
+      handler: () => console.log('Clicked Save!')
+    }, {
+      text: 'Log',
+      handler: () => console.log('Clicked Log!')
+    }]
+  };
+
   onChange(ev: any) {
     console.log('Changed', ev);
   }


### PR DESCRIPTION
#### Short description of what this resolves:
Passing `buttons` in `pickerOptions` to the DateTime component will drop the handler functions because of the `deepCopy`. 

#### Changes proposed in this pull request:

- Uses the spread operator instead of the deepCopy function.
- Adds pickerOptions to one of the examples in the e2e test

**Ionic Version**: 3.x

**Fixes**: #11641
