### PR TITLE
feat(angular): add ifPl, ifWidth and autoFocus directives

### DIFF
--- a/angular/src/directives/control-element/autofocus.ts
+++ b/angular/src/directives/control-element/autofocus.ts
@@ -1,0 +1,14 @@
+import { Directive, ElementRef, AfterViewInit } from '@angular/core';
+
+@Directive({
+  selector: '[autoFocus]'
+})
+export class AutoFocus implements AfterViewInit {
+
+  constructor(private el: ElementRef) { }
+
+  ngAfterViewInit() {
+    this.el.nativeElement.focus();
+  }
+
+}

--- a/angular/src/directives/control-template/ifplatform.ts
+++ b/angular/src/directives/control-template/ifplatform.ts
@@ -1,0 +1,64 @@
+import {Directive,  Input, TemplateRef, ViewContainerRef, Renderer2} from '@angular/core';
+
+@Directive({
+  selector: '[ifPl]',
+})
+
+export class IfPlatform {
+  public _context: IfPlatformContext = new IfPlatformContext();
+  public _thenTemplateRef: TemplateRef<IfPlatformContext>|null = null;
+  public platform: string;
+  constructor(public _viewContainer: ViewContainerRef, public templateRef: TemplateRef<any>, public render: Renderer2) {
+    this._thenTemplateRef = templateRef;
+  }
+
+  onResize() {
+    this._context.$implicit = this._context.ifPlatform = IsThisPlateForm(window, this.platform);
+    this._updateView();
+  }
+
+  @Input('ifPl')
+  set myIfPl(platform: string) {
+    this.platform = platform;
+    this._context.$implicit = this._context.ifPlatform = IsThisPlateForm(window, platform);
+    console.log(IsThisPlateForm(window, platform))
+    this._updateView();
+    this.render.listen("window", "resize", this.onResize.bind(this));
+
+  }
+
+  private _updateView() {
+    if (!this._context.$implicit) {
+      this._viewContainer.clear();
+      this._context.see = false;
+    } else {
+      if(!this._context.see){
+        this._viewContainer.createEmbeddedView(this._thenTemplateRef, this._context);
+      }
+      this._context.see = true;
+    }
+  }
+}
+
+export class IfPlatformContext {
+  public $implicit: any = null;
+  public ifPlatform: any = null;
+  public see: boolean = false;
+}
+
+// TODO: Use the util provided by core/src/util
+export function IsThisPlateForm(win, pl){
+  let agent = win.navigator.userAgent;
+  switch (pl){
+    case "ios":
+      return (agent.match("/iPad|iPhone|iPod/i") || []).length > 0;
+    case "iPad":
+      return (agent.match("/iPad/i") || []).length > 0;
+    case "iPhone":
+      return (agent.match("/iPhone/i") || []).length > 0;
+    case "android":
+      return (agent.match(/Android/i) || []).length > 0;
+    case "wd":
+      return (agent.match(/Windows Phone/i) || []).length > 0;
+  }
+}

--- a/angular/src/directives/control-template/ifplatform.ts
+++ b/angular/src/directives/control-template/ifplatform.ts
@@ -3,8 +3,7 @@ import {Directive,  Input, TemplateRef, ViewContainerRef, Renderer2} from '@angu
 @Directive({
   selector: '[ifPl]',
 })
