### PR TITLE
style(#14996) [Ionic v4] Add height 100% to .scroll-inner

### DIFF
--- a/core/src/components/content/content.scss
+++ b/core/src/components/content/content.scss
@@ -43,6 +43,7 @@
 
   box-sizing: border-box;
 
+  height: 100%;
   min-height: 100%;
   -webkit-margin-collapse: discard;
 }


### PR DESCRIPTION
#### Short description of what this resolves:

If you use an `ion-scroll` (scroll-y) inside an `ion-content` it isn't possible to set its height in percent because the height of the element `ion-scroll div.scroll-inner` isn't specified

Adding `height: 100%` to `ion-scroll div.scroll-inner` resolves the problem

See screenshots in https://github.com/ionic-team/ionic/issues/14996 for a visual representation of the problem

#### Changes proposed in this pull request:

- Set `height: 100%` to `ion-scroll div.scroll-inner`

**Ionic Version**:
v4

**Issues**
This PR solves https://github.com/ionic-team/ionic/issues/14996 and might solves https://github.com/ionic-team/ionic/issues/14985 too