### PR TITLE
fix: Fix scrollAssist boolean instead of string definition

### DIFF
--- a/core/src/global/config.ts
+++ b/core/src/global/config.ts
@@ -23,7 +23,7 @@ export interface IonicConfig {
   menuType?: string;
   scrollPadding?: string;
   inputBlurring?: string;
-  scrollAssist?: string;
+  scrollAssist?: boolean;
   hideCaretOnScroll?: string;
   infiniteLoadingSpinner?: string;
   keyboardHeight?: number;


### PR DESCRIPTION
#### Short description of what this resolves:

This resolves https://github.com/ionic-team/ionic/issues/15202 respectively it fix the definition of `scrollAssist` in `config.ts` by declaring it as `boolean` instead of `string` as introduced in v4.beta-3

**Ionic Version**:

v4
