### PR TITLE
fix(alert): allow disabled for any type of input

### DIFF
--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -308,6 +308,7 @@ export class Alert {
               min={i.min}
               max={i.max}
               id={i.id}
+              disabled={i.disabled}
               tabIndex={0}
               class='alert-input'/>
           </div>


### PR DESCRIPTION
#### Short description of what this resolves:

Allows for other input types besides just checkbox and radio button to be disabled.
Core version of change made here:
https://github.com/ionic-team/ionic/pull/13521

**Ionic Version**: 4.x

**Fixes**: #13488 
