### PR TITLE
fix(content): align getScrollElement signatures

### DIFF
--- a/angular/src/directives/proxies.ts
+++ b/angular/src/directives/proxies.ts
@@ -151,10 +151,10 @@ export class ChipButton {
 }
 
 export declare interface ChipIcon extends StencilComponents.IonChipIcon {}
-@Directive({ selector: 'ion-chip-icon', inputs: ['color', 'mode', 'name', 'src'] })
+@Directive({ selector: 'ion-chip-icon', inputs: ['color', 'mode', 'fill', 'name', 'src'] })
 export class ChipIcon {
   constructor(r: ElementRef) {
-    proxyInputs(this, r, ['color', 'mode', 'name', 'src']);
+    proxyInputs(this, r, ['color', 'mode', 'fill', 'name', 'src']);
   }
 }
 
@@ -709,7 +709,7 @@ export class Text {
 }
 
 export declare interface Textarea extends StencilComponents.IonTextarea {}
-@Directive({ selector: 'ion-textarea', inputs: ['color', 'mode', 'autocapitalize', 'autocomplete', 'autofocus', 'clearOnEdit', 'debounce', 'disabled', 'maxlength', 'minlength', 'name', 'placeholder', 'readonly', 'required', 'spellcheck', 'cols', 'rows', 'wrap', 'value'], outputs: ['ionChange', 'ionInput', 'ionStyle', 'ionBlur', 'ionFocus'] })
+@Directive({ selector: 'ion-textarea', inputs: ['color', 'mode', 'autocapitalize', 'autofocus', 'clearOnEdit', 'debounce', 'disabled', 'maxlength', 'minlength', 'name', 'placeholder', 'readonly', 'required', 'spellcheck', 'cols', 'rows', 'wrap', 'value'], outputs: ['ionChange', 'ionInput', 'ionStyle', 'ionBlur', 'ionFocus'] })
 export class Textarea {
   ionChange: EventEmitter<any>;
   ionInput: EventEmitter<any>;
@@ -717,7 +717,7 @@ export class Textarea {
   ionBlur: EventEmitter<any>;
   ionFocus: EventEmitter<any>;
   constructor(r: ElementRef) {
-    proxyInputs(this, r, ['color', 'mode', 'autocapitalize', 'autocomplete', 'autofocus', 'clearOnEdit', 'debounce', 'disabled', 'maxlength', 'minlength', 'name', 'placeholder', 'readonly', 'required', 'spellcheck', 'cols', 'rows', 'wrap', 'value']);
+    proxyInputs(this, r, ['color', 'mode', 'autocapitalize', 'autofocus', 'clearOnEdit', 'debounce', 'disabled', 'maxlength', 'minlength', 'name', 'placeholder', 'readonly', 'required', 'spellcheck', 'cols', 'rows', 'wrap', 'value']);
     proxyOutputs(this, ['ionChange', 'ionInput', 'ionStyle', 'ionBlur', 'ionFocus']);
   }
 }
@@ -749,9 +749,9 @@ export class Toolbar {
 }
 
 export declare interface ToolbarTitle extends StencilComponents.IonTitle {}
-@Directive({ selector: 'ion-title', inputs: ['mode', 'color'] })
+@Directive({ selector: 'ion-title', inputs: ['color'] })
 export class ToolbarTitle {
   constructor(r: ElementRef) {
-    proxyInputs(this, r, ['mode', 'color']);
+    proxyInputs(this, r, ['color']);
   }
 }

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -622,7 +622,7 @@ declare global {
        * If true, the content will scroll behind the headers and footers. This effect can easily be seen by setting the toolbar to transparent.
        */
       'fullscreen': boolean;
-      'getScrollElement': () => HTMLElement;
+      'getScrollElement': () => Promise<HTMLElement>;
       /**
        * Scroll by a specified X/Y distance in the component
        */
@@ -2107,7 +2107,7 @@ declare global {
        * The text to display on the ok button. Default: `OK`.
        */
       'okText': string;
-      'open': (ev?: UIEvent | undefined) => Promise<HTMLIonActionSheetElement> | Promise<HTMLIonAlertElement> | Promise<HTMLIonPopoverElement>;
+      'open': (ev?: UIEvent | undefined) => Promise<HTMLIonPopoverElement> | Promise<HTMLIonActionSheetElement> | Promise<HTMLIonAlertElement>;
       /**
        * The text to display when the select is empty.
        */

--- a/core/src/components/content/content.tsx
+++ b/core/src/components/content/content.tsx
@@ -160,8 +160,8 @@ export class Content {
   }
 
   @Method()
-  getScrollElement(): HTMLElement {
-    return this.scrollEl;
+  getScrollElement(): Promise<HTMLElement> {
+    return Promise.resolve(this.scrollEl);
   }
 
   /**

--- a/core/src/components/infinite-scroll/infinite-scroll.tsx
+++ b/core/src/components/infinite-scroll/infinite-scroll.tsx
@@ -77,7 +77,7 @@ export class InfiniteScroll {
     const contentEl = this.el.closest('ion-content');
     if (contentEl) {
       await contentEl.componentOnReady();
-      this.scrollEl = contentEl.getScrollElement();
+      this.scrollEl = await contentEl.getScrollElement();
     }
     this.thresholdChanged(this.threshold);
     this.enableScrollEvents(!this.disabled);

--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -97,7 +97,7 @@ export class Refresher {
     const contentEl = this.el.closest('ion-content');
     if (contentEl) {
       await contentEl.componentOnReady();
-      this.scrollEl = contentEl.getScrollElement();
+      this.scrollEl = await contentEl.getScrollElement();
     } else {
       console.error('ion-refresher did not attach, make sure the parent is an ion-content.');
     }

--- a/core/src/components/reorder-group/reorder-group.tsx
+++ b/core/src/components/reorder-group/reorder-group.tsx
@@ -48,7 +48,7 @@ export class ReorderGroup {
     const contentEl = this.el.closest('ion-content');
     if (contentEl) {
       await contentEl.componentOnReady();
-      this.scrollEl = contentEl.getScrollElement();
+      this.scrollEl = await contentEl.getScrollElement();
     }
 
     this.gesture = (await import('../../utils/gesture/gesture')).createGesture({

--- a/core/src/components/virtual-scroll/virtual-scroll.tsx
+++ b/core/src/components/virtual-scroll/virtual-scroll.tsx
@@ -124,7 +124,7 @@ export class VirtualScroll {
     await contentEl.componentOnReady();
 
     this.contentEl = contentEl;
-    this.scrollEl = contentEl.getScrollElement();
+    this.scrollEl = await contentEl.getScrollElement();
     this.calcCells();
     this.updateState();
   }


### PR DESCRIPTION
#### Short description of what this resolves:

This commit aligns the different signatures for IonContent.getScrollElement.

#### Changes proposed in this pull request:

The return type in the interface generated by Stencil was HTMLElement. But
the Angular proxy generated by Stencil was returning a promise for it after
awaiting for componentReady(). All the uses of this method were also
awaiting for componentReady().

So this commit now implements the method in the web component to return
a (immediate) promise for the HTMLElement. The implementations of the using
components (infinite-scroll, refresher, reorder-group and virtual-scroll)
are also changed accordingly.

Now, you need to do without a framework:
```
await contentEl.componentReady();
let scrollEl = await contentEl.getScrollElement();
```

And with Ionic/Angular:
```
let scrollEl = await content.getScrollElement();
```

**Ionic Version**: 4.0.0-beta.3

**Fixes**: #15141

**Warning**: I included the regenerated result in `components.d.ts` and `proxies.ts`. I was not sure I had to do that. Also, please tell me if and how I can improve this PR.