### PR TITLE
Replace ion-navbar with ion-toolbar

### DIFF
--- a/core/src/components/header/usage/javascript.md
+++ b/core/src/components/header/usage/javascript.md
@@ -1,8 +1,11 @@
 ```html
 <ion-header>
-  <ion-navbar>
-    <ion-title>Page1</ion-title>
-  </ion-navbar>
+  <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-back-button></ion-back-button>
+    </ion-buttons>
+    <ion-title>My Navigation Bar</ion-title>
+  </ion-toolbar>
 
   <ion-toolbar>
     <ion-title>Subheader</ion-title>


### PR DESCRIPTION
The header still has an old example of `ion-navbar`.

#### Short description of what this resolves:

Update docs with breaking change.


#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 4.x

**Fixes**: #
