### PR TITLE
docs: demonstrate use of onDidDismiss() with Alert

### DIFF
--- a/src/components/alert/alert-controller.ts
+++ b/src/components/alert/alert-controller.ts
@@ -59,6 +59,7 @@ import { Config } from '../../config/config';
  *     subTitle: '10% of battery remaining',
  *     buttons: ['Dismiss']
  *   });
+ *   alert.onDidDismiss(() => console.log('Alert was dismissed by the user'));
  *   alert.present();
  * }
  *
@@ -82,6 +83,7 @@ import { Config } from '../../config/config';
  *       }
  *     ]
  *   });
+ *   alert.onDidDismiss(() => console.log('Alert was dismissed by the user'));
  *   alert.present();
  * }
  *
@@ -160,6 +162,11 @@ import { Config } from '../../config/config';
  *  | handler  | `any`    | Emitted when the button is pressed.                             |
  *  | cssClass | `string` | An additional CSS class for the button.                         |
  *  | role     | `string` | The buttons role, null or `cancel`.                             |
+ *
+ * ### Detecting dismissal
+ *
+ * Any dismissal of the alert (including backdrop) can be detected
+ * using the method `onDidDismiss(() => {})`.
  *
  * ### Dismissing And Async Navigation
  *


### PR DESCRIPTION
#### Short description of what this resolves:

There are various inaccurate examples on SO and elsewhere that suggest that onDismiss() can be used to detect dismissal of alert controllers.
This documentation showed neither the old nor new way to get this...

#### Changes proposed in this pull request:

- Example of use of onDidDismiss()
- Explanation

**Ionic Version**: 1.x / 2.x / 3.x

**Fixes**: #
