### PR TITLE
V3: Use APP_BASE_HREF in deep linker

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -446,7 +446,7 @@ export class IonicModule {
         { provide: ModuleLoader, useFactory: provideModuleLoader, deps: [NgModuleLoader, Injector]},
         { provide: LocationStrategy, useFactory: provideLocationStrategy, deps: [ PlatformLocation, [new Inject(APP_BASE_HREF), new Optional()], Config ] },
         { provide: UrlSerializer, useFactory: setupUrlSerializer, deps: [ App, DeepLinkConfigToken ] },
-        { provide: DeepLinker, useFactory: setupDeepLinker, deps: [ App, UrlSerializer, Location,  ModuleLoader, ComponentFactoryResolver ] },
+        { provide: DeepLinker, useFactory: setupDeepLinker, deps: [ App, UrlSerializer, Location,  ModuleLoader, ComponentFactoryResolver, [new Inject(APP_BASE_HREF), new Optional()] ] },
       ]
     };
   }

--- a/src/navigation/deep-linker.ts
+++ b/src/navigation/deep-linker.ts
@@ -27,7 +27,8 @@ export class DeepLinker {
     public _serializer: UrlSerializer,
     public _location: Location,
     public _moduleLoader: ModuleLoader,
-    public _baseCfr: ComponentFactoryResolver
+    public _baseCfr: ComponentFactoryResolver,
+    public _baseHref: string
   ) {}
 
   /**
@@ -35,7 +36,7 @@ export class DeepLinker {
    */
   init() {
     // scenario 1: Initial load of all navs from the initial browser URL
-    const browserUrl = normalizeUrl(this._location.path());
+    const browserUrl = normalizeUrl(this._location.path(), this._baseHref);
     console.debug(`DeepLinker, init load: ${browserUrl}`);
 
     // remember this URL in our internal history stack
@@ -43,7 +44,7 @@ export class DeepLinker {
 
     // listen for browser URL changes
     this._location.subscribe((locationChg: { url: string }) => {
-      this._urlChange(normalizeUrl(locationChg.url));
+      this._urlChange(normalizeUrl(locationChg.url, this._baseHref));
     });
   }
 
@@ -120,7 +121,7 @@ export class DeepLinker {
 
   getCurrentSegments(browserUrl?: string) {
     if (!browserUrl) {
-      browserUrl = normalizeUrl(this._location.path());
+      browserUrl = normalizeUrl(this._location.path(), this._baseHref);
     }
     return this._serializer.parse(browserUrl);
   }
@@ -290,7 +291,7 @@ export class DeepLinker {
    * @internal
    */
   getSegmentByNavIdOrName(navId: string, name: string): NavSegment {
-    const browserUrl = normalizeUrl(this._location.path());
+    const browserUrl = normalizeUrl(this._location.path(), this._baseHref);
     const segments = this._serializer.parse(browserUrl);
     for (const segment of segments) {
       if (segment.navId === navId || segment.navId === name) {
@@ -433,18 +434,21 @@ export class DeepLinker {
 }
 
 
-export function setupDeepLinker(app: App, serializer: UrlSerializer, location: Location, moduleLoader: ModuleLoader, cfr: ComponentFactoryResolver) {
-  const deepLinker = new DeepLinker(app, serializer, location, moduleLoader, cfr);
+export function setupDeepLinker(app: App, serializer: UrlSerializer, location: Location, moduleLoader: ModuleLoader, cfr: ComponentFactoryResolver, baseHref: string) {
+  const deepLinker = new DeepLinker(app, serializer, location, moduleLoader, cfr, baseHref);
   deepLinker.init();
   return deepLinker;
 }
 
 
-export function normalizeUrl(browserUrl: string): string {
+export function normalizeUrl(browserUrl: string, baseHref: string = '/'): string {
   browserUrl = browserUrl.trim();
   if (browserUrl.charAt(0) !== '/') {
     // ensure first char is a /
     browserUrl = '/' + browserUrl;
+  }
+  if (!browserUrl.startsWith(baseHref)) {
+    browserUrl = baseHref + browserUrl;
   }
   if (browserUrl.length > 1 && browserUrl.charAt(browserUrl.length - 1) === '/') {
     // ensure last char is not a /

--- a/src/util/mock-providers.ts
+++ b/src/util/mock-providers.ts
@@ -394,7 +394,7 @@ export function mockDeepLinker(linkConfig: DeepLinkConfig = null, app?: App) {
   let serializer = new UrlSerializer(app, linkConfig);
   let location = mockLocation();
 
-  return new DeepLinker(app || mockApp(), serializer, location, null, null);
+  return new DeepLinker(app || mockApp(), serializer, location, null, null, '/');
 }
 
 export function mockNavController(): NavControllerBase {
@@ -451,7 +451,7 @@ export function mockOverlayPortal(app: App, config: Config, plt: MockPlatform): 
   let gestureCtrl = new GestureController(app);
   let serializer = new UrlSerializer(app, null);
   let location = mockLocation();
-  let deepLinker = new DeepLinker(app, serializer, location, null, null);
+  let deepLinker = new DeepLinker(app, serializer, location, null, null, '/');
 
   return new OverlayPortal(
     app,

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -53,10 +53,10 @@ export function debounce(fn: Function, wait: number, immediate: boolean = false)
  * @hidden
  * Rewrites an absolute URL so it works across file and http based engines
  */
-export function normalizeURL(url: string): string {
+export function normalizeURL(url: string, baseHref: string = '/'): string {
   const ionic = (<any>window)['Ionic'];
   if (ionic && ionic.normalizeURL) {
-    return ionic.normalizeURL(url);
+    return ionic.normalizeURL(url, baseHref);
   }
   return url;
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes urls generated by deep linker that will work when using a custom base href and the `locationStrategy: path`

#### Changes proposed in this pull request:
Uses injected APP_BASE_HREF to allow configuration of deep link urls

**Ionic Version**: 3.9..2

**Fixes**: #12983
