### PR TITLE
fix(cordova): don't apply safe area to footer if there are bottom tabs

### DIFF
--- a/src/platform/cordova.scss
+++ b/src/platform/cordova.scss
@@ -105,4 +105,9 @@ $cordova-statusbar-padding-modal-max-width:         767px !default;
     min-height: calc(#{$toolbar-height} + constant(safe-area-inset-bottom));
     min-height: calc(#{$toolbar-height} + env(safe-area-inset-bottom));
   }
+
+  .tabs:not(.tabs-ios[tabsPlacement='top']) ion-footer .toolbar:last-child {
+    @include padding(null, null, $toolbar-padding, null);
+    min-height: $toolbar-height;
+  }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes applying the `safe-area-inset-bottom` twice when there is both a footer and bottom tabs.

#### Changes proposed in this pull request:

- Overrides footer rule when there are bottom tabs, as they already have the `safe-area-inset-bottom` fix applied.

**Ionic Version**: 1.x / 2.x / 3.x
3.9.2

**Fixes**: #13615
