### PR TITLE
Warn about IonicPage Lifecycle

### DIFF
--- a/src/navigation/nav-controller.ts
+++ b/src/navigation/nav-controller.ts
@@ -266,6 +266,7 @@ import { NavigationContainer } from './navigation-container';
  *  | `ionViewCanEnter`   | boolean/Promise&lt;void&gt; | Runs before the view can enter. This can be used as a sort of "guard" in authenticated views where you need to check permissions before the view can enter                                                                                                     |
  *  | `ionViewCanLeave`   | boolean/Promise&lt;void&gt; | Runs before the view can leave. This can be used as a sort of "guard" in authenticated views where you need to check permissions before the view can leave                                                                                                     |
  *
+ * Those events are only fired on IonicPage, for classic Angular Component, use [Angular Lifecycle Hooks](https://angular.io/guide/lifecycle-hooks).
  *
  * ## Nav Guards
  *


### PR DESCRIPTION
Warn IonicPage Lifecycle events are only available on IonicPage component, others components need Angular Lifecycle Hooks.

#### Short description of what this resolves:
In the NavController documentation, only Ionic Page Lifecycle events are present. At first, we have the impression that these events replace the Angular Lifecycle hooks, but that's not the case!

#### Changes proposed in this pull request:
Add warn

**Ionic Version**: 3
