### PR TITLE
WIP: suggest(ion-label) use <label> tag for accessibility.

### DIFF
--- a/core/src/components/label/label.tsx
+++ b/core/src/components/label/label.tsx
@@ -7,9 +7,6 @@ import { Color, Mode, StyleEvent } from '../../interface';
   styleUrls: {
     ios: 'label.ios.scss',
     md: 'label.md.scss'
-  },
-  host: {
-    theme: 'label'
   }
 })
 export class Label {
@@ -36,6 +33,10 @@ export class Label {
    */
   @Prop() position?: 'fixed' | 'stacked' | 'floating';
 
+
+  @Prop() text?: string;
+  @Prop() labelfor?: string;
+
   /**
    * Emitted when the styles change.
    */
@@ -58,13 +59,23 @@ export class Label {
     });
   }
 
-  hostData() {
+  protected render() {
+
+    const TagType = 'label';
     const position = this.position;
-    return {
-      class: {
-        [`label-${position}`]: !!position,
-        [`label-${this.mode}-${position}`]: !!position
-      }
+    const labelClasses = {
+      [`label-${position}`]: !!position,
+      [`label-${this.mode}-${position}`]: !!position
     };
+
+    return (
+      <TagType
+        class={labelClasses}
+        htmlFor={this.labelfor}
+      >
+        {this.text}
+      </TagType>
+    );
   }
+
 }


### PR DESCRIPTION
#### Short description of what this resolves:
ion-label made `host : label` - `Web Components`. But many environment can't read hosted label. accessibility, Speech reading software, Lighthouse...
 
So this is right, But I think ion-label should be make `<label>` tag for accessibility.

this pull request related https://github.com/ionic-team/ionic/pull/14521 .

Please tell me your opinion on this.

#### Changes proposed in this pull request:

- ion-label

**Ionic Version**: 4.x

**Fixes**: #
