### PR TITLE
docs(button): add example for icons

### DIFF
--- a/core/src/components/button/test/preview/index.html
+++ b/core/src/components/button/test/preview/index.html
@@ -75,6 +75,26 @@
           <ion-button id="dynamicColor1" onclick="changeColor(event)">Change Color</ion-button>
           <ion-button id="dynamicColor2" onclick="changeColor(event)" fill="outline">Change Color</ion-button>
         </p>
+        
+        <p>
+          <ion-button>
+            <ion-icon slot="start" name="star"></ion-icon>
+            Left Icon
+          </ion-button>
+        </p>
+
+        <p>
+          <ion-button>
+            Right Icon
+            <ion-icon slot="end" name="star"></ion-icon>
+          </ion-button>
+        </p>
+
+        <p>
+          <ion-button>
+            <ion-icon slot="icon-only" name="star"></ion-icon>
+          </ion-button>
+        </p>
 
       </ion-content>
 


### PR DESCRIPTION
add example to show how ion-icon works in ion-button using slot start, end and icon-only, like we can see in documentation https://beta.ionicframework.com/docs/api/button

**Ionic Version**: 1.x / 2.x / 3.x / 4.x
4.x