### PR TITLE
Allow placeholder-style CSS variable

### DIFF
--- a/core/src/components/textarea/textarea.scss
+++ b/core/src/components/textarea/textarea.scss
@@ -20,6 +20,7 @@
   --color: currentColor;
   --placeholder-color: currentColor;
   --placeholder-weight: inherit;
+  --placeholder-style: inherit;
   --placeholder-opacity: .5;
   --padding-top: 0;
   --padding-end: 0;
@@ -84,6 +85,7 @@
 
     font-family: inherit;
     font-weight: var(--placeholder-weight);
+    font-style: var(--placeholder-style);
 
     opacity: var(--placeholder-opacity);
   }


### PR DESCRIPTION
#### Short description of what this resolves:

Allows styling the font-style of the placeholder UI inside the text-area. For example to make it italic. 


#### Changes proposed in this pull request:
- Adds new `--placeholder-style` CSS variable 

**Ionic Version**: 4

