### PR TITLE
docs(MenuToggle): Fix Navbar Documentation Link

### DIFF
--- a/src/components/menu/menu-toggle.ts
+++ b/src/components/menu/menu-toggle.ts
@@ -9,7 +9,7 @@ import { ViewController } from '../../navigation/view-controller';
  * @name MenuToggle
  * @description
  * The `menuToggle` directive can be placed on any button to toggle a menu open or closed.
- * If it is added to the [NavBar](../../toolbar/Navbar) of a page, the button will only appear
+ * If it is added to the [Navbar](../toolbar/Navbar) of a page, the button will only appear
  * when the page it's in is currently a root page. See the [Menu Navigation Bar Behavior](../Menu#navigation-bar-behavior)
  * docs for more information.
  *


### PR DESCRIPTION
#### Short description of what this resolves:

There was a leftover broken link the in the MenuToggle docs

#### Changes proposed in this pull request:

- Update the first inline link to the correct

**Ionic Version**: 3.x

**Fixes**: #
