### PR TITLE
Include example options for the lines property

### DIFF
--- a/core/src/components/list/readme.md
+++ b/core/src/components/list/readme.md
@@ -39,6 +39,7 @@ If true, the list will have margin around it and rounded corners. Defaults to `f
 string
 
 How the bottom border should be displayed on all items.
+Default options are: `"full"`, `"inset"`, or `"none"`.
 
 
 ## Methods


### PR DESCRIPTION
#### Short description of what this resolves:
Couldnt find the available options for the lines property of the ion-list component.

#### Changes proposed in this pull request:
Includes the 3 options for the lines property.
-
-
-

**Ionic Version**: 4.x

**Fixes**: #
