### PR TITLE
refactor(checkbox) form usage and declarative set

### DIFF
--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -50,7 +50,7 @@ export class Checkbox implements CheckboxInput {
   /**
    * the value of the checkbox.
    */
-  @Prop() value: string;
+  @Prop() value = 'on';
 
   /**
    * Emitted when the checked property has changed.

--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -1,5 +1,6 @@
 import { BlurEvent, CheckboxInput, CheckedInputChangeEvent, FocusEvent, StyleEvent } from '../../utils/input-interfaces';
 import { Component, CssClassMap, Event, EventEmitter, Prop, State, Watch } from '@stencil/core';
+import { debounce } from '../../utils/helpers';
 
 
 @Component({
@@ -16,7 +17,6 @@ export class Checkbox implements CheckboxInput {
   private didLoad: boolean;
   private inputId: string;
   private nativeInput: HTMLInputElement;
-  private styleTmr: any;
 
   @State() keyFocus: boolean;
 
@@ -81,6 +81,7 @@ export class Checkbox implements CheckboxInput {
   }
 
   componentDidLoad() {
+    this.ionStyle.emit = debounce(this.ionStyle.emit.bind(this.ionStyle));
     this.nativeInput.checked = this.checked;
     this.didLoad = true;
 
@@ -116,13 +117,9 @@ export class Checkbox implements CheckboxInput {
   }
 
   emitStyle() {
-    clearTimeout(this.styleTmr);
-
-    this.styleTmr = setTimeout(() => {
-      this.ionStyle.emit({
-        'checkbox-disabled': this.disabled,
-        'checkbox-checked': this.checked,
-      });
+    this.ionStyle.emit({
+      'checkbox-disabled': this.disabled,
+      'checkbox-checked': this.checked,
     });
   }
 

--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -35,7 +35,7 @@ export class Checkbox implements CheckboxInput {
   /**
    * The name of the control, which is submitted with the form data.
    */
-  @Prop() name: string;
+  @Prop({ mutable: true }) name: string;
 
   /**
    * If true, the checkbox is selected. Defaults to `false`.
@@ -50,7 +50,7 @@ export class Checkbox implements CheckboxInput {
   /**
    * the value of the checkbox.
    */
-  @Prop({ mutable: true }) value: string;
+  @Prop() value: string;
 
   /**
    * Emitted when the checked property has changed.
@@ -74,8 +74,8 @@ export class Checkbox implements CheckboxInput {
 
   componentWillLoad() {
     this.inputId = `ion-cb-${checkboxIds++}`;
-    if (this.value === undefined) {
-      this.value = this.inputId;
+    if (this.name === undefined) {
+      this.name = this.inputId;
     }
     this.emitStyle();
   }

--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -73,7 +73,7 @@ export class Checkbox implements CheckboxInput {
   @Event() ionStyle: EventEmitter<StyleEvent>;
 
   componentWillLoad() {
-    this.inputId = 'ion-cb-' + (checkboxIds++);
+    this.inputId = `ion-cb-${checkboxIds++}`;
     if (this.value === undefined) {
       this.value = this.inputId;
     }
@@ -82,7 +82,6 @@ export class Checkbox implements CheckboxInput {
 
   componentDidLoad() {
     this.ionStyle.emit = debounce(this.ionStyle.emit.bind(this.ionStyle));
-    this.nativeInput.checked = this.checked;
     this.didLoad = true;
 
     const parentItem = this.nativeInput.closest('ion-item');
@@ -97,10 +96,6 @@ export class Checkbox implements CheckboxInput {
 
   @Watch('checked')
   checkedChanged(isChecked: boolean) {
-    if (this.nativeInput.checked !== isChecked) {
-      // keep the checked value and native input `nync
-      this.nativeInput.checked = isChecked;
-    }
     if (this.didLoad) {
       this.ionChange.emit({
         checked: isChecked,
@@ -111,11 +106,6 @@ export class Checkbox implements CheckboxInput {
   }
 
   @Watch('disabled')
-  disabledChanged(isDisabled: boolean) {
-    this.nativeInput.disabled = isDisabled;
-    this.emitStyle();
-  }
-
   emitStyle() {
     this.ionStyle.emit({
       'checkbox-disabled': this.disabled,
@@ -166,6 +156,7 @@ export class Checkbox implements CheckboxInput {
         onFocus={this.onFocus.bind(this)}
         onBlur={this.onBlur.bind(this)}
         onKeyUp={this.onKeyUp.bind(this)}
+        checked={this.checked}
         id={this.inputId}
         name={this.name}
         value={this.value}


### PR DESCRIPTION
#### Short description of what this resolves:
This refactors the checkbox component. It should work correctly in forms now and also sets checked more declaratively on the native input.

#### Changes proposed in this pull request:

- Replace a custom timeout with the `debounce` helper.
- Instead of keeping native/component in sync manually, just pass attributes.
- Instead of setting a default value, set a default name and let value be the native default of `"on"`.

**Ionic Version**: 4.x
