### PR TITLE
fix(ios): fix placeholder flicker on iOS. #10733 11844

### DIFF
--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -26,12 +26,6 @@ ion-textarea {
   width: 100%;
 }
 
-.item-input ion-input,
-.item-input ion-textarea {
-  position: static;
-}
-
-
 // Textarea Within An Item
 // --------------------------------------------------
 

--- a/src/themes/ionic.mixins.scss
+++ b/src/themes/ionic.mixins.scss
@@ -26,6 +26,9 @@
     // Safari placeholder margin issue
     text-indent: $text-indent;
     color: $color;
+    // Removes flicker from overscroll
+    position: absolute;
+    transform: translateY(8px);
   }
 }
 


### PR DESCRIPTION
#### Short description of what this resolves:

This resolves a flicker that happens on iOS when overscrolling a page containing inputs with `placeholder` attributes. See #11844 and #10733 for examples

This might be needed in v4 as well, haven't tested it.

#### Changes proposed in this pull request:

- Changes placeholder to be `position: absolute` and adjusts its positioning with `translateY`. This specific change fixes the flicker
- Removes the `position: static` on `.item-input ion-input` which defaults it back to `position: relative`.
-

**Ionic Version**: 3.x

**Fixes**: #10733 and #11844

Unclear about the implications of the `position: static` change. In my testing of a few of the form tests I didn't notice any issues.
