### PR TITLE
Fix(picker) issue where datepicker could select invalid dates

### DIFF
--- a/core/src/components/picker-column/picker-column.tsx
+++ b/core/src/components/picker-column/picker-column.tsx
@@ -158,11 +158,7 @@ export class PickerColumnCmp {
     }
 
     if (emitChange) {
-      if (this.lastIndex === undefined) {
-        // have not set a last index yet
-        this.lastIndex = this.col.selectedIndex;
-
-      } else if (this.lastIndex !== this.col.selectedIndex) {
+      if (this.lastIndex !== this.col.selectedIndex) {
         // new selected index has changed from the last index
         // update the lastIndex and emit that it has changed
         this.lastIndex = this.col.selectedIndex;


### PR DESCRIPTION
#### Short description of what this resolves:
This fix resolves the Invalid Dates issue in ion-datetime. Currently, it is possible to select invalid dates, because the day column does not update on the first picker change (for example, open the picker, select January 31st, then move Month February).

Full credit for this fix goes to @eisene, you can see his commit here:
eisene/ionic@4aa494d

#### Changes proposed in this pull request:
make ion-change fire on first change of picker column

**Ionic Version**: 1.x / 2.x / 3.x / 4.x
4.x

**Fixes**: #
#13287
#12533
#12319
#13430
