### PR TITLE
chore(e2e) rename tests to match v3 master

### DIFF
--- a/packages/core/scripts/e2e/index.js
+++ b/packages/core/scripts/e2e/index.js
@@ -148,7 +148,7 @@ if (require.main === module) {
 
 module.exports = {
   Page,
-  navigate: url => driver => new Page(driver, url).navigate(),
+  navigate: (url, tagName) => driver => new Page(driver, url).navigate(tagName),
   register: registerE2ETest,
   run: run
 };

--- a/packages/core/scripts/e2e/page.js
+++ b/packages/core/scripts/e2e/page.js
@@ -8,10 +8,10 @@ module.exports = class E2ETestPage {
     this.driver = driver;
   }
 
-  navigate() {
+  navigate(tagName = '') {
     this.driver.navigate().to(this.url);
     this.driver.wait(until.elementLocated(By.css('.hydrated')));
-    return this.driver.wait(until.elementIsVisible(this.driver.findElement(By.css('.hydrated'))));
+    return this.driver.wait(until.elementIsVisible(this.driver.findElement(By.css(`${tagName}.hydrated`))));
   }
 
   present(clickTarget, options) {

--- a/packages/core/src/components/action-sheet/test/basic/e2e.js
+++ b/packages/core/src/components/action-sheet/test/basic/e2e.js
@@ -16,8 +16,8 @@ class ActionSheetE2ETestPage extends Page {
   }
 }
 
-describe('action-sheet: basic', () => {
-  register('navigates', driver => {
+describe('action-sheet/basic', () => {
+  register('should init', driver => {
     const page = new ActionSheetE2ETestPage(driver);
     return page.navigate();
   });

--- a/packages/core/src/components/badge/test/basic/e2e.js
+++ b/packages/core/src/components/badge/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('badge: basic', () => {
+describe('badge/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/badge/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/badge/test/basic'));
 
 });

--- a/packages/core/src/components/button/test/anchor/e2e.js
+++ b/packages/core/src/components/button/test/anchor/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('button: anchor', () => {
+describe('button/anchor', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/button/test/anchor'));
+  register('should init', navigate('http://localhost:3333/src/components/button/test/anchor'));
 
 });

--- a/packages/core/src/components/button/test/basic/e2e.js
+++ b/packages/core/src/components/button/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('button: basic', () => {
+describe('button/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/button/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/button/test/basic'));
 
 });

--- a/packages/core/src/components/button/test/expand/e2e.js
+++ b/packages/core/src/components/button/test/expand/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('button: expand', () => {
+describe('button/expand', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/button/test/expand'));
+  register('should init', navigate('http://localhost:3333/src/components/button/test/expand'));
 
 });

--- a/packages/core/src/components/button/test/fill/e2e.js
+++ b/packages/core/src/components/button/test/fill/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('button: fill', () => {
+describe('button/fill', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/button/test/fill'));
+  register('should init', navigate('http://localhost:3333/src/components/button/test/fill'));
 
 });

--- a/packages/core/src/components/button/test/icon/e2e.js
+++ b/packages/core/src/components/button/test/icon/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('button: icon', () => {
+describe('button/icon', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/button/test/icon'));
+  register('should init', navigate('http://localhost:3333/src/components/button/test/icon'));
 
 });

--- a/packages/core/src/components/button/test/round/e2e.js
+++ b/packages/core/src/components/button/test/round/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('button: round', () => {
+describe('button/round', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/button/test/round'));
+  register('should init', navigate('http://localhost:3333/src/components/button/test/round'));
 
 });

--- a/packages/core/src/components/button/test/size/e2e.js
+++ b/packages/core/src/components/button/test/size/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('button: size', () => {
+describe('button/size', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/button/test/size'));
+  register('should init', navigate('http://localhost:3333/src/components/button/test/size'));
 
 });

--- a/packages/core/src/components/button/test/strong/e2e.js
+++ b/packages/core/src/components/button/test/strong/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('button: strong', () => {
+describe('button/strong', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/button/test/strong'));
+  register('should init', navigate('http://localhost:3333/src/components/button/test/strong'));
 
 });

--- a/packages/core/src/components/button/test/toolbar/e2e.js
+++ b/packages/core/src/components/button/test/toolbar/e2e.js
@@ -1,5 +1,5 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('button: toolbar', () => {
-  register('navigates', navigate('http://localhost:3333/src/components/button/test/toolbar'));
+describe('button/toolbar', () => {
+  register('should init', navigate('http://localhost:3333/src/components/button/test/toolbar'));
 });

--- a/packages/core/src/components/card/test/basic/e2e.js
+++ b/packages/core/src/components/card/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('card: basic', () => {
+describe('card/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/card/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/card/test/basic'));
 
 });

--- a/packages/core/src/components/checkbox/test/basic/e2e.js
+++ b/packages/core/src/components/checkbox/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('checkbox: basic', () => {
+describe('checkbox/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/checkbox/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/checkbox/test/basic'));
 
 });

--- a/packages/core/src/components/chip/test/basic/e2e.js
+++ b/packages/core/src/components/chip/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('chip: basic', () => {
+describe('chip/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/chip/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/chip/test/basic'));
 
 });

--- a/packages/core/src/components/content/test/basic/e2e.js
+++ b/packages/core/src/components/content/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('content: basic', () => {
+describe('content/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/content/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/content/test/basic'));
 
 });

--- a/packages/core/src/components/datetime/test/basic/e2e.js
+++ b/packages/core/src/components/datetime/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('datetime: basic', () => {
+describe('datetime/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/datetime/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/datetime/test/basic'));
 
 });

--- a/packages/core/src/components/fab/test/basic/e2e.js
+++ b/packages/core/src/components/fab/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('fab: basic', () => {
+describe('fab/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/fab/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/fab/test/basic'));
 
 });

--- a/packages/core/src/components/grid/test/basic/e2e.js
+++ b/packages/core/src/components/grid/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('grid: basic', () => {
+describe('grid/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/grid/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/grid/test/basic'));
 
 });

--- a/packages/core/src/components/icon/test/basic/e2e.js
+++ b/packages/core/src/components/icon/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('icon: basic', () => {
+describe('icon/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/icon/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/icon/test/basic'));
 
 });

--- a/packages/core/src/components/icon/test/items/e2e.js
+++ b/packages/core/src/components/icon/test/items/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('icon: items', () => {
+describe('icon/items', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/icon/test/items'));
+  register('should init', navigate('http://localhost:3333/src/components/icon/test/items'));
 
 });

--- a/packages/core/src/components/infinite-scroll/test/basic/e2e.js
+++ b/packages/core/src/components/infinite-scroll/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('inifinite-scroll: basic', () => {
+describe('inifinite-scroll/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/infinite-scroll/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/infinite-scroll/test/basic'));
 
 });

--- a/packages/core/src/components/input/test/basic/e2e.js
+++ b/packages/core/src/components/input/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('input: basic', () => {
+describe('input/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/input/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/input/test/basic'));
 
 });

--- a/packages/core/src/components/item-sliding/test/basic/e2e.js
+++ b/packages/core/src/components/item-sliding/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('item-sliding: basic', () => {
+describe('item-sliding/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/item-sliding/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/item-sliding/test/basic'));
 
 });

--- a/packages/core/src/components/item/test/basic/e2e.js
+++ b/packages/core/src/components/item/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('item: basic', () => {
+describe('item/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/item/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/item/test/basic'));
 
 });

--- a/packages/core/src/components/item/test/buttons/e2e.js
+++ b/packages/core/src/components/item/test/buttons/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('item: buttons', () => {
+describe('item/buttons', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/item/test/buttons'));
+  register('should init', navigate('http://localhost:3333/src/components/item/test/buttons'));
 
 });

--- a/packages/core/src/components/list/test/basic/e2e.js
+++ b/packages/core/src/components/list/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('list: basic', () => {
+describe('list/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/list/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/list/test/basic'));
 
 });

--- a/packages/core/src/components/loading/test/basic/e2e.js
+++ b/packages/core/src/components/loading/test/basic/e2e.js
@@ -1,9 +1,9 @@
 const { register, navigate, Page } = require('../../../../../scripts/e2e');
 const testPageURL = 'http://localhost:3333/src/components/loading/test/basic';
 
-describe('loading: basic', () => {
+describe('loading/basic', () => {
 
-  register('navigates', navigate(testPageURL));
+  register('should init', navigate(testPageURL));
 
   describe('present', () => {
 

--- a/packages/core/src/components/menu/test/basic/e2e.js
+++ b/packages/core/src/components/menu/test/basic/e2e.js
@@ -1,9 +1,9 @@
 const { register, navigate, Page } = require('../../../../../scripts/e2e');
 const testPageURL = 'http://localhost:3333/src/components/menu/test/basic';
 
-describe('menu: basic', () => {
+describe('menu/basic', () => {
 
-  register('navigates', navigate(testPageURL));
+  register('should init', navigate(testPageURL));
 
   describe('present', () => {
 

--- a/packages/core/src/components/modal/test/basic/e2e.js
+++ b/packages/core/src/components/modal/test/basic/e2e.js
@@ -1,9 +1,9 @@
 const { register, navigate, Page } = require('../../../../../scripts/e2e');
 const testPageURL = 'http://localhost:3333/src/components/modal/test/basic';
 
-describe('modal: basic', () => {
+describe('modal/basic', () => {
 
-  register('navigates', navigate(testPageURL));
+  register('should init', navigate(testPageURL));
 
   describe('present', () => {
 

--- a/packages/core/src/components/nav/test/basic/e2e.js
+++ b/packages/core/src/components/nav/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('nav: basic', () => {
+describe('nav/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/nav/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/nav/test/basic'));
 
 });

--- a/packages/core/src/components/nav/test/basic/e2e.js
+++ b/packages/core/src/components/nav/test/basic/e2e.js
@@ -2,6 +2,6 @@ const { register, navigate } = require('../../../../../scripts/e2e');
 
 describe('nav/basic', () => {
 
-  register('should init', navigate('http://localhost:3333/src/components/nav/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/nav/test/basic', 'ion-nav'));
 
 });

--- a/packages/core/src/components/popover/test/basic/e2e.js
+++ b/packages/core/src/components/popover/test/basic/e2e.js
@@ -2,9 +2,9 @@ const { register, navigate, Page } = require('../../../../../scripts/e2e');
 const testPageURL = 'http://localhost:3333/src/components/popover/test/basic';
 
 
-describe('popover: basic', () => {
+describe('popover/basic', () => {
 
-  register('navigates', navigate(testPageURL));
+  register('should init', navigate(testPageURL));
 
   describe('present', () => {
 

--- a/packages/core/src/components/radio/test/basic/e2e.js
+++ b/packages/core/src/components/radio/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('radio: basic', () => {
+describe('radio/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/radio/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/radio/test/basic'));
 
 });

--- a/packages/core/src/components/range/test/basic/e2e.js
+++ b/packages/core/src/components/range/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('range: basic', () => {
+describe('range/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/range/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/range/test/basic'));
 
 });

--- a/packages/core/src/components/reorder/test/basic/e2e.js
+++ b/packages/core/src/components/reorder/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('reorder: basic', () => {
+describe('reorder/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/reorder/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/reorder/test/basic'));
 
 });

--- a/packages/core/src/components/searchbar/test/basic/e2e.js
+++ b/packages/core/src/components/searchbar/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('searchbar: basic', () => {
+describe('searchbar/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/searchbar/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/searchbar/test/basic'));
 
 });

--- a/packages/core/src/components/segment/test/basic/e2e.js
+++ b/packages/core/src/components/segment/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('segment: basic', () => {
+describe('segment/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/segment/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/segment/test/basic'));
 
 });

--- a/packages/core/src/components/select/test/basic/e2e.js
+++ b/packages/core/src/components/select/test/basic/e2e.js
@@ -1,9 +1,9 @@
 const { register, navigate, Page } = require('../../../../../scripts/e2e');
 const testPageURL = 'http://localhost:3333/src/components/select/test/basic';
 
-describe('select: basic', () => {
+describe('select/basic', () => {
 
-  register('navigates', navigate(testPageURL));
+  register('should init', navigate(testPageURL));
 
   describe('present', () => {
 

--- a/packages/core/src/components/slides/test/basic/e2e.js
+++ b/packages/core/src/components/slides/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('slides: basic', () => {
+describe('slides/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/slides/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/slides/test/basic'));
 
 });

--- a/packages/core/src/components/spinner/test/basic/e2e.js
+++ b/packages/core/src/components/spinner/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('spinner: basic', () => {
+describe('spinner/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/spinner/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/spinner/test/basic'));
 
 });

--- a/packages/core/src/components/spinner/test/color/e2e.js
+++ b/packages/core/src/components/spinner/test/color/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('spinner: color', () => {
+describe('spinner/color', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/spinner/test/color'));
+  register('should init', navigate('http://localhost:3333/src/components/spinner/test/color'));
 
 });

--- a/packages/core/src/components/split-pane/test/basic/e2e.js
+++ b/packages/core/src/components/split-pane/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('split-pane: basic', () => {
+describe('split-pane/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/split-pane/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/split-pane/test/basic'));
 
 });

--- a/packages/core/src/components/tabs/test/basic/e2e.js
+++ b/packages/core/src/components/tabs/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('tabs: basic', () => {
+describe('tabs/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/tabs/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/tabs/test/basic'));
 
 });

--- a/packages/core/src/components/textarea/test/basic/e2e.js
+++ b/packages/core/src/components/textarea/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('textarea: basic', () => {
+describe('textarea/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/textarea/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/textarea/test/basic'));
 
 });

--- a/packages/core/src/components/toast/test/basic/e2e.js
+++ b/packages/core/src/components/toast/test/basic/e2e.js
@@ -1,9 +1,9 @@
 const { register, navigate, Page } = require('../../../../../scripts/e2e');
 const testPageURL = 'http://localhost:3333/src/components/toast/test/basic';
 
-describe('toast: basic', () => {
+describe('toast/basic', () => {
 
-  register('navigates', navigate(testPageURL));
+  register('should init', navigate(testPageURL));
 
   describe('present', () => {
 

--- a/packages/core/src/components/toggle/test/basic/e2e.js
+++ b/packages/core/src/components/toggle/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('toggle: basic', () => {
+describe('toggle/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/toggle/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/toggle/test/basic'));
 
 });

--- a/packages/core/src/components/toolbar/test/basic/e2e.js
+++ b/packages/core/src/components/toolbar/test/basic/e2e.js
@@ -1,7 +1,7 @@
 const { register, navigate } = require('../../../../../scripts/e2e');
 
-describe('toolbar: basic', () => {
+describe('toolbar/basic', () => {
 
-  register('navigates', navigate('http://localhost:3333/src/components/toolbar/test/basic'));
+  register('should init', navigate('http://localhost:3333/src/components/toolbar/test/basic'));
 
 });


### PR DESCRIPTION
#### Short description of what this resolves:
This renames all of the e2e tests to match their counterparts in v3 master so we can compare the snapshots.

**Ionic Version**: 4.x
