### PR TITLE
fix(virtual-scroll): remove console.log message

### DIFF
--- a/core/src/components/virtual-scroll/virtual-scroll.tsx
+++ b/core/src/components/virtual-scroll/virtual-scroll.tsx
@@ -226,7 +226,6 @@ export class VirtualScroll {
       node = node.parentElement;
     }
     this.viewportOffset = topOffset;
-    console.log(this.viewportOffset);
     if (scrollEl) {
       this.viewportHeight = scrollEl.offsetHeight;
       this.currentScrollTop = scrollEl.scrollTop;


### PR DESCRIPTION
remove console.log message with the viewportOffset which is executed on every virtual scroll update

**Ionic Version**: 4.x