### PR TITLE
fix(css): ion-item-background > ion-item-background-color

### DIFF
--- a/core/src/components/card/card.ios.scss
+++ b/core/src/components/card/card.ios.scss
@@ -5,7 +5,7 @@
 // --------------------------------------------------
 
 :host {
-  --ion-color-base: var(--ion-item-background, transparent);
+  --ion-color-base: var(--ion-item-background-color, transparent);
   --ion-color-contrast: #{$card-ios-text-color};
 
   @include margin($card-ios-margin-top, $card-ios-margin-end, $card-ios-margin-bottom, $card-ios-margin-start);

--- a/core/src/components/card/card.md.scss
+++ b/core/src/components/card/card.md.scss
@@ -5,7 +5,7 @@
 // --------------------------------------------------
 
 :host {
-  --ion-color-base: var(--ion-item-background, transparent);
+  --ion-color-base: var(--ion-item-background-color, transparent);
   --ion-color-contrast: #{$card-md-text-color};
 
   @include margin($card-md-margin-top, $card-md-margin-end, $card-md-margin-bottom, $card-md-margin-start);

--- a/core/src/components/item/item.ios.scss
+++ b/core/src/components/item/item.ios.scss
@@ -5,7 +5,7 @@
 // --------------------------------------------------
 
 :host {
-  --ion-color-base: var(--ion-item-background, transparent);
+  --ion-color-base: var(--ion-item-background-color, transparent);
   --ion-color-contrast: #{$item-ios-text-color};
   --ion-color-tint: #{$item-ios-background-color-active};
   --ion-color-shade: #{$item-ios-border-bottom-color};

--- a/core/src/components/item/item.md.scss
+++ b/core/src/components/item/item.md.scss
@@ -5,7 +5,7 @@
 // --------------------------------------------------
 
 :host {
-  --ion-color-base: var(--ion-item-background, transparent);
+  --ion-color-base: var(--ion-item-background-color, transparent);
   --ion-color-contrast: #{$item-md-text-color};
   --ion-color-tint: #{$item-md-background-color-active};
   --ion-color-shade: #{$item-md-border-bottom-color};


### PR DESCRIPTION
#### Short description of what this resolves:
I might be mistaken, but I believe the card and item components were referencing `--ion-item-background` instead of `--ion-item-background-color`.

#### Changes proposed in this pull request:

- item.ios.scss: --ion-item-background > --ion-item-background-color
- item.md.scss: --ion-item-background > --ion-item-background-color
- card.ios.scss: --ion-item-background > --ion-item-background-color
- card.md.scss: --ion-item-background > --ion-item-background-color

**Ionic Version**: 1.x / 2.x / 3.x / 4.x
4.x