### PR TITLE
docs(item-sliding): use new side values start and end

### DIFF
--- a/core/src/components/item-options/item-options.tsx
+++ b/core/src/components/item-options/item-options.tsx
@@ -13,7 +13,9 @@ export class ItemOptions {
   @Element() private el: HTMLElement;
 
   /**
-   * The side the option button should be on. Defaults to `"right"`.
+   * The side the option button should be on.
+   * Possible values: `"start"` and `"end"`.
+   * Defaults to `"end"`.
    * If you have multiple `ion-item-options`, a side must be provided for each.
    */
   @Prop() side: Side = 'end';

--- a/core/src/components/item-options/readme.md
+++ b/core/src/components/item-options/readme.md
@@ -1,6 +1,6 @@
 # ion-item-options
 
-The option buttons for an `ion-item-sliding`. These buttons can be placed either on the left or right side.
+The option buttons for an `ion-item-sliding`. These buttons can be placed either on the [start or end side](#side-description).
 You can combine the `(ionSwipe)` event plus the `expandable` directive to create a full swipe action for the item.
 
 
@@ -16,6 +16,13 @@ You can combine the `(ionSwipe)` event plus the `expandable` directive to create
   </ion-item-options>
 </ion-item-sliding>
 ```
+
+### Side description
+
+| Side         | Position                                                        | Swipe direction                                                   |
+|--------------|-----------------------------------------------------------------|-------------------------------------------------------------------|
+| `start`      | To the `left` of the content in LTR, and to the `right` in RTL. | From `left` to `right` in LTR, and from `right` to `left` in RTL. |
+| `end`        | To the `right` of the content in LTR, and to the `left` in RTL. | From `right` to `left` in LTR, and from `left` to `right` in RTL. |
 
 
 <!-- Auto Generated Below -->

--- a/core/src/components/item-sliding/readme.md
+++ b/core/src/components/item-sliding/readme.md
@@ -23,7 +23,7 @@ A Sliding item is a component that contains an item that can be dragged to revea
 
 ### Direction
 
-By default, the options are revealed when the sliding item is swiped from right to left, so the buttons are placed on the right side. It's also possible to reveal them from the right side by setting the `side` attribute on the `ion-item-options` element. Up to two `ion-item-options` can be used at the same time in order to reveal two different sets of options depending on the swiping direction.
+By default, the buttons are placed on the `"end"` side. This means that options are revealed when the sliding item is swiped from end to start, i.e. from right to left in LTR, but from left to right in RTL. To place them on the opposite side, so that they are revealed when swiping to the opposite direction, set the `side` attribute to `"start"` on the `ion-item-options` element. Refer to [`ion-item-options` docs](https://github.com/ionic-team/ionic/blob/master/core/src/components/item-options/readme.md). Up to two `ion-item-options` can be used at the same time in order to reveal two different sets of options depending on the swiping direction.
 
 ```html
 <ion-item-options side="end">


### PR DESCRIPTION
#### Short description of what this resolves:
As mentioned in https://github.com/ionic-team/ionic/issues/14293#issuecomment-380559751, this PR replaces the remaining obsolete references to `side` values `"left"` and `"right"` by the new values `"start"` and `"end"`, and the associated swipe direction description.

#### Changes proposed in this pull request:

- Reword description of swipe direction in `item-sliding` + link to `item-options` docs.
- Replace possible values description in `item-options`'s `side` Prop by new values.
- Add a table in `item-options` to describe effect of `side` value in button position and swipe direction to reveal them.

**Ionic Version**: ~~1.x / 2.x / 3.x~~ / **4.x**

**Fixes**: helps the documentation part of #14293, but does not fix the missing side bug.
