### PR TITLE
Update readme.md

### DIFF
--- a/core/src/components/alert/readme.md
+++ b/core/src/components/alert/readme.md
@@ -1,6 +1,6 @@
 # ion-alert
 
-An Alert is a dialog that presents users with information or collects information from the user using inputs. An alert appears on top of the app's content, and must be manually dismissed by the user before they can resume interaction with the app. It can also optionally have a `title`, `subTitle` and `message`.
+An Alert is a dialog that presents users with information or collects information from the user using inputs. An alert appears on top of the app's content, and must be manually dismissed by the user before they can resume interaction with the app. It can also optionally have a `header`, `subHeader` and `message`.
 
 
 ### Creating


### PR DESCRIPTION
#### Short description of what this resolves:
'title' does not exist in type 'AlertOptions' in Ionic 4

#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x / 3.x / 4.x
4.0.0-beta.0

**Fixes**: #
Documentation