### PR TITLE
fix(alert): focus input after it is ready

### DIFF
--- a/src/components/alert/alert-component.ts
+++ b/src/components/alert/alert-component.ts
@@ -204,7 +204,7 @@ export class AlertCmp {
     // and ionViewDidEnter is not in the same callstack as the touch event :(
     const focusableEle = this._elementRef.nativeElement.querySelector('input,button');
     if (focusableEle) {
-      focusableEle.focus();
+      setTimeout(() => focusableEle.focus());
     }
     this.enabled = true;
   }


### PR DESCRIPTION
#### Short description of what this resolves:
When creating a new alert which has an input text field it doesn't get focused.

#### Changes proposed in this pull request:
Wrap the focus() method of the input element in a setTimeout so that the web component
has enough time to initialize. This effectively defers the work until the end of the execution queue.
-
-
-

**Ionic Version**: 3.8.0

**Fixes**: #12784
