### PR TITLE
fix(tabs): center the tab label to be horizontally aligned with the icon

### DIFF
--- a/core/src/components/tabbar/tab-button.scss
+++ b/core/src/components/tabbar/tab-button.scss
@@ -58,6 +58,8 @@
   font-size: var(--label-font-size);
 
   line-height: var(--label-line-height);
+
+  text-align: center;
 }
 
 .tab-btn-icon {


### PR DESCRIPTION
#### Short description of what this resolves:

<img width="391" alt="screen shot 2018-08-21 at 6 02 16 pm" src="https://user-images.githubusercontent.com/3728897/44428967-638c7300-a56c-11e8-964c-64dafcd7dfea.png">

Labels should be horizontally aligned with icons.

**Ionic Version**: 4.0.0-beta.3

**Fixes**: #15273