### PR TITLE
docs(fab): examples use vertical + horizontal attrs

### DIFF
--- a/core/src/components/fab/readme.md
+++ b/core/src/components/fab/readme.md
@@ -2,71 +2,71 @@
 
 Fabs are container elements that contain one or more fab buttons. They should be placed in a fixed position that does not scroll with the content. The following attributes can be used to position the fab with respect to the content:
 
-| Value        | Alignment  | Details                                                                   |
-|--------------|------------|---------------------------------------------------------------------------|
-| `top`        | vertical   | Places the container at the top of the content.                           |
-| `bottom`     | vertical   | Places the container at the bottom of the content.                        |
-| `middle`     | vertical   | Places the container in the middle vertically.                            |
-| `edge`       | vertical   | Used to place the container between the content and the header/footer.    |
-| `left`       | horizontal | Places the container on the left.                                         |
-| `right`      | horizontal | Places the container on the right.                                        |
-| `center`     | horizontal | Places the container in the center horizontally.                          |
+| Attribute  | Value        | Details                                                                               |
+|------------|--------------|---------------------------------------------------------------------------------------|
+| vertical   | `"top"`      | Places the container at the top of the content.                                       |
+| vertical   | `"bottom"`   | Places the container at the bottom of the content.                                    |
+| vertical   | `"center"`   | Places the container in the center/middle vertically.                                 |
+| edge       | `"edge"`     | Used to place the container vertically between the content and the header/footer.     |
+| horizontal | `"start"`    | Places the container in the start slot (i.e. on the left in LTR, on the right in RTL).|
+| horizontal | `"end"`      | Places the container in the end slot (i.e. on the right in LTR, on the left in RTL).  |
+| horizontal | `"center"`   | Places the container in the center horizontally.                                      |
 
 The fab should have one main fab button. Fabs can also contain fab lists which contain related buttons that show when the main fab button is clicked. The same fab container can contain several [fab list](../../fab-list/FabList) elements with different side values.
 
 ```html
 <ion-content>
-  <!-- fab placed to the top right -->
-  <ion-fab top right slot="fixed">
+  <!-- fab placed to the top end -->
+  <ion-fab vertical="top" horizontal="end" slot="fixed">
     <ion-fab-button>
       <ion-icon name="add"></ion-icon>
     </ion-fab-button>
   </ion-fab>
 
-  <!-- fab placed to the bottom right -->
-  <ion-fab bottom right slot="fixed">
+  <!-- fab placed to the bottom end -->
+  <ion-fab vertical="bottom" horizontal="end" slot="fixed">
     <ion-fab-button>
       <ion-icon name="arrow-dropleft"></ion-icon>
     </ion-fab-button>
   </ion-fab>
 
-  <!-- fab placed to the top left -->
-  <ion-fab top left slot="fixed">
+  <!-- fab placed to the top start -->
+  <ion-fab vertical="top" horizontal="start" slot="fixed">
     <ion-fab-button>
       <ion-icon name="arrow-dropright"></ion-icon>
     </ion-fab-button>
   </ion-fab>
 
-  <!-- fab placed to the bottom left -->
-  <ion-fab bottom left slot="fixed">
+  <!-- fab placed to the bottom start -->
+  <ion-fab vertical="bottom" horizontal="start" slot="fixed">
     <ion-fab-button>
       <ion-icon name="arrow-dropup"></ion-icon>
     </ion-fab-button>
   </ion-fab>
 
-  <!-- fab placed to the left and middle -->
-  <ion-fab left middle slot="fixed">
+  <!-- fab placed to the (vertical) center and start -->
+  <ion-fab vertical="center" horizontal="start" slot="fixed">
     <ion-fab-button>
       <ion-icon name="share"></ion-icon>
     </ion-fab-button>
   </ion-fab>
 
-  <!-- fab placed to the right and middle -->
-  <ion-fab right middle slot="fixed">
+  <!-- fab placed to the (vertical) center and end -->
+  <ion-fab vertical="center" horizontal="end" slot="fixed">
     <ion-fab-button>
       <ion-icon name="add"></ion-icon>
     </ion-fab-button>
   </ion-fab>
 
-  <!-- fab placed to the top and right and on the top edge of the content overlapping header -->
-  <ion-fab top right edge slot="fixed">
+  <!-- fab placed to the top and end and on the top edge of the content overlapping header -->
+  <ion-fab vertical="top" horizontal="end" edge slot="fixed">
     <ion-fab-button>
       <ion-icon name="person"></ion-icon>
     </ion-fab-button>
   </ion-fab>
 
-  <!-- fab placed to the bottom and left and on the bottom edge of the content overlapping footer with a list to the right -->
-  <ion-fab bottom left edge slot="fixed">
+  <!-- fab placed to the bottom and start and on the bottom edge of the content overlapping footer with a list to the right -->
+  <ion-fab vertical="bottom" horizontal="start" edge slot="fixed">
     <ion-fab-button>
       <ion-icon name="settings"></ion-icon>
     </ion-fab-button>
@@ -76,8 +76,10 @@ The fab should have one main fab button. Fabs can also contain fab lists which c
   </ion-fab>
 
   <!-- fab placed in the center of the content with a list on each side -->
-  <ion-fab center middle slot="fixed">
-    <ion-fab-button><ion-icon name="share"></ion-icon></ion-fab-button>
+  <ion-fab vertical="center" horizontal="center" slot="fixed">
+    <ion-fab-button>
+      <ion-icon name="share"></ion-icon>
+    </ion-fab-button>
     <ion-fab-list side="top">
       <ion-fab-button><ion-icon name="logo-vimeo"></ion-icon></ion-fab-button>
     </ion-fab-list>


### PR DESCRIPTION
Hi,

#### Short description of what this resolves:

Since https://github.com/ionic-team/ionic/commit/cc365f829d08b3f958032709a5817eb0655fe1f3 released in `@ionic/core` [`v0.1.4-1`](https://github.com/ionic-team/ionic/releases/tag/v0.1.4-1) (v4), FAB position now uses `horizontal` and `vertical` attributes instead of directly alignment values as attributes, as described in the [BREAKING page](https://github.com/ionic-team/ionic/blob/v0.1.4-1/BREAKING.md#fab).

However, the FAB component [README page](https://github.com/ionic-team/ionic/tree/v0.1.4-1/packages/core/src/components/fab) has not been updated accordingly ([latest version](https://github.com/ionic-team/ionic/tree/v4.0.0-alpha.6/core/src/components/fab))

Horizontal position names have also been renamed from "left" and "right" to "start" and "end" for RTL support.

#### Changes proposed in this pull request:

- Update FAB component README top table to use `horizontal` and `vertical` attributes instead of directly alignment values as attributes.
- Rename horizontal values from "left" and "right" to "start" and "end" for RTL support.
- Update all README examples accordingly.

**Ionic Version**: ~~1.x / 2.x / 3.x~~ / **4.x**

I :heart: ionic4!