### PR TITLE
chore(): add 4.x to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,6 +2,7 @@
 [ ] **1.x** (For Ionic 1.x issues, please use https://github.com/ionic-team/ionic-v1)
 [ ] **2.x**
 [ ] **3.x**
+[ ] **4.x**
 
 **I'm submitting a ...**  (check one with "x")
 [ ] bug report


### PR DESCRIPTION
#### Short description of what this resolves:

4.x is now `master`, but 4.x is not present in the Github issue template.

#### Changes proposed in this pull request:

- Adds the 4.x checkbox to the Github issue template
