### PR TITLE
fix(datetime): Invalid dates in ion-datetime

### DIFF
--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -4579,6 +4579,7 @@ declare global {
   namespace JSXElements {
     export interface IonPickerColumnAttributes extends HTMLAttributes {
       'col'?: PickerColumn;
+      'onIonPickerColChange'?: (event: CustomEvent) => void;
     }
   }
 }

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -29,8 +29,7 @@ export class Datetime {
 
   @Listen('body:ionPickerColChange')
   protected ionPickerDidUnload(col: any) {
-    // this.validate();
-    console.log(col.detail.name);
+      this.validate();
   }
 
   @State() text: any;

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -1,26 +1,6 @@
 import { Component, Event, EventEmitter, Prop, State, Watch } from '@stencil/core';
 
-<<<<<<< HEAD
 import { DatetimeData, LocaleData, convertFormatToKey, convertToArrayOfNumbers, convertToArrayOfStrings, dateDataSortValue, dateSortValue, dateValueRange, daysInMonth, getValueFromFormat, parseDate, parseTemplate, renderDatetime, renderTextFormat, updateDate } from './datetime-util';
-=======
-import {
-  DatetimeData,
-  LocaleData,
-  convertFormatToKey,
-  convertToArrayOfNumbers,
-  convertToArrayOfStrings,
-  dateDataSortValue,
-  dateSortValue,
-  dateValueRange,
-  daysInMonth,
-  getValueFromFormat,
-  parseDate,
-  parseTemplate,
-  renderDatetime,
-  renderTextFormat,
-  updateDate
-} from './datetime-util';
->>>>>>> addeventlistener to the rescue
 
 import { CssClassMap, PickerColumn, PickerOptions, StyleEvent } from '../../interface';
 import { clamp, deferEvent } from '../../utils/helpers';
@@ -289,11 +269,7 @@ export class Datetime {
     const pickerOptions = {...this.pickerOptions};
     this.picker = await this.buildPicker(pickerOptions);
     this.validate();
-<<<<<<< HEAD
     await this.picker!.present();
-=======
-    await this.picker.present();
->>>>>>> addeventlistener to the rescue
     const picker = document.querySelector('ion-picker');
     if (picker) picker.addEventListener('ionPickerColChange', this.validate.bind(this));
   }

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -1,6 +1,26 @@
 import { Component, Event, EventEmitter, Prop, State, Watch } from '@stencil/core';
 
+<<<<<<< HEAD
 import { DatetimeData, LocaleData, convertFormatToKey, convertToArrayOfNumbers, convertToArrayOfStrings, dateDataSortValue, dateSortValue, dateValueRange, daysInMonth, getValueFromFormat, parseDate, parseTemplate, renderDatetime, renderTextFormat, updateDate } from './datetime-util';
+=======
+import {
+  DatetimeData,
+  LocaleData,
+  convertFormatToKey,
+  convertToArrayOfNumbers,
+  convertToArrayOfStrings,
+  dateDataSortValue,
+  dateSortValue,
+  dateValueRange,
+  daysInMonth,
+  getValueFromFormat,
+  parseDate,
+  parseTemplate,
+  renderDatetime,
+  renderTextFormat,
+  updateDate
+} from './datetime-util';
+>>>>>>> addeventlistener to the rescue
 
 import { CssClassMap, PickerColumn, PickerOptions, StyleEvent } from '../../interface';
 import { clamp, deferEvent } from '../../utils/helpers';
@@ -26,11 +46,6 @@ export class Datetime {
   datetimeMin: DatetimeData = {};
   datetimeMax: DatetimeData = {};
   datetimeValue: DatetimeData = {};
-
-  @Listen('body:ionPickerColChange')
-  protected ionPickerDidUnload(col: any) {
-      this.validate();
-  }
 
   @State() text: any;
 
@@ -274,7 +289,11 @@ export class Datetime {
     const pickerOptions = {...this.pickerOptions};
     this.picker = await this.buildPicker(pickerOptions);
     this.validate();
+<<<<<<< HEAD
     await this.picker!.present();
+=======
+    await this.picker.present();
+>>>>>>> addeventlistener to the rescue
     const picker = document.querySelector('ion-picker');
     if (picker) picker.addEventListener('ionPickerColChange', this.validate.bind(this));
   }

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -27,6 +27,12 @@ export class Datetime {
   datetimeMax: DatetimeData = {};
   datetimeValue: DatetimeData = {};
 
+  @Listen('body:ionPickerColChange')
+  protected ionPickerDidUnload(col: any) {
+    // this.validate();
+    console.log(col.detail.name);
+  }
+
   @State() text: any;
 
   @Prop({ connect: 'ion-picker-controller' }) pickerCtrl!: HTMLIonPickerControllerElement;
@@ -270,6 +276,8 @@ export class Datetime {
     this.picker = await this.buildPicker(pickerOptions);
     this.validate();
     await this.picker!.present();
+    const picker = document.querySelector('ion-picker');
+    if (picker) picker.addEventListener('ionPickerColChange', this.validate.bind(this));
   }
 
   private generateColumns(): PickerColumn[] {

--- a/core/src/components/picker-column/picker-column.tsx
+++ b/core/src/components/picker-column/picker-column.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Prop, QueueApi } from '@stencil/core';
+import { Component, Element, Prop, QueueApi, Event, EventEmitter } from '@stencil/core';
 import { GestureDetail, Mode, PickerColumn, PickerColumnOption } from '../../interface';
 import { hapticSelectionChanged } from '../../utils';
 import { clamp } from '../../utils/helpers';
@@ -30,6 +30,8 @@ export class PickerColumnCmp {
   @Prop({ context: 'queue' }) queue!: QueueApi;
 
   @Prop() col!: PickerColumn;
+
+  @Event() ionPickerColChange!: EventEmitter;
 
   componentWillLoad() {
     let pickerRotateFactor = 0;
@@ -156,20 +158,11 @@ export class PickerColumnCmp {
       this.y = y;
     }
 
-    if (emitChange) {
-      if (this.lastIndex === undefined) {
-        // have not set a last index yet
+    if (emitChange && (this.lastIndex !== this.col.selectedIndex)) {
+      // If the emit change is true, broadcast that a column has been updated
+      if (emitChange) {
         this.lastIndex = this.col.selectedIndex;
-
-      } else if (this.lastIndex !== this.col.selectedIndex) {
-        // new selected index has changed from the last index
-        // update the lastIndex and emit that it has changed
-        this.lastIndex = this.col.selectedIndex;
-        // TODO ionChange event
-        // var ionChange = this.ionChange;
-        // if (ionChange.observers.length > 0) {
-        //   this._zone.run(ionChange.emit.bind(ionChange, this.col.options[this.col.selectedIndex]));
-        // }
+        this.ionPickerColChange.emit();
       }
     }
   }

--- a/core/src/components/picker-column/readme.md
+++ b/core/src/components/picker-column/readme.md
@@ -19,6 +19,11 @@ PickerColumn
 
 
 
+## Events
+
+#### ionPickerColChange
+
+
 
 ----------------------------------------------
 


### PR DESCRIPTION
#### Short description of what this resolves:

This fix resolves the Invalid Dates issue in ion-datetime. Currently, it is possible to select invalid dates, because the day column does not update on the first picker change (for example, open the picker, select January 31st, then move Month February).

The fix had to be updated from the original fix: https://github.com/ionic-team/ionic/pull/13529
due to the changeover to Stencil / Ionic 4. 

I opened a separate hotfix patch to the 3.9 tag.
https://github.com/ionic-team/ionic/pull/14447

#### Changes proposed in this pull request:

- picker-column emits on change
- ion-datetime listens for the emit and re-validates the columns

**Ionic Version**: 1.x / 2.x / 3.x / 4.x

4.x

**Fixes**: #

#13287
#12533
#12319
#13430