### PR TITLE
Added an example of attaching an event handler function.

### DIFF
--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -44,8 +44,8 @@ import { Platform } from '../../platform/platform';
  * `checkbox`, `radio`, `toggle`, `range`, `select`, etc.
  *
  * Along with the blur/focus events, `input` support all standard text input
- * events like `keyup`, `keydown`, `keypress`, `input`,etc. Any standard event
- * can be attached and will function as expected.
+ * events like `keyup`, `keydown`, `keypress`, `input`, etc. Any standard event
+ * can be attached and will function as expected. Example: `<ion-input (click)="someFunction()"></ion-input>`
  *
  * @usage
  * ```html


### PR DESCRIPTION
#### Short description of what this resolves: adds an example of how to attach an event handler function to an ion-input element.

There was no example before, and so it wasn't clear that you need to use ( ) around the event name in order for this to work.

**Ionic Version**: 2.x
