### PR TITLE
fix(select): explicitly return true from alert OK

### DIFF
--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -396,7 +396,10 @@ export class Select extends BaseInput<any> implements OnDestroy {
 
       (overlay as Alert).addButton({
         text: this.okText,
-        handler: (selectedValues: any) => this.value = selectedValues
+        handler: (selectedValues: any) => {
+          this.value = selectedValues;
+          return true;
+        }
       });
 
     }

--- a/src/components/select/test/single-value/e2e.ts
+++ b/src/components/select/test/single-value/e2e.ts
@@ -1,5 +1,20 @@
-import { by, element } from 'protractor';
+import { browser, by, element, protractor } from 'protractor';
 
 it('should open gender single select', function() {
   element(by.css('.e2eSelectGender button')).click();
+});
+
+it('should select a false value and close', function() {
+  // Open the boolean alert
+  element(by.css('.e2eSelectBoolean button')).click();
+  // Click on the "false" value
+  element(by.css('#alert-input-0-1')).click();
+  // Click OK
+  element.all(by.css('.alert-button-group .alert-button')).last().click();
+
+  browser.wait(
+    protractor.ExpectedConditions.stalenessOf(
+      element(by.css('.select-alert'))
+    ), 500
+  );
 });

--- a/src/components/select/test/single-value/pages/page-one/page-one.html
+++ b/src/components/select/test/single-value/pages/page-one/page-one.html
@@ -172,4 +172,12 @@
     </ion-select>
   </ion-item>
 
+  <ion-item>
+    <ion-label>Boolean Values</ion-label>
+    <ion-select [(ngModel)]="booleanValue" class="e2eSelectBoolean">
+      <ion-option [value]="true">True</ion-option>
+      <ion-option [value]="false">False</ion-option>
+    </ion-select>
+  </ion-item>
+
 </ion-content>

--- a/src/components/select/test/single-value/pages/page-one/page-one.ts
+++ b/src/components/select/test/single-value/pages/page-one/page-one.ts
@@ -61,6 +61,7 @@ export class PageOne {
   fruitsForm = new FormGroup({
     'fruit': this.fruitCtrl
   });
+  booleanValue: boolean = true;
 
   constructor() {
     this.currency = this.currencies[0];


### PR DESCRIPTION
#### Short description of what this resolves:
If an ion-option has a falsy value and the ion-select uses an alert component to display options, the alert will never close because the `handle` method returns the falsy value.

#### Changes proposed in this pull request:

- Explicitly return true from the handle method of the OK button

**Ionic Version**: 3.x

**Fixes**: #12858 
