### PR TITLE
fix: add name property to checkbox and radio alert

### DIFF
--- a/core/src/components/alert/test/preview/index.html
+++ b/core/src/components/alert/test/preview/index.html
@@ -182,32 +182,38 @@
           {
             type: 'radio',
             label: 'Radio 1',
+            name: 'Radio 1',
             value: 'value1',
             checked: true
           },
           {
             type: 'radio',
             label: 'Radio 2',
+            name: 'Radio 2',
             value: 'value2'
           },
           {
             type: 'radio',
             label: 'Radio 3',
+            name: 'Radio 3',
             value: 'value3'
           },
           {
             type: 'radio',
             label: 'Radio 4',
+            name: 'Radio 4',
             value: 'value4'
           },
           {
             type: 'radio',
             label: 'Radio 5',
+            name: 'Radio 5',
             value: 'value5'
           },
           {
             type: 'radio',
             label: 'Radio 6 Radio 6 Radio 6 Radio 6 Radio 6 Radio 6 Radio 6 Radio 6 Radio 6 Radio 6 ',
+            name: 'Radio 6',
             value: 'value6'
           }
         ],
@@ -241,6 +247,7 @@
           {
             type: 'checkbox',
             label: 'Checkbox 1',
+            name: 'Checkbox 1',
             value: 'value1',
             checked: true
           },
@@ -248,30 +255,35 @@
           {
             type: 'checkbox',
             label: 'Checkbox 2',
+            name: 'Checkbox 2',
             value: 'value2'
           },
 
           {
             type: 'checkbox',
             label: 'Checkbox 3',
+            name: 'Checkbox 3',
             value: 'value3'
           },
 
           {
             type: 'checkbox',
             label: 'Checkbox 4',
+            name: 'Checkbox 4',
             value: 'value4'
           },
 
           {
             type: 'checkbox',
             label: 'Checkbox 5',
+            name: 'Checkbox 5',
             value: 'value5'
           },
 
           {
             type: 'checkbox',
             label: 'Checkbox 6 Checkbox 6 Checkbox 6 Checkbox 6 Checkbox 6 Checkbox 6 Checkbox 6 Checkbox 6 Checkbox 6 Checkbox 6',
+            name: 'Checkbox 6',
             value: 'value6'
           }
         ],


### PR DESCRIPTION
added the `name` property which is required to checkbox and radio input data

#### Short description of what this resolves:
fixes a bug in Ionic 4 alert examples

#### Changes proposed in this pull request:

- adding the `name` property to the alert inputs

**Ionic Version**: 4.x
