### PR TITLE
Fix the link to select api docs

### DIFF
--- a/core/src/components/select-option/readme.md
+++ b/core/src/components/select-option/readme.md
@@ -1,6 +1,6 @@
 # ion-select-option
 
-SelectOption is a component that is a child element of Select. For more information, see the [Select docs](../select).
+SelectOption is a component that is a child element of Select. For more information, see the [Select docs](./select).
 
 
 <!-- Auto Generated Below -->


### PR DESCRIPTION
#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x / 3.x / 4.x

**Fixes**: #
