### PR TITLE
fix(list): scss for lines="none" on ios

### DIFF
--- a/core/src/components/list/list.ios.scss
+++ b/core/src/components/list/list.ios.scss
@@ -8,7 +8,7 @@
   @include margin(-1px, $list-ios-margin-end, $list-ios-margin-bottom, $list-ios-margin-start);
 }
 
-.list-ios:not(.list-inset) .item:last-child {
+.list-ios:not(.list-inset):not(.list-ios-lines-none) .item:last-child {
   --inner-border-width: 0;
   --border-width: #{0 0 $list-ios-item-border-bottom-width 0};
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Fixes an issue where list items in ios mode still had lines with `lines="none"` set.

#### Changes proposed in this pull request:

- Don't apply this scss rule that sets border width, if lines="none".

**Ionic Version**: 4.x

**Fixes**: #14769
