### PR TITLE
WIP: Use explicit props for tab button icon and labels

### DIFF
--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -6415,6 +6415,9 @@ declare global {
 
   namespace StencilComponents {
     interface IonTabButton {
+      'badge': string;
+      'icon': string;
+      'label': string;
       'selected': boolean;
       'tab': HTMLIonTabElement;
     }
@@ -6439,6 +6442,9 @@ declare global {
   }
   namespace JSXElements {
     export interface IonTabButtonAttributes extends HTMLAttributes {
+      'badge'?: string;
+      'icon'?: string;
+      'label'?: string;
       'onIonTabButtonDidLoad'?: (event: CustomEvent<void>) => void;
       'onIonTabButtonDidUnload'?: (event: CustomEvent<void>) => void;
       'onIonTabbarClick'?: (event: CustomEvent<HTMLIonTabElement>) => void;

--- a/core/src/components/tab-button/readme.md
+++ b/core/src/components/tab-button/readme.md
@@ -7,6 +7,21 @@
 
 ## Properties
 
+#### badge
+
+string
+
+
+#### icon
+
+string
+
+
+#### label
+
+string
+
+
 #### selected
 
 boolean
@@ -18,6 +33,21 @@ HTMLIonTabElement
 
 
 ## Attributes
+
+#### badge
+
+string
+
+
+#### icon
+
+string
+
+
+#### label
+
+string
+
 
 #### selected
 

--- a/core/src/components/tab-button/tab-button.tsx
+++ b/core/src/components/tab-button/tab-button.tsx
@@ -18,6 +18,11 @@ export class TabButton {
   @State() keyFocus = false;
 
   @Prop() selected = false;
+
+  @Prop() icon: string = '';
+  @Prop() label: string = '';
+  @Prop() badge: string = '';
+
   @Prop() tab!: HTMLIonTabElement;
 
   @Event() ionTabbarClick!: EventEmitter<HTMLIonTabElement>;
@@ -52,11 +57,11 @@ export class TabButton {
   hostData() {
     const selected = this.selected;
     const tab = this.tab;
-    const hasTitle = !!tab.label;
-    const hasIcon = !!tab.icon;
+    const hasTitle = !!this.label;
+    const hasIcon = !!this.icon;
     const hasTitleOnly = (hasTitle && !hasIcon);
     const hasIconOnly = (hasIcon && !hasTitle);
-    const hasBadge = !!tab.badge;
+    const hasBadge = !!this.badge;
     return {
       'role': 'tab',
       'id': tab.btnId,
@@ -85,9 +90,9 @@ export class TabButton {
         class="tab-cover"
         onKeyUp={this.onKeyUp.bind(this)}
         onBlur={this.onBlur.bind(this)}>
-        { tab.icon && <ion-icon class="tab-button-icon" icon={tab.icon}></ion-icon> }
-        { tab.label && <span class="tab-button-text">{tab.label}</span> }
-        { tab.badge && <ion-badge class="tab-badge" color={tab.badgeColor}>{tab.badge}</ion-badge> }
+        { this.icon && <ion-icon class="tab-button-icon" icon={this.icon}></ion-icon> }
+        { this.label && <span class="tab-button-text">{this.label}</span> }
+        { this.badge && <ion-badge class="tab-badge" color={tab.badgeColor}>{this.badge}</ion-badge> }
         { this.mode === 'md' && <ion-ripple-effect tapClick={true}/> }
       </a>
     ];

--- a/core/src/components/tabbar/tabbar.tsx
+++ b/core/src/components/tabbar/tabbar.tsx
@@ -186,7 +186,12 @@ export class Tabbar {
     const selectedTab = this.selectedTab;
     const ionTabbarHighlight = this.highlight ? <div class="animated tabbar-highlight"/> as HTMLElement : null;
     const buttonClasses = createThemedClasses(this.mode, this.color, 'tab-button');
-    const tabButtons = this.tabs.map(tab => <ion-tab-button class={buttonClasses} tab={tab} selected={selectedTab === tab}/>);
+    const tabButtons = this.tabs.map(tab => <ion-tab-button class={buttonClasses}
+                                                            icon={tab.icon}
+                                                            label={tab.label}
+                                                            badge={tab.badge}
+                                                            tab={tab}
+                                                            selected={selectedTab === tab}/>);
 
     if (this.scrollable) {
       return [


### PR DESCRIPTION
#### Short description of what this resolves:

Currently, if you change the `icon`, `label`, or `badge` props of an `<ion-tab-button>`, such as when setting those values on `<ion-tab>`, the tab button does not re-render.

This makes sense because the prop was binding to `tab`, so changing a sub-property of `tab` would not cause a re-render.

#### Changes proposed in this pull request:

- Pass `icon`, `badge`, and `label` as props to `<ion-tab-button>`

**Ionic Version**: 4.x
