### PR TITLE
docs(changelog): fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ To use lettable operators, modify the code from above to look like this:
 ```typescript
 //Use Deep imports here for smallest bunlde size
 import { debounceTime } from 'rxjs/operators/debounceTime';
-import { switch } from 'rxjs/operators/switchMap';
+import { switchMap } from 'rxjs/operators/switchMap';
 
 export MyClass {
 


### PR DESCRIPTION
Code says 'switch' instead of 'switchMap'

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x / 3.x

**Fixes**: #
