### PR TITLE
docs(fabList): update README to start+end sides and FAB horizontal+vertical attrs

### DIFF
--- a/core/src/components/fab-list/readme.md
+++ b/core/src/components/fab-list/readme.md
@@ -5,8 +5,8 @@ The `ion-fab-list` element is a container for multiple FAB buttons. This collect
 ```
 [top] - Show the list of buttons above the main FAB button
 [bottom] - Show the list of buttons under the main FAB button
-[left] - Show the list of buttons to the left of the main FAB button
-[right] - Show the list of buttons to the right of the main FAB button
+[start] - Show the list of buttons on the start side of the main FAB button (i.e. on the left in LTR, on the right in RTL)
+[end] - Show the list of buttons on the end side of the main FAB button (i.e. on the right in LTR, on the left in RTL)
 ```
 
 ```html

--- a/core/src/components/fab-list/readme.md
+++ b/core/src/components/fab-list/readme.md
@@ -10,7 +10,7 @@ The `ion-fab-list` element is a container for multiple FAB buttons. This collect
 ```
 
 ```html
-<ion-fab bottom right>
+<ion-fab vertical="bottom" horizontal="end">
   <ion-fab-button>Share</ion-fab-button>
   <ion-fab-list side="top">
     <ion-fab-button>Facebook</ion-fab-button>


### PR DESCRIPTION
Hi again,

#### Short description of what this resolves:

Since https://github.com/ionic-team/ionic/commit/a203534b27c86104313daacee8365b306dfcfbcb released in `@ionic/core` (v4) [`v4.0.0-alpha.2`](https://github.com/ionic-team/ionic/releases/tag/v4.0.0-alpha.2), FAB List `side` attribute now uses `"start"` and `"end"` values instead of `"left"` and `"right"`, for RTL support.

However, the FAB List [README page top table](https://github.com/ionic-team/ionic/tree/v4.0.0-alpha.2/core/src/components/fab-list) has not been updated accordingly ([latest version](https://github.com/ionic-team/ionic/tree/v4.0.0-alpha.6/core/src/components/fab-list)).

#### Changes proposed in this pull request:

- Replace in README top table `side` attribute `"left"` and `"right"` values by `"start"` and `"end"`.
- Update example FAB usage with `vertical` and `horizontal` attributes instead of directly alignment values as attributes (see also PR https://github.com/ionic-team/ionic/pull/14474).

**Ionic Version**: ~~1.x / 2.x / 3.x~~ / **4.x**
