### PR TITLE
fix(radio-group): propagate the disabled attribute

### DIFF
--- a/packages/core/src/components/radio-group/radio-group.tsx
+++ b/packages/core/src/components/radio-group/radio-group.tsx
@@ -34,6 +34,13 @@ export class RadioGroup implements ComponentDidLoad, RadioGroupInput {
    */
   @Prop({ mutable: true }) value: string;
 
+  @Watch('disabled')
+  disabledChanged() {
+    this.radios.forEach(radio => {
+      radio.disabled = this.disabled;
+    });
+  }
+
   @Watch('value')
   valueChanged() {
     // this radio group's value just changed

--- a/packages/core/src/components/radio-group/radio-group.tsx
+++ b/packages/core/src/components/radio-group/radio-group.tsx
@@ -22,7 +22,7 @@ export class RadioGroup implements ComponentDidLoad, RadioGroupInput {
   /*
    * If true, the user cannot interact with the radio group. Default false.
    */
-  @Prop({ mutable: true }) disabled = false;
+  @Prop() disabled = false;
 
   /**
    * The name of the control, which is submitted with the form data.
@@ -36,9 +36,7 @@ export class RadioGroup implements ComponentDidLoad, RadioGroupInput {
 
   @Watch('disabled')
   disabledChanged() {
-    this.radios.forEach(radio => {
-      radio.disabled = this.disabled;
-    });
+    this.setDisabled();
   }
 
   @Watch('value')
@@ -157,7 +155,14 @@ export class RadioGroup implements ComponentDidLoad, RadioGroupInput {
       }
     }
 
+    this.setDisabled();
     this.didLoad = true;
+  }
+
+  setDisabled() {
+    this.radios.forEach(radio => {
+      radio.disabled = this.disabled;
+    });
   }
 
   hostData() {

--- a/packages/core/src/components/radio-group/test/basic/index.html
+++ b/packages/core/src/components/radio-group/test/basic/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html dir="ltr">
+<head>
+  <meta charset="UTF-8">
+  <title>Radio Group - Basic</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <script src="/dist/ionic.js"></script>
+</head>
+<body>
+  <ion-app>
+    <ion-page>
+
+      <ion-header>
+        <ion-toolbar>
+          <ion-title>Radio Group - Basic</ion-title>
+        </ion-toolbar>
+      </ion-header>
+
+      <ion-content class="outer-content">
+        <ion-radio-group id="dynamicDisabled" disabled name="tannen" id="group" value="biff">
+          <ion-list-header>
+            <ion-label>Luckiest Man On Earth</ion-label>
+          </ion-list-header>
+
+          <ion-item>
+            <ion-label>Biff <span id="biff"></span></ion-label>
+            <ion-radio value="biff" slot="start"></ion-radio>
+          </ion-item>
+
+          <ion-item>
+            <ion-label>Griff <span id="griff"></span></ion-label>
+            <ion-radio value="griff" slot="start"></ion-radio>
+          </ion-item>
+
+          <ion-item>
+            <ion-label>Buford <span id="buford"></span></ion-label>
+            <ion-radio value="buford" slot="start"></ion-radio>
+          </ion-item>
+
+          <ion-item>
+            <ion-label>George</ion-label>
+            <ion-radio value="george" slot="start"></ion-radio>
+          </ion-item>
+
+        </ion-radio-group>
+
+        <ion-button onClick="toggleDisabled()">Toggle Disabled</ion-button>
+      </ion-content>
+
+    </ion-page>
+
+    <script>
+      var dynamicDisabled = document.getElementById('dynamicDisabled');
+
+      function toggleDisabled() {
+        dynamicDisabled.disabled = !dynamicDisabled.disabled;
+      }
+    </script>
+
+  </ion-app>
+</body>
+</html>
+
+
+


### PR DESCRIPTION
#### Short description of what this resolves:

Resolves issue where disabling the radio-group does not disable the radio buttons.

#### Changes proposed in this pull request:

- Propagate the disabled value from the group down to the radios in the group.

**Ionic Version**: 4.x
