### PR TITLE
Update file

### DIFF
--- a/src/components/tabs/tabs.ios.scss
+++ b/src/components/tabs/tabs.ios.scss
@@ -21,9 +21,6 @@ $tabs-ios-tab-padding-bottom:       $tabs-ios-tab-padding-top !default;
 /// @prop - Padding start on the tab button
 $tabs-ios-tab-padding-start:        $tabs-ios-tab-padding-end !default;
 
-/// @prop - Max width of the tab button
-$tabs-ios-tab-max-width:            240px !default;
-
 /// @prop - Minimum height of the tab button
 $tabs-ios-tab-min-height:           49px !default;
 


### PR DESCRIPTION
ios max width : 240 px  please delete this line. In ipad this is causing an issue tabs are not setting upto right and left edges. Please make this changes in this repository. 
or how to comment this line /*$tabs-ios-tab-max-width:240px;*/ for ios platform in ionic guide me please ! thanks

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x / 3.x / 4.x

**Fixes**: #
