### PR TITLE
fix(menu): backdrop dismiss only working in Chrome

### DIFF
--- a/core/src/components/menu/menu.tsx
+++ b/core/src/components/menu/menu.tsx
@@ -214,7 +214,7 @@ export class Menu {
 
   @Listen('body:click', { enabled: false, capture: true })
   onBackdropClick(ev: any) {
-    const path = ev.path;
+    const path = ev.composedPath();
     if (path && !path.includes(this.menuInnerEl) && this.lastOnEnd < ev.timeStamp - 100) {
       ev.preventDefault();
       ev.stopPropagation();


### PR DESCRIPTION
#### Short description of what this resolves:
Menus don't dismiss when tapping the backdrop in browsers other than Chrome. This is because `event.path` returns `undefined` in other browsers.

#### Changes proposed in this pull request:

- Use `composedPath()` instead of `path` ([Event.composedPath()](https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath))

**Ionic Version**: 4.0.0-beta.1