### PR TITLE
Correct loadingController options parameter

### DIFF
--- a/core/src/components/loading/usage/angular.md
+++ b/core/src/components/loading/usage/angular.md
@@ -12,7 +12,7 @@ export class LoadingExample {
 
   async presentLoading() {
     const loading = await this.loadingController.create({
-      message: 'Hellooo',
+      content: 'Hellooo',
       duration: 2000
     });
     return await loading.present();


### PR DESCRIPTION
#### Short description of what this resolves:
LoadingOptions in the loadingController takes "content" as a parameter instead of "message"

#### Changes proposed in this pull request:
Change "message" by "content"

**Ionic Version**: 4.x
