### PR TITLE
fix(tap-click): activated state is kept on activable element

### DIFF
--- a/src/tap-click/tap-click.ts
+++ b/src/tap-click/tap-click.ts
@@ -23,6 +23,7 @@ export class TapClick {
   private usePolyfill: boolean;
   private activator: ActivatorBase;
   private startCoord: any;
+  private activatableEle: HTMLElement;
   private events: UIEventManager;
   private pointerEvents: PointerEvents;
   private lastTouchEnd: number;
@@ -77,14 +78,14 @@ export class TapClick {
       return true;
     }
 
-    let activatableEle = getActivatableTarget(ev.target);
-    if (!activatableEle) {
+    this.activatableEle = getActivatableTarget(ev.target);
+    if (!this.activatableEle) {
       this.startCoord = null;
       return false;
     }
 
     this.startCoord = pointerCoord(ev);
-    this.activator && this.activator.downAction(ev, activatableEle, this.startCoord);
+    this.activator && this.activator.downAction(ev, this.activatableEle, this.startCoord);
     return true;
   }
 
@@ -103,7 +104,7 @@ export class TapClick {
       return;
     }
     if (this.activator && ev.target !== this.plt.doc()) {
-      let activatableEle = getActivatableTarget(ev.target);
+      let activatableEle = getActivatableTarget(ev.target) || this.activatableEle;
       if (activatableEle) {
         this.activator.upAction(ev, activatableEle, this.startCoord);
       }
@@ -112,6 +113,7 @@ export class TapClick {
       this.handleTapPolyfill(ev);
     }
     this.startCoord = null;
+    this.activatableEle = null;
   }
 
   pointerCancel(ev: UIEvent) {

--- a/src/tap-click/tap-click.ts
+++ b/src/tap-click/tap-click.ts
@@ -120,6 +120,7 @@ export class TapClick {
     console.debug(`pointerCancel from ${ev.type} ${Date.now()}`);
 
     this.startCoord = null;
+    this.activatableEle = null;
     this.dispatchClick = false;
     this.activator && this.activator.clearState(false);
     this.pointerEvents.stop();


### PR DESCRIPTION
#### Short description of what this resolves:
The .activated class is kept on a activable element when the finger or mouse is released on an non-activable element (#13044)

#### Changes proposed in this pull request:
Keep previous activatableEle between pointerStart and pointerEnd method

**Ionic Version**: 3.x

**Fixes**: #13044 
