### PR TITLE
feat(button): allow material design button text transform to be confi…

### DIFF
--- a/core/src/components/button/button.md.scss
+++ b/core/src/components/button/button.md.scss
@@ -17,7 +17,8 @@
   --padding-bottom: #{$button-md-padding-bottom};
   --padding-start: #{$button-md-padding-start};
   --padding-end: #{$button-md-padding-end};
-  --height: #{$button-md-height};
+	--height: #{$button-md-height};
+	--text-transform: #{$button-md-text-transform};
 
   font-family: #{$button-md-font-family};
   font-size: #{$button-md-font-size};
@@ -25,7 +26,7 @@
 
   letter-spacing: #{$button-md-letter-spacing};
 
-  text-transform: #{$button-md-text-transform};
+  text-transform: var(--text-transform);
 }
 
 // Material Design Solid Button


### PR DESCRIPTION
…gured via css variable (#14927)

#### Short description of what this resolves:

Allows developers to override text transform style for material design buttons

#### Changes proposed in this pull request:

- use css variable for material design button text-transform

**Ionic Version**: 4.x

**Fixes**: #14927