-
-export class IfPlatform {
+export class ifPlatform {
   public _context: IfPlatformContext = new IfPlatformContext();
   public _thenTemplateRef: TemplateRef<IfPlatformContext>|null = null;
   public platform: string;
@@ -13,18 +12,27 @@ export class IfPlatform {
   }
 
   onResize() {
-    this._context.$implicit = this._context.ifPlatform = IsThisPlateForm(window, this.platform);
+    if (this._context.inversed) {
+      this._context.$implicit = this._context.ifPlatform = !IsThisPlateForm(window, this.platform);
+    }else{
+      this._context.$implicit = this._context.ifPlatform = IsThisPlateForm(window, this.platform);
+    }
     this._updateView();
   }
 
   @Input('ifPl')
   set myIfPl(platform: string) {
-    this.platform = platform;
-    this._context.$implicit = this._context.ifPlatform = IsThisPlateForm(window, platform);
+    this.platform = this.ParsePlatform(platform);
+    if (this._context.inversed) {
+      this._context.$implicit = this._context.ifPlatform = !IsThisPlateForm(window, this.platform);
+    }else{
+      this._context.$implicit = this._context.ifPlatform = IsThisPlateForm(window, this.platform);
+    }
     this._updateView();
     this.render.listen("window", "resize", this.onResize.bind(this));
 
   }
+
 
   private _updateView() {
     if (!this._context.$implicit) {
@@ -35,6 +43,15 @@ export class IfPlatform {
         this._viewContainer.createEmbeddedView(this._thenTemplateRef, this._context);
       }
       this._context.see = true;
+
+    }
+  }
+
+  private ParsePlatform(pl: string) {
+    var splitted = pl.split("!");
+    if (splitted.length > 1) {
+      this._context.inversed = true;
+      return splitted[1]
     }
   }
 }
@@ -43,6 +60,7 @@ export class IfPlatformContext {
   public $implicit: any = null;
   public ifPlatform: any = null;
   public see: boolean = false;
+  public inversed: boolean = false;
 }
 
 // TODO: Use the util provided by core/src/util
@@ -60,5 +78,6 @@ export function IsThisPlateForm(win, pl){
     case "wd":
       return (agent.match(/Windows Phone/i) || []).length > 0;
   }
-  throw new Error(`there is no platform named : ${pl}. Use : ios, iPad, iPhone, android, wd instead.`)
+  throw new Error(`there is no platform named : ${pl}. Use : ios, iPad, iPhone, android, wd instead.`);
 }
+

--- a/angular/src/directives/control-template/ifplatform.ts
+++ b/angular/src/directives/control-template/ifplatform.ts
@@ -3,7 +3,7 @@ import {Directive,  Input, TemplateRef, ViewContainerRef, Renderer2} from '@angu
 @Directive({
   selector: '[ifPl]',
 })
