### PR TITLE
remove headline negative margin

### DIFF
--- a/core/src/components/app/app.scss
+++ b/core/src/components/app/app.scss
@@ -90,7 +90,7 @@ h6 {
   h5,
   h6 {
     &:first-child {
-      @include margin(-3px, null, null, null);
+      @include margin(0, null, null, null);
     }
   }
 }


### PR DESCRIPTION
This negative margin does not display 2 byte font well.

#### Short description of what this resolves:
if use headline negative margin in `ion-list` - `ion-item`, The top of the letters had disappeared. It did not occur in English in v2-3 , occur in v4. And in Japanese(2 byte font) is always happened.
As it become version 4, I expect that this will be fixed.

<img width="413" alt="2018-03-23 13 15 16" src="https://user-images.githubusercontent.com/9690024/37811864-daaabf58-2e9f-11e8-8824-dcbfc0782f1a.png">

#### Changes proposed in this pull request:

- core/src/components/app/app.scss

**Ionic Version**: 4.x (since 2.x for Japanese)

**Fixes**: #
