### PR TITLE
Check that swiper is defined, prior to destroying

### DIFF
--- a/core/src/components/slides/slides.tsx
+++ b/core/src/components/slides/slides.tsx
@@ -130,7 +130,9 @@ export class Slides {
   }
 
   componentDidUnload() {
-    this.swiper.destroy(true, true);
+    if (this.swiper) {
+      this.swiper.destroy(true, true);
+    }
   }
 
   private initSlides() {


### PR DESCRIPTION
#### Short description of what this resolves:

When combining the swiper control with Angular bound animations, occasionally there is a race condition where Angular destroys the component before the Stencil component can destroy itself. 

i.e.:

```
<ng-container *ngIf="someCondition; then loadingTemplate; else sliderTemplate"></ng-container>

<ng-template #loadingTemplate>
   <ion-spinner></ion-spinner>
</ng-template>

<ng-template #sliderTemplate>
   <ion-slides #slider [options]="slideOpts">
      <ion-slide *ngFor="let item of items">
         <ng-container *ngTemplateOutlet="slide; context: { $implicit: item }"></ng-container>
      </ion-slide>
   </ion-slides>
</ng-template>

<ng-template let-item #slide>
   <div class="some-container" [@fadeAnimation]="'in'">
   </div>
</ng-template>
```

Where fadeAnimation is:
```
trigger('fadeAnimation', [
    state('in', style({ opacity: 1 })),
    transition(':enter', [
        style({ opacity: 0 }),
        animate(350)
    ]),
    transition(':leave', [
        animate(350, style({ opacity: 0 }))
    ])
])
```

Results in the following error (occasionally - whenever Angular cycles first).
```
console.js:35 TypeError: Cannot read property 'destroy' of undefined
    at e.componentDidUnload (doewca4g.js:5)
    at t (ionic.core.js:6)
    at HTMLElement.i.disconnectedCallback (ionic.core.js:6)
    at EmulatedEncapsulationDomRenderer2.push.../../node_modules/@angular/platform-browser/fesm5/platform-browser.js.DefaultDomRenderer2.removeChild (platform-browser.js:1072)
    at InjectableAnimationEngine.AnimationRendererFactory.engine.onRemovalComplete (animations.js:119)
    at TransitionAnimationEngine.AnimationEngine._transitionEngine.onRemovalComplete (browser.js:3806)
    at TransitionAnimationEngine.push.../../node_modules/@angular/animations/fesm5/browser.js.TransitionAnimationEngine._onRemovalComplete (browser.js:2733)
    at AnimationTransitionNamespace.push.../../node_modules/@angular/animations/fesm5/browser.js.AnimationTransitionNamespace.removeNode (browser.js:2650)
    at TransitionAnimationEngine.push.../../node_modules/@angular/animations/fesm5/browser.js.TransitionAnimationEngine.removeNode (browser.js:2905)
    at InjectableAnimationEngine.push.../../node_modules/@angular/animations/fesm5/browser.js.AnimationEngine.onRemove (browser.js:3833)
    at AnimationRenderer.push.../../node_modules/@angular/platform-browser/fesm5/animations.js.BaseAnimationRenderer.removeChild (animations.js:234)
    at DebugRenderer2.push.../../node_modules/@angular/core/fesm5/core.js.DebugRenderer2.removeChild (core.js:11454)
    at execRenderNodeAction (core.js:7919)
    at visitRenderNode (core.js:7896)
    at visitSiblingRenderNodes (core.js:7845)
    at visitRootRenderNodes (core.js:7839)
    at renderDetachView (core.js:8581)
    at detachEmbeddedView (core.js:8539)
    at ViewContainerRef_.push.../../node_modules/@angular/core/fesm5/core.js.ViewContainerRef_.clear (core.js:874
```

#### Changes proposed in this pull request:
- Just a simple `if` check that the component is defined, prior to destroying. 

**Ionic Version**: 4