### PR TITLE
docs: minor typos fixed in readmes

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -29,7 +29,7 @@ Additionally, within this package is a `dist/ionic.js` file and accompanying `di
 
 ## Framework Bindings
 
-The `@ionic/core` package can by used in simple HTML, or by vanilla JavaScript without any framework at all. Ionic also has packages that make it easiesr to integrate Ionic into a framework's traditional ecosystem and patterns. (However, at the lowest-level framework bindings are still just using Ionic Core and Web Components).
+The `@ionic/core` package can by used in simple HTML, or by vanilla JavaScript without any framework at all. Ionic also has packages that make it easier to integrate Ionic into a framework's traditional ecosystem and patterns. (However, at the lowest-level framework bindings are still just using Ionic Core and Web Components).
 
 * [@ionic/angular](https://www.npmjs.com/package/@ionic/angular)
 

--- a/core/scripts/readme.md
+++ b/core/scripts/readme.md
@@ -20,7 +20,7 @@ Make sure you are inside the `core` directory.
 
     npm run dev
 
-With the `dev` command, Ionic components will be built with [Stencil](https://stenciljs.com/), changes to source files are warched, a local http server will startup, and http://localhost:3333/ will open in a browser.
+With the `dev` command, Ionic components will be built with [Stencil](https://stenciljs.com/), changes to source files are watched, a local http server will startup, and http://localhost:3333/ will open in a browser.
 
 ### 4. Preview
 


### PR DESCRIPTION
Minor change, just fixing obvious typos
Thanks!
**Ionic Version**: 1.x / 2.x / 3.x / 4.x
4.x