### PR TITLE
fix(autofocus): fix not working `autofocus="false"`

### DIFF
--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -320,7 +320,7 @@ export class Input implements InputComponent {
         autoCapitalize={this.autocapitalize}
         autoComplete={this.autocomplete}
         autoCorrect={this.autocorrect}
-        autoFocus={this.autofocus}
+        {this.autofocus ? 'autofocus' : false}
         class={themedClasses}
         disabled={this.disabled}
         inputMode={this.inputmode}

--- a/core/src/components/textarea/textarea.tsx
+++ b/core/src/components/textarea/textarea.tsx
@@ -246,7 +246,7 @@ export class Textarea implements TextareaComponent {
       <textarea
         autoCapitalize={this.autocapitalize}
         // autoComplete={this.autocomplete}
-        autoFocus={this.autofocus}
+        {this.autofocus ? 'autofocus' : false}
         disabled={this.disabled}
         maxLength={this.maxlength}
         minLength={this.minlength}


### PR DESCRIPTION
#### Short description of what this resolves:
Google Chrome don't work autofocus's boolean. when autofocus is false, browser require not exist.

don't work `<input autofocus="false">`
work  
`<input>`  <= autofocus is false
`<input autofocus>` <= autofocus is true
`<input autofocus="false">` <= autofocus is **true**

#### Changes proposed in this pull request:
- ion-input
- ion-textarea

**Ionic Version**: 4.x

**Fixes**: #
