### PR TITLE
feat(content): set height to make it accessible for childs

### DIFF
--- a/core/src/components/content/content.scss
+++ b/core/src/components/content/content.scss
@@ -39,6 +39,7 @@
 .scroll-inner {
   @include padding(var(--padding-top), var(--padding-end), calc(var(--padding-bottom) + var(--keyboard-offset)), var(--padding-start));
 
+  height: 100%;
   min-height: 100%;
   box-sizing: border-box;
   -webkit-margin-collapse: discard;


### PR DESCRIPTION
#### Short description of what this resolves:
Makes height of content available for childs.

#### Changes proposed in this pull request:

- add height: 100%; to scroll-inner class of content component.

**Ionic Version**:   4.x

**Fixes**: #14771 