### PR TITLE
Typo in toast component angular usage example

### DIFF
--- a/core/src/components/toast/usage/angular.md
+++ b/core/src/components/toast/usage/angular.md
@@ -11,16 +11,16 @@ export class ToastExample {
 
   constructor(public toastController: ToastController) {}
 
-  presentToast() {
-    const toast = this.toastController.create({
+  async presentToast() {
+    const toast = await this.toastController.create({
       message: 'Your settings have been saved.',
       duration: 2000
     });
     toast.present();
   }
 
-  presentToastWithOptions() {
-    const toast = this.toastController.create({
+  async presentToastWithOptions() {
+    const toast = await this.toastController.create({
       message: 'Click to Close',
       showCloseButton: true,
       position: 'top',


### PR DESCRIPTION
The create method returns a promise. Other examples deal with this using async-await, so I did the same thing in this instance.

#### Short description of what this resolves:
Typo in documentation

#### Changes proposed in this pull request:

- Just fixing the typo. Only touches documentation.

**Ionic Version**: 4.x

**Fixes**: No issue opened, because I think it's such a small change. If you need me to open it, please tell me.