-export class ifPlatform {
+export class IfPlatform {
   public _context: IfPlatformContext = new IfPlatformContext();
   public _thenTemplateRef: TemplateRef<IfPlatformContext>|null = null;
   public platform: string;

--- a/angular/src/directives/control-template/ifplatform.ts
+++ b/angular/src/directives/control-template/ifplatform.ts
@@ -60,4 +60,5 @@ export function IsThisPlateForm(win, pl){
     case "wd":
       return (agent.match(/Windows Phone/i) || []).length > 0;
   }
+  throw new Error(`there is no platform named : ${pl}. Use : ios, iPad, iPhone, android, wd instead.`)
 }

--- a/angular/src/directives/control-template/ifplatform.ts
+++ b/angular/src/directives/control-template/ifplatform.ts
@@ -21,7 +21,6 @@ export class IfPlatform {
   set myIfPl(platform: string) {
     this.platform = platform;
     this._context.$implicit = this._context.ifPlatform = IsThisPlateForm(window, platform);
-    console.log(IsThisPlateForm(window, platform))
     this._updateView();
     this.render.listen("window", "resize", this.onResize.bind(this));
 

--- a/angular/src/directives/control-template/ifwidth.ts
+++ b/angular/src/directives/control-template/ifwidth.ts
@@ -1,0 +1,90 @@
+import {Directive, Input, Renderer2, TemplateRef, ViewContainerRef} from '@angular/core';
+
+@Directive({
+  selector: '[ifWidth]'
+})
+export class IfWidth {
+  private _context: WidthContext = new WidthContext();
+  public _thenTemplateRef: TemplateRef<WidthContext>|null = null;
+
+  constructor(private _viewContainer: ViewContainerRef, templateRef: TemplateRef<WidthContext>, public render: Renderer2) {
+    this._thenTemplateRef = templateRef;
+  }
+
+  onResize(){
+    this._updateView();
+  }
+
+  @Input()
+  set ifWidth(width: string) {
+    this._context.$implicit = assertTemplate(width.toLowerCase())
+    this._context.asked = assertTemplate(width.toLowerCase())
+    this._updateView();
+    this.render.listen("window", "resize", this.onResize.bind(this));
+  }
+
+  private _updateView() {
+    this._context.condition = TestWidth(this._context.asked);
+    if (this._context.condition) {
+      if (!this._context.see) {
+        this._viewContainer.createEmbeddedView(this._thenTemplateRef, this._context);
+        this._context.see = true;
+      }
+    }else {
+      this._viewContainer.clear();
+      this._context.see = false;
+    }
+  }
+}
+
+export const BREAKDOWN = {
+  "xs": ">0",
+  "sm": ">576",
+  "md": ">768",
+  "lg": ">992",
+  "xl": ">1200"
+};
+
+export class WidthContext {
+  public $implicit: any = null;
+  public asked: string = null;
+  public see: boolean = false;
+  public condition: boolean = false;
+}
+
+export function TestWidth(asked) : boolean{
+  if(asked[0] == ">"){
+    if ( parseInt(asked.split(">")[1]) < window.innerWidth ){
+      return true
+    }
+  }else {
+    if ( parseInt(asked.split("<")[1]) > window.innerWidth ){
+      return true
+    }
+  }
+  return false;
+}
+
+export function assertTemplate(property: string) { // xs|sm|md|lg|xl|>452px
+  if (["xs", "sm", "md", "lg", "xl"].includes(property)){
+    return BREAKDOWN[property];
+  }
+  var beforePx = property.split("px")[0];
+  if (beforePx.length > 1){
+    if((beforePx[0]) == ">"){
+      if(isNaN(parseInt(beforePx.split(">")[1]))){
+        throw new Error(`${property} must be a value followed by 'px' (<785px).`);
+      }
+    }else if( (beforePx[0]) == "<"){
+      if(isNaN(parseInt(beforePx.split("<")[1]))){
+        throw new Error(`${property} must be a value followed by 'px' (<785px).`);
+      }
+    }else {
+      throw new Error(`${property} must begin by a comparator '>' or '<' (>785px).`);
+    }
+    return beforePx;
+  }
+
+  throw new Error(`${property} must be either a breakdown (xs, sm, md, lg, xl) or a value followed by 'px' (>785px).`);
+
+}

--- a/angular/src/directives/index.ts
+++ b/angular/src/directives/index.ts
@@ -21,3 +21,5 @@ export { VirtualFooter } from './virtual-scroll/virtual-footer';
 
 export { IfPlatform } from './control-template/ifplatform';
 export { IfWidth } from './control-template/ifwidth';
+
+export {AutoFocus} from "./control-element/autofocus";

--- a/angular/src/directives/index.ts
+++ b/angular/src/directives/index.ts
@@ -1,4 +1,3 @@
-
 export { BooleanValueAccessor } from './control-value-accessors/boolean-value-accessor';
 export { NumericValueAccessor } from './control-value-accessors/numeric-value-accesssor';
 export { RadioValueAccessor } from './control-value-accessors/radio-value-accessor';
@@ -19,3 +18,5 @@ export { VirtualScroll } from './virtual-scroll/virtual-scroll';
 export { VirtualItem } from './virtual-scroll/virtual-item';
 export { VirtualHeader } from './virtual-scroll/virtual-header';
 export { VirtualFooter } from './virtual-scroll/virtual-footer';
+
+export { IfPlatform } from './control-template/ifplatform';

--- a/angular/src/directives/index.ts
+++ b/angular/src/directives/index.ts
@@ -20,3 +20,4 @@ export { VirtualHeader } from './virtual-scroll/virtual-header';
 export { VirtualFooter } from './virtual-scroll/virtual-footer';
 
 export { IfPlatform } from './control-template/ifplatform';
+export { IfWidth } from './control-template/ifwidth';


### PR DESCRIPTION
Dynamically adding or removing the content to the DOM respectively to the asked platform/ breakdown.
Usage :
```
<my-block *ifPl="'android'"> // ios, iPad, iPhone, wd
    I hide myself when it's a non android platform...
</my-block>

<my-block *ifPl="'!android'"> // ios, iPad, iPhone, wd
    I hide myselft when it's an android platform...
</my-block>
```
```
<my-block *ifWidth="'md'"> // xs, sm, md, lg, xl
    I'm here on the md mode and plus!
</my-block>
// or
<my-block *ifWidth="'>1111px'"> // or '<457px'
  Hi I'm here only on the > 1111px window!
</my-block>
```

Auto focus an element:
```
<my-element autoFocus> 
</my-element>
```