### PR TITLE
Add null check for Optional _content in ItemReorder

### DIFF
--- a/src/components/item/item-reorder.ts
+++ b/src/components/item/item-reorder.ts
@@ -243,6 +243,7 @@ export class ItemReorder implements ItemReorderGestureDelegate {
   }
 
   _scrollContent(scroll: number) {
+    if (!this._content) return scroll;
     const scrollTop = this._content.scrollTop + scroll;
     if (scroll !== 0) {
       this._content.scrollTo(0, scrollTop, 0);


### PR DESCRIPTION
#### Short description of what this resolves:
When I used this directive within a template that was included in the body of a content, the _content was null and I got the following exception. But there are probably more circumstances where this will manifest.

vendor.js Uncaught TypeError: Cannot read property 'scrollTop' of null
    at ItemReorder._scrollContent 
    at ItemReorderGesture.onDragStart
    at PointerEvents.handleMouseDown

#### Changes proposed in this pull request:
Add null check for Optional _content where _content is used
-
-
-

**Ionic Version**: 1.x / 2.x / 3.x
3.x
**Fixes**: #
