### PR TITLE
Fixed case-sensitive Slides/slides link

### DIFF
--- a/core/src/components/slide/readme.md
+++ b/core/src/components/slide/readme.md
@@ -1,10 +1,10 @@
 # ion-slide
 
-The Slide component is a child component of [Slides](../Slides). The template
+The Slide component is a child component of [Slides](../slides). The template
 should be written as `ion-slide`. Any slide content should be written
-in this component and it should be used in conjunction with [Slides](../Slides).
+in this component and it should be used in conjunction with [Slides](../slides).
 
-See the [Slides API Docs](../Slides) for more usage information.
+See the [Slides API Docs](../slides) for more usage information.
 
 
 <!-- Auto Generated Below -->


### PR DESCRIPTION
Links were pointing to https://beta.ionicframework.com/docs/api/Slides (upper-case 'S') when they should be pointing to "https://beta.ionicframework.com/docs/api/slides" (lower-case 's').

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x / 3.x / 4.x

**Fixes**: #
