### PR TITLE
docs(usage): setting angular usage example to be typescript

### DIFF
--- a/core/src/components/action-sheet/usage/angular.md
+++ b/core/src/components/action-sheet/usage/angular.md
@@ -1,4 +1,4 @@
-```javascript
+```typescript
 import { Component } from '@angular/core';
 import { ActionSheetController } from '@ionic/angular';
 

--- a/core/src/components/alert/usage/angular.md
+++ b/core/src/components/alert/usage/angular.md
@@ -1,4 +1,4 @@
-```javascript
+```typescript
 import { Component } from '@angular/core';
 import { AlertController } from '@ionic/angular';
 

--- a/core/src/components/backdrop/usage/angular.md
+++ b/core/src/components/backdrop/usage/angular.md
@@ -15,7 +15,7 @@
 <ion-backdrop [tappable]="enableBackdropDismiss" [visible]="showBackdrop" [stopPropagation]="shouldPropagate"></ion-backdrop>
 ```
 
-```javascript
+```typescript
 import { Component } from '@angular/core';
 
 @Component({

--- a/core/src/components/loading/usage/angular.md
+++ b/core/src/components/loading/usage/angular.md
@@ -1,4 +1,4 @@
-```javascript
+```typescript
 import { Component } from '@angular/core';
 import { LoadingController } from '@ionic/angular';
 

--- a/core/src/components/popover/usage/angular.md
+++ b/core/src/components/popover/usage/angular.md
@@ -1,4 +1,4 @@
-```javascript
+```typescript
 import { Component } from '@angular/core';
 import { PopoverController } from '@ionic/angular';
 

--- a/core/src/components/segment-button/usage/angular.md
+++ b/core/src/components/segment-button/usage/angular.md
@@ -47,7 +47,7 @@
 </ion-segment>
 ```
 
-```javascript
+```typescript
 import { Component } from '@angular/core';
 
 @Component({

--- a/core/src/components/segment/usage/angular.md
+++ b/core/src/components/segment/usage/angular.md
@@ -55,7 +55,7 @@
 </ion-toolbar>
 ```
 
-```javascript
+```typescript
 import { Component } from '@angular/core';
 
 @Component({

--- a/core/src/components/select/usage/angular.md
+++ b/core/src/components/select/usage/angular.md
@@ -105,7 +105,7 @@
 </ion-list>
 ```
 
-```javascript
+```typescript
 import { Component } from '@angular/core';
 
 @Component({


### PR DESCRIPTION
#### Short description of what this resolves:

The usage docs in the new docs have pretty typescript syntax highlighting, but that only works if they're told that the code is typescript

#### Changes proposed in this pull request:

- change every angular example in the usage section to be marked as typescript
-
-

**Ionic Version**: 1.x / 2.x / 3.x / 4.x
4.x

**Fixes**: #
