### PR TITLE
fix(CHANGELOG.md): typo in 4.0.0-beta.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bug Fixes
 
 * **all:** strong typing for color ([618f708](https://github.com/ionic-team/ionic/commit/618f708))
-* **angula:** platform logic belongs to core ([af5db2f](https://github.com/ionic-team/ionic/commit/af5db2f))
+* **angular:** platform logic belongs to core ([af5db2f](https://github.com/ionic-team/ionic/commit/af5db2f))
 * **angular:** build script ([a88e1e8](https://github.com/ionic-team/ionic/commit/a88e1e8))
 * **angular:** params are assigned to props ([7fa6e43](https://github.com/ionic-team/ionic/commit/7fa6e43))
 * **angular:** populated the platforms array ([#14466](https://github.com/ionic-team/ionic/issues/14466)) ([d177087](https://github.com/ionic-team/ionic/commit/d177087))


### PR DESCRIPTION
#### Short description of what this resolves:

there is a typo in the changelog of 4.0.0-beta.7

#### Changes proposed in this pull request:

- add a missing 'r' so angular is correctly written

**Ionic Version**:  4.x
