### PR TITLE
card header text wraps by default

### DIFF
--- a/core/src/components/card-header/card-header.scss
+++ b/core/src/components/card-header/card-header.scss
@@ -6,10 +6,4 @@
 :host {
   display: block;
   position: relative;
-
-  text-overflow: ellipsis;
-
-  white-space: nowrap;
-
-  overflow: hidden;
 }


### PR DESCRIPTION
#### Short description of what this resolves:
The current scss implementation of card headers assumes that long text should be hidden by default. For designs that can't guarantee content length, it is better to default to wrapping long text.

To get around the current implementation, developers must remember to add the 'text-wrap' attribute to every instance of <card-header>, which invites gaps in coverage once projects mature with many pages. That, or they will have to overwrite the card header component's properties.

#### Changes proposed in this pull request:

- Remove css that assumes long content should hide instead of wrap.

**Ionic Version**: 1.x / 2.x / 3.x / 4.x

Before:
![card-text-hidden](https://user-images.githubusercontent.com/9669144/44222644-2c285b80-a153-11e8-9cec-21416b85e4a5.PNG)

After:
![card-text-wrap](https://user-images.githubusercontent.com/9669144/44222645-2c285b80-a153-11e8-8544-d285b67425f2.PNG)
