### PR TITLE
fix(menu): menu closing when taping in an higher component

### DIFF
--- a/core/src/components/menu/menu.tsx
+++ b/core/src/components/menu/menu.tsx
@@ -187,7 +187,7 @@ export class Menu {
   @Listen('body:click', { enabled: false, capture: true })
   onBackdropClick(ev: any) {
     const path = ev.path;
-    if (path && !path.includes(this.menuInnerEl) && this.lastOnEnd < ev.timeStamp - 100) {
+    if (path && path.includes(this.backdropEl) && this.lastOnEnd < ev.timeStamp - 100) {
       ev.preventDefault();
       ev.stopPropagation();
       this.close();


### PR DESCRIPTION
#### Short description of what this resolves:

Fixes closing of menu when tapping in an higher component.

#### Changes proposed in this pull request:

Fire the backdropClick of when the background is clicked. :) Not only if the content is not clicked...

**Ionic Version**:  4.0.0 alpha

**Fixes**: #14816
