### PR TITLE
fix(grid): working check for CSS custom variables in Safari

### DIFF
--- a/core/src/components/col/col.tsx
+++ b/core/src/components/col/col.tsx
@@ -2,7 +2,7 @@ import { Component, Element, Listen, Prop } from '@stencil/core';
 
 import { isMatch } from '../../utils/media';
 
-const SUPPORTS_VARS = !!(CSS && CSS.supports && CSS.supports('--a', '0'));
+const SUPPORTS_VARS = !!(CSS && CSS.supports && CSS.supports('--a: 0'));
 const BREAKPOINTS = ['', 'xs', 'sm', 'md', 'lg', 'xl'];
 
 @Component({

--- a/core/src/components/col/readme.md
+++ b/core/src/components/col/readme.md
@@ -64,6 +64,7 @@ There are several attributes that can be added to a column to customize this beh
 | `--ion-grid-column-padding-sm` | Padding for the Column on sm screens and up |
 | `--ion-grid-column-padding-xl` | Padding for the Column on xl screens and up |
 | `--ion-grid-column-padding-xs` | Padding for the Column on xs screens and up |
+| `--ion-grid-columns`           | The number of total Columns in the Grid     |
 
 
 ----------------------------------------------


### PR DESCRIPTION
#### Short description of what this resolves:

Safari ignores alternate values for --ion-grid-columns when determining col width, reverting always to the default 12.

#### Changes proposed in this pull request:

- Use a equivalent way of calling CSS.supports() that works with custom variables in Safari, cause at the moment is partially broken in WebKit: https://bugs.webkit.org/show_bug.cgi?id=154669

**Ionic Version**: 4.0-beta.3

More details here:

https://github.com/ionic-team/ionic/issues/14562#issuecomment-414072347