### PR TITLE
fix(datetime): allow values to be zero

### DIFF
--- a/core/src/components/datetime/datetime-util.ts
+++ b/core/src/components/datetime/datetime-util.ts
@@ -11,7 +11,7 @@ export function renderDatetime(template: string, value: DatetimeData, locale: Lo
       const token = '{' + index + '}';
       const text = renderTextFormat(format.f, (value as any)[format.k], value, locale);
 
-      if (!hasText && text && (value as any)[format.k]) {
+      if (!hasText && text && ((value as any)[format.k] || (value as any)[format.k] === 0)) {
         hasText = true;
       }
 

--- a/core/src/components/datetime/datetime-util.ts
+++ b/core/src/components/datetime/datetime-util.ts
@@ -11,7 +11,7 @@ export function renderDatetime(template: string, value: DatetimeData, locale: Lo
       const token = '{' + index + '}';
       const text = renderTextFormat(format.f, (value as any)[format.k], value, locale);
 
-      if (!hasText && text && ((value as any)[format.k] || (value as any)[format.k] === 0)) {
+      if (!hasText && text && (value as any)[format.k] != null) {
         hasText = true;
       }
 


### PR DESCRIPTION
#### Short description of what this resolves:
Currently, if all the values in `ion-datetime` are `0`, it doesn't render any text. 
E.g. `<ion-datetime displayFormat="HH:mm" value="00:00"></ion-datetime>` doesn't render any text, even tough "00:00" is a valid time.

#### Changes proposed in this pull request:

- allow values to be zero

**Ionic Version**: 4.x

**Fixes**: #
