### PR TITLE
fixed links to menu API docs in MenuController docs

### DIFF
--- a/src/components/app/menu-controller.ts
+++ b/src/components/app/menu-controller.ts
@@ -112,7 +112,7 @@ import { assert, removeArrayItem  } from '../../util/util';
  * @demo /docs/demos/src/menu/
  *
  * @see {@link /docs/components#menus Menu Component Docs}
- * @see {@link ../menu Menu API Docs}
+ * @see {@link /docs/api/components/menu/Menu/ Menu API Docs}
  *
  */
 export class MenuController {

--- a/src/components/app/menu-controller.ts
+++ b/src/components/app/menu-controller.ts
@@ -6,7 +6,7 @@ import { assert, removeArrayItem  } from '../../util/util';
 /**
  * @name MenuController
  * @description
- * The MenuController is a provider which makes it easy to control a [Menu](../../Menu/Menu/).
+ * The MenuController is a provider which makes it easy to control a [Menu](../../menu/Menu/).
  * Its methods can be used to display the menu, enable the menu, toggle the menu, and more.
  * The controller will grab a reference to the menu by the `side`, `id`, or, if neither
  * of these are passed to it, it will grab the first menu it finds.
@@ -14,7 +14,7 @@ import { assert, removeArrayItem  } from '../../util/util';
  *
  * @usage
  *
- * Add a basic menu component to start with. See the [Menu](../../Menu/Menu/) API docs
+ * Add a basic menu component to start with. See the [Menu](../../menu/Menu/) API docs
  * for more information on adding menu components.
  *
  * ```html
@@ -112,7 +112,7 @@ import { assert, removeArrayItem  } from '../../util/util';
  * @demo /docs/demos/src/menu/
  *
  * @see {@link /docs/components#menus Menu Component Docs}
- * @see {@link ../Menu Menu API Docs}
+ * @see {@link ../menu Menu API Docs}
  *
  */
 export class MenuController {


### PR DESCRIPTION
#### Short description of what this resolves:

links to _menu API docs_ wasn't working on <https://ionicframework.com/docs/api/components/app/MenuController/>

#### Changes proposed in this pull request:

- just some fixed links/URLs :)

**Ionic Version**: 1.x / 2.x / 3.x

**Fixes**: #
