### PR TITLE
fix(router-outlet): fix stack attribute detection

### DIFF
--- a/angular/src/directives/navigation/ion-router-outlet.ts
+++ b/angular/src/directives/navigation/ion-router-outlet.ts
@@ -32,7 +32,7 @@ export class IonRouterOutlet implements OnDestroy, OnInit {
   ) {
     this.name = name || PRIMARY_OUTLET;
     parentContexts.onChildOutletCreated(this.name, this as any);
-    const hasStack = stack !== 'false' || stack !== false;
+    const hasStack = stack !== 'false' && stack !== false;
     this.stackCtrl = new StackController(hasStack, elementRef.nativeElement, router, this.navCtrl);
   }
 


### PR DESCRIPTION
(stack !== 'false' OR stack !== false) will always be TRUE. That OR should be an AND.

#### Short description of what this resolves:

Stack Attribute was not working on `ion-router-outlet`

**Ionic Version**: 4.x
