### PR TITLE
Add missing `electron` platform to the platform's list

### DIFF
--- a/src/platform/platform.ts
+++ b/src/platform/platform.ts
@@ -167,6 +167,7 @@ export class Platform {
    * | phablet         | on a phablet device.               |
    * | tablet          | on a tablet device.                |
    * | windows         | on a device running Windows.       |
+   * | electron        | in Electron on a desktop device.   |
    *
    * @param {string} platformName
    */


### PR DESCRIPTION
#### Short description of what this resolves:

Electron platform is not documented.

#### Changes proposed in this pull request:

- Add missing `electron` platform to the platform's list

**Ionic Version**: 1.x / 2.x / 3.x

**Fixes**: #
