### PR TITLE
fix(angular) correct subscription to cordova ready event

### DIFF
--- a/angular/src/providers/platform.ts
+++ b/angular/src/providers/platform.ts
@@ -50,7 +50,7 @@ export class Platform {
     let readyResolve: (value: string) => void;
     this._readyPromise = new Promise(res => { readyResolve = res; } );
     if ((window as any)['cordova']) {
-      window.addEventListener('deviceready', () => {
+      document.addEventListener('deviceready', () => {
         readyResolve('cordova');
       }, {once: true});
     } else {


### PR DESCRIPTION
#### Short description of what this resolves:
According to [cordova documentation](https://cordova.apache.org/docs/en/latest/cordova/events/events.html#deviceready), `addEventListener` call for `deviceready` event should be done on `document` object. `platform.ready()` does not resolve on device if this change is not made.

#### Changes proposed in this pull request:
- Change the `deviceready` subscription from `window` to `document`.

**Ionic Version**: 4.x

**Fixes**: #
