### PR TITLE
Fixed Critical Documentation Issue

### DIFF
--- a/src/components/item/item-sliding.ts
+++ b/src/components/item/item-sliding.ts
@@ -125,9 +125,9 @@ const enum SlidingState {
  *
  * ```html
  *
- * <ion-item-sliding (ionSwipe)="delete(item)">
+ * <ion-item-sliding>
  *   <ion-item>Item</ion-item>
- *   <ion-item-options>
+ *   <ion-item-options (ionSwipe)="delete(item)">
  *     <button ion-button expandable (click)="delete(item)">Delete</button>
  *   </ion-item-options>
  * </ion-item-sliding>


### PR DESCRIPTION
#### Short description of what this resolves:
(ionSwipe) is shown in the doc as being on <ion-item-sliding> but in the code it is on <ion-item-options>. I spent over 2 hours trying to figure out why the event wasn't firing

#### Changes proposed in this pull request:

-Moved (ionSwipe) to correct element in documentation.
-
-

**Ionic Version**: 3.x

**Fixes**: #1213
