### PR TITLE
Update event options to match new version of Swiper

### DIFF
--- a/angular/src/directives/proxies.ts
+++ b/angular/src/directives/proxies.ts
@@ -623,8 +623,11 @@ export class Slide {
 }
 
 export declare interface Slides extends StencilComponents.IonSlides {}
-@Directive({selector: 'ion-slides', inputs: ['options', 'pager', 'scrollbar'], outputs: ['ionSlideWillChange', 'ionSlideDidChange', 'ionSlideNextStart', 'ionSlidePrevStart', 'ionSlideNextEnd', 'ionSlidePrevEnd', 'ionSlideTransitionStart', 'ionSlideTransitionEnd', 'ionSlideDrag', 'ionSlideReachStart', 'ionSlideReachEnd', 'ionSlideTouchStart', 'ionSlideTouchEnd']})
+@Directive({selector: 'ion-slides', inputs: ['options', 'pager', 'scrollbar'], outputs: ['ionSlidesDidLoad', 'ionSlideTap', 'ionSlideDoubleTap', 'ionSlideWillChange', 'ionSlideDidChange', 'ionSlideNextStart', 'ionSlidePrevStart', 'ionSlideNextEnd', 'ionSlidePrevEnd', 'ionSlideTransitionStart', 'ionSlideTransitionEnd', 'ionSlideDrag', 'ionSlideReachStart', 'ionSlideReachEnd', 'ionSlideTouchStart', 'ionSlideTouchEnd']})
 export class Slides {
+  ionSlidesDidLoad: EventEmitter<any>;
+  ionSlideTap: EventEmitter<any>;
+  ionSlideDoubleTap: EventEmitter<any>;
   ionSlideWillChange: EventEmitter<any>;
   ionSlideDidChange: EventEmitter<any>;
   ionSlideNextStart: EventEmitter<any>;
@@ -641,7 +644,7 @@ export class Slides {
   constructor(r: ElementRef) {
     proxyMethods(this, r, ['update', 'slideTo', 'slideNext', 'slidePrev', 'getActiveIndex', 'getPreviousIndex', 'length', 'isEnd', 'isBeginning', 'startAutoplay', 'stopAutoplay', 'lockSwipeToNext', 'lockSwipeToPrev', 'lockSwipes']);
     proxyInputs(this, r, ['options', 'pager', 'scrollbar']);
-    proxyOutputs(this, ['ionSlideWillChange', 'ionSlideDidChange', 'ionSlideNextStart', 'ionSlidePrevStart', 'ionSlideNextEnd', 'ionSlidePrevEnd', 'ionSlideTransitionStart', 'ionSlideTransitionEnd', 'ionSlideDrag', 'ionSlideReachStart', 'ionSlideReachEnd', 'ionSlideTouchStart', 'ionSlideTouchEnd']);
+    proxyOutputs(this, ['ionSlidesDidLoad', 'ionSlideTap', 'ionSlideDoubleTap', 'ionSlideWillChange', 'ionSlideDidChange', 'ionSlideNextStart', 'ionSlidePrevStart', 'ionSlideNextEnd', 'ionSlidePrevEnd', 'ionSlideTransitionStart', 'ionSlideTransitionEnd', 'ionSlideDrag', 'ionSlideReachStart', 'ionSlideReachEnd', 'ionSlideTouchStart', 'ionSlideTouchEnd']);
   }
 }
 

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -6787,6 +6787,10 @@ declare global {
        */
       'onIonSlideDidChange'?: (event: CustomEvent) => void;
       /**
+       * Emitted when the user double taps on the slide's container.
+       */
+      'onIonSlideDoubleTap'?: (event: CustomEvent) => void;
+      /**
        * Emitted when the slider is actively being moved.
        */
       'onIonSlideDrag'?: (event: CustomEvent) => void;
@@ -6815,6 +6819,10 @@ declare global {
        */
       'onIonSlideReachStart'?: (event: CustomEvent) => void;
       /**
+       * Emitted when the user taps/clicks on the slide's container.
+       */
+      'onIonSlideTap'?: (event: CustomEvent) => void;
+      /**
        * Emitted when the user releases the touch.
        */
       'onIonSlideTouchEnd'?: (event: CustomEvent) => void;
@@ -6834,6 +6842,10 @@ declare global {
        * Emitted before the active slide has changed.
        */
       'onIonSlideWillChange'?: (event: CustomEvent) => void;
+      /**
+       * Emitted after Swiper initialization
+       */
+      'onIonSlidesDidLoad'?: (event: CustomEvent) => void;
       /**
        * Options to pass to the swiper instance. See http://idangero.us/swiper/api/ for valid options
        */

--- a/core/src/components/slides/readme.md
+++ b/core/src/components/slides/readme.md
@@ -74,6 +74,11 @@ If true, show the scrollbar. Defaults to `false`.
 Emitted after the active slide has changed.
 
 
+#### ionSlideDoubleTap
+
+Emitted when the user double taps on the slide's container.
+
+
 #### ionSlideDrag
 
 Emitted when the slider is actively being moved.
@@ -109,6 +114,11 @@ Emitted when the slider is at the last slide.
 Emitted when the slider is at its initial position.
 
 
+#### ionSlideTap
+
+Emitted when the user taps/clicks on the slide's container.
+
+
 #### ionSlideTouchEnd
 
 Emitted when the user releases the touch.
@@ -132,6 +142,11 @@ Emitted when the slide transition has started.
 #### ionSlideWillChange
 
 Emitted before the active slide has changed.
+
+
+#### ionSlidesDidLoad
+
+Emitted after Swiper initialization
 
 
 ## Methods

--- a/core/src/components/slides/slides.tsx
+++ b/core/src/components/slides/slides.tsx
@@ -21,6 +21,21 @@ export class Slides {
   @Element() el!: HTMLStencilElement;
 
   /**
+   * Emitted after Swiper initialization
+   */
+  @Event() ionSlidesDidLoad!: EventEmitter;
+
+  /**
+   * Emitted when the user taps/clicks on the slide's container.
+   */
+  @Event() ionSlideTap!: EventEmitter;
+
+  /**
+   * Emitted when the user double taps on the slide's container.
+   */
+  @Event() ionSlideDoubleTap!: EventEmitter;
+
+  /**
    * Emitted before the active slide has changed.
    */
   @Event() ionSlideWillChange!: EventEmitter;
@@ -347,19 +362,28 @@ export class Slides {
     // Keep the event options separate, we dont want users
     // overwriting these
     const eventOptions = {
-      onSlideChangeStart: this.ionSlideWillChange.emit,
-      onSlideChangeEnd: this.ionSlideDidChange.emit,
-      onSlideNextStart: this.ionSlideNextStart.emit,
-      onSlidePrevStart: this.ionSlidePrevStart.emit,
-      onSlideNextEnd: this.ionSlideNextEnd.emit,
-      onSlidePrevEnd: this.ionSlidePrevEnd.emit,
-      onTransitionStart: this.ionSlideTransitionStart.emit,
-      onTransitionEnd: this.ionSlideTransitionEnd.emit,
-      onSliderMove: this.ionSlideDrag.emit,
-      onReachBeginning: this.ionSlideReachStart.emit,
-      onReachEnd: this.ionSlideReachEnd.emit,
-      onTouchStart: this.ionSlideTouchStart.emit,
-      onTouchEnd: this.ionSlideTouchEnd.emit
+      on: {
+        init: () => {
+          setTimeout(() => {
+            this.ionSlidesDidLoad.emit();
+          }, 20);
+        },
+        slideChangeTransitionStart: this.ionSlideWillChange.emit,
+        slideChangeTransitionEnd: this.ionSlideDidChange.emit,
+        slideNextTransitionStart: this.ionSlideNextStart.emit,
+        slidePrevTransitionStart: this.ionSlidePrevStart.emit,
+        slideNextTransitionEnd: this.ionSlideNextEnd.emit,
+        slidePrevTransitionEnd: this.ionSlidePrevEnd.emit,
+        transitionStart: this.ionSlideTransitionStart.emit,
+        transitionEnd: this.ionSlideTransitionEnd.emit,
+        sliderMove: this.ionSlideDrag.emit,
+        reachBeginning: this.ionSlideReachStart.emit,
+        reachEnd: this.ionSlideReachEnd.emit,
+        touchStart: this.ionSlideTouchStart.emit,
+        touchEnd: this.ionSlideTouchEnd.emit,
+        tap: this.ionSlideTap.emit,
+        doubleTap: this.ionSlideDoubleTap.emit
+      }
     };
 
     // Merge the base, user options, and events together then pas to swiper

--- a/core/src/components/slides/slides.tsx
+++ b/core/src/components/slides/slides.tsx
@@ -403,7 +403,7 @@ export class Slides {
           <slot></slot>
         </div>
         { this.pager ? <div class="swiper-pagination"></div> : null }
-        { this.scrollbar ? <div class="swiper-scrollbar"></div> : null }
+        <div class="swiper-scrollbar" hidden={!this.scrollbar}/>
       </div>
     );
   }

--- a/core/src/components/slides/test/basic/index.html
+++ b/core/src/components/slides/test/basic/index.html
@@ -142,6 +142,15 @@
     slides.addEventListener('ionSlideTouchEnd', function (e) {
       console.log('slide touch end', e)
     });
+    slides.addEventListener('ionSlidesDidLoad', function (e) {
+      console.log('slides did load', e)
+    });
+    slides.addEventListener('ionSlideTap', function (e) {
+      console.log('slide tapped', e)
+    });
+    slides.addEventListener('ionSlideDoubleTap', function (e) {
+      console.log('slide double-tapped', e)
+    });
   </script>
 </body>
 


### PR DESCRIPTION
#### Short description of what this resolves:
Some of the Swiper options have been re-named/re-structured: http://idangero.us/swiper/api/#events

When navigating away from a page that contained `<ion-slides  scrollbar={false}>` you'd receive an error:

> Uncaught TypeError: Cannot read property 'removeEventListener' of undefined
    at Swiper.disableDraggable (ion-anchor.md.js:8691)
    at Swiper.destroy (ion-anchor.md.js:8770)
    at Swiper.destroy (ion-anchor.md.js:8837)
    at ion-anchor.md.js:3370
    at Array.forEach (<anonymous>)
    at ion-anchor.md.js:3369
    at Array.forEach (<anonymous>)
    at Swiper.emit (ion-anchor.md.js:3363)
    at Swiper.destroy (ion-anchor.md.js:6827)
    at Slides.componentDidUnload (ion-anchor.md.js:11703)

 
It looks like Swiper expects the scrollbar div to be in the dom.

#### Changes proposed in this pull request:
Add events: 
- ionSlidesDidLoad
- ionSlideTap
- ionSlideDoubleTap

Fix:
- The structure and names in `eventOptions`.
- Keep swiper-scrollbar in dom and instead add a hidden attribute

**Ionic Version**: 4.0.0-beta.0

**Fixes**: #14859, #14822
