### PR TITLE
Set safe-area-top to 0 by default

### DIFF
--- a/core/src/components/app/app.scss
+++ b/core/src/components/app/app.scss
@@ -4,7 +4,7 @@ ion-app.is-device {
 }
 
 ion-app.statusbar-padding {
-  --ion-safe-area-top: 20px;
+  --ion-safe-area-top: 0;
 }
 
 // TODO: remove once Safari 11.2 dies


### PR DESCRIPTION
In our test we've found out that if we don't set this by default to zero it adds 20 extra pixels on every device, not just the ones with a notch, on both android and ios. It get's set to the right value in the below `@supports` blocks

**Ionic Version**: 4.x