### PR TITLE
chore(skeleton-text): add directive `height` and `border-radius`

### DIFF
--- a/core/src/components/skeleton-text/skeleton-text.tsx
+++ b/core/src/components/skeleton-text/skeleton-text.tsx
@@ -13,8 +13,16 @@ import { Component, Prop } from '@stencil/core';
 })
 export class SkeletonText {
   @Prop() width = '100%';
+  @Prop() height = 'auto';
+  @Prop() radius = '0';
 
   render () {
-    return <span style={{width: this.width}}>&nbsp;</span>;
+    const themedStyles = {
+      'width': this.width,
+      'height': this.height,
+      'border-radius': this.radius,
+    };
+
+    return <span style={themedStyles}>&nbsp;</span>;
   }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
be able use `height` and `border-radius` on `skeleton-text`.

#### Changes proposed in this pull request:
- skeleton-text

**Ionic Version**: 4.x

**Fixes**: #
