### PR TITLE
[Slide]Don't touchstart when moving.

### DIFF
--- a/src/components/slides/swiper/swiper-events.ts
+++ b/src/components/slides/swiper/swiper-events.ts
@@ -300,6 +300,10 @@ var startMoving: boolean;
 function onTouchStart(s: Slides, plt: Platform, ev: SlideUIEvent) {
   console.debug(`ion-slide, onTouchStart: ${ev.type}`);
 
+  if (isMoved) {
+    return false;
+  }
+
   if (ev.originalEvent) {
     ev = ev.originalEvent;
   }


### PR DESCRIPTION
#### Short description of what this resolves:

If you multi-touch Slide Component, the slide stops halfway

#### Changes proposed in this pull request:

Don't touchstart when moving.
