### PR TITLE
docs(FabButton): correct grammar mistake

### DIFF
--- a/src/components/fab/fab.ts
+++ b/src/components/fab/fab.ts
@@ -9,7 +9,7 @@ import { Ion } from '../ion';
   *
   * @description
   * FABs (Floating Action Buttons) are standard material design components. They are shaped as a circle that represents a promoted action. When pressed, it may contain more related actions.
-  * FABs as its name suggests are floating over the content in a fixed position. This is not achieved exclusively with `<button ion-fab>Button</button>` but it has to wrapped with the `<ion-fab>` component, like this:
+  * FABs as its name suggests are floating over the content in a fixed position. This is not achieved exclusively with `<button ion-fab>Button</button>` but it has to be wrapped with the `<ion-fab>` component, like this:
   *
   * ```html
   * <ion-content>


### PR DESCRIPTION
From "it has to wrapped" to "it has to be wrapped".

#### Short description of what this resolves:

This corrects a grammar mistake on the first paragraph of the [FabButton page](https://ionicframework.com/docs/api/components/fab/FabButton/).

#### Changes proposed in this pull request:

- Change the text _"it has to wrapped"_ to _"it has to be wrapped"_.

**Ionic Version**: 3.x

**Fixes**: #
