### PR TITLE
fix(select): make select clickable on parent element

### DIFF
--- a/packages/core/src/components/select/select.tsx
+++ b/packages/core/src/components/select/select.tsx
@@ -108,7 +108,7 @@ export class Select {
   protected ionViewDidLoad() {
     // Get the parent item
     this.item = this.el.closest('ion-item');
-
+    this.item.onclick = this.open.bind(this);
     this.setOptions();
   }
 
@@ -394,7 +394,6 @@ export class Select {
         id={this.selectId}
         aria-labelledby={this.labelId}
         aria-disabled={this.disabled ? 'true' : false}
-        onClick={this.open.bind(this)}
         class='item-cover'>
       </button>
     ];


### PR DESCRIPTION
#### Short description of what this resolves:
Registers the click handler on select's parent element.

#### Changes proposed in this pull request:
Instead of adding a click handler to the select DOM element use it on its parent in the ionViewDidLoad phase.
-
-
-

**Ionic Version**:  4

**Fixes**: #13244
