### PR TITLE
fix(alert-message): only show alert-message scrollbar when necessary

### DIFF
--- a/src/components/alert/alert.scss
+++ b/src/components/alert/alert.scss
@@ -71,7 +71,7 @@ ion-alert input {
 }
 
 .alert-message {
-  overflow-y: scroll;
+  overflow-y: auto;
 
   -webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
#### Short description of what this resolves:

The `.alert-message` dialog always displays a vertical scroll bar:
![screen shot 2018-03-27 at 4 07 15 pm](https://user-images.githubusercontent.com/904007/37992223-12913dd4-31d9-11e8-8287-18dea89caa45.png)

This sets `overflow-y` to `auto`:
![screen shot 2018-03-27 at 4 07 28 pm](https://user-images.githubusercontent.com/904007/37992233-1ed2390e-31d9-11e8-87f6-a58b772cafc8.png)

After looking around, I didn't see the reasoning for forcing the scroll bar to always be visible. If there's a better/preferred way to hide it, please let me know. 

**Ionic Version**: 3.9.2