### PR TITLE
fix() remove default focus styles

### DIFF
--- a/packages/core/src/components/action-sheet/action-sheet.scss
+++ b/packages/core/src/components/action-sheet/action-sheet.scss
@@ -33,6 +33,11 @@ ion-action-sheet {
   width: $action-sheet-width;
 
   border: 0;
+
+  &:active,
+  &:focus {
+    outline: none;
+  }
 }
 
 .action-sheet-container {

--- a/packages/core/src/components/alert/alert.scss
+++ b/packages/core/src/components/alert/alert.scss
@@ -105,3 +105,14 @@ ion-alert input {
   line-height: initial;
   background: transparent;
 }
+
+
+.alert-button,
+.alert-checkbox,
+.alert-input,
+.alert-radio {
+  &:active,
+  &:focus {
+    outline: none;
+  }
+}

--- a/packages/core/src/components/chip-button/chip-button.scss
+++ b/packages/core/src/components/chip-button/chip-button.scss
@@ -9,4 +9,9 @@
 
   width: $chip-button-size;
   height: $chip-button-size;
+
+  &:active,
+  &:focus {
+    outline: none;
+  }
 }

--- a/packages/core/src/components/fab-button/fab-button.scss
+++ b/packages/core/src/components/fab-button/fab-button.scss
@@ -29,6 +29,11 @@
   user-select: none;
 
   contain: strict;
+
+  &:active,
+  &:focus {
+    outline: none;
+  }
 }
 
 .fab-button ion-icon {

--- a/packages/core/src/components/input/input.scss
+++ b/packages/core/src/components/input/input.scss
@@ -38,6 +38,11 @@ ion-input {
   border: 0;
 
   background: transparent;
+
+  &:active,
+  &:focus {
+    outline: none;
+  }
 }
 
 .native-input[disabled] {

--- a/packages/core/src/components/radio/radio.scss
+++ b/packages/core/src/components/radio/radio.scss
@@ -24,6 +24,11 @@ ion-radio input {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+
+  &:active,
+  &:focus {
+    outline: none;
+  }
 }
 
 ion-radio .radio-icon {

--- a/packages/core/src/components/range/range.scss
+++ b/packages/core/src/components/range/range.scss
@@ -52,3 +52,10 @@ ion-range .range-slider {
 .range-pin {
   box-sizing: border-box;
 }
+
+.range-knob-handle {
+  &:active,
+  &:focus {
+    outline: none;
+  }
+}

--- a/packages/core/src/components/searchbar/searchbar.scss
+++ b/packages/core/src/components/searchbar/searchbar.scss
@@ -36,6 +36,11 @@ ion-searchbar {
 
   border: 0;
   font-family: inherit;
+
+  &:active,
+  &:focus {
+    outline: none;
+  }
 }
 
 .searchbar-clear-icon {

--- a/packages/core/src/components/segment/segment.scss
+++ b/packages/core/src/components/segment/segment.scss
@@ -25,4 +25,9 @@ ion-segment {
   text-overflow: ellipsis;
   white-space: nowrap;
   cursor: pointer;
+
+  &:active,
+  &:focus {
+    outline: none;
+  }
 }

--- a/packages/core/src/components/textarea/textarea.scss
+++ b/packages/core/src/components/textarea/textarea.scss
@@ -43,6 +43,11 @@ ion-textarea {
   font-size: inherit;
 
   background: transparent;
+
+  &:active,
+  &:focus {
+    outline: none;
+  }
 }
 
 .native-textarea[disabled] {

--- a/packages/core/src/components/toolbar/toolbar.scss
+++ b/packages/core/src/components/toolbar/toolbar.scss
@@ -104,6 +104,11 @@ ion-buttons,
   vertical-align: -webkit-baseline-middle; // the best for those that support it
 
   user-select: none;
+
+  &:active,
+  &:focus {
+    outline: none;
+  }
 }
 
 .bar-button::after {


### PR DESCRIPTION
#### Short description of what this resolves:
This removes the default focus outline from certain components. Previously, we used a global rule for this, but that has performance implications and breaks encapsulation for standalone use.

```css
*:active,
*:focus {
  outline: none;
}
```

This affects these components:
- action-sheet
- alert
- chip-button
- fab-button
- input
- radio
- range
- searchbar
- segment
- textarea
- toolbar

**Ionic Version**: 4.x
