### PR TITLE
fix(sass): use sass variables for slide background values

### DIFF
--- a/src/components/slides/slides.scss
+++ b/src/components/slides/slides.scss
@@ -239,7 +239,7 @@ button.swiper-pagination-bullet {
 }
 
 .swiper-pagination-bullet-active {
-  background: #007aff;
+  background: color($colors, primary);
   opacity: 1;
 }
 
@@ -282,7 +282,7 @@ button.swiper-pagination-bullet {
   width: 100%;
   height: 100%;
 
-  background: #007aff;
+  background: color($colors, primary);
 
   transform: scale(0);
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Values for swiper pagination bullet and progress bar backgrounds were hard-coded to ionic blue. Should use app theme primary colors.

#### Changes proposed in this pull request:

- switch hard-coded sass color to variable

**Ionic Version**: 3.x

