### PR TITLE
fix(tabs): align text to the center unless layout is icon start/end

### DIFF
--- a/core/src/components/tabbar/tab-button.scss
+++ b/core/src/components/tabbar/tab-button.scss
@@ -23,6 +23,7 @@
 
   background: transparent;
 
+  text-align: var(--text-align, center);
   text-decoration: none;
 
   cursor: pointer;

--- a/core/src/components/tabbar/tabbar.scss
+++ b/core/src/components/tabbar/tabbar.scss
@@ -77,10 +77,12 @@
 
 :host(.layout-icon-start) .tab-btn {
   --flex-direction: row;
+  --text-align: left;
 }
 
 :host(.layout-icon-end) .tab-btn {
   --flex-direction: row-reverse;
+  --text-align: right;
 }
 
 :host(.layout-icon-bottom) .tab-btn {

--- a/core/src/components/tabs/test/colors/index.html
+++ b/core/src/components/tabs/test/colors/index.html
@@ -14,7 +14,7 @@
 
     <!-- Default -->
     <ion-tabs>
-      <ion-tab label="Recents"></ion-tab>
+      <ion-tab label="Hi"></ion-tab>
       <ion-tab label="Favorites" badge="6"></ion-tab>
       <ion-tab label="Settings"></ion-tab>
     </ion-tabs>
@@ -30,7 +30,7 @@
 
     <!-- Icons on top of text -->
     <ion-tabs selected-index="2" color="secondary">
-      <ion-tab label="Location" icon="navigate"></ion-tab>
+      <ion-tab label="Hi" icon="navigate"></ion-tab>
       <ion-tab label="Favorites" badge="6" icon="heart"></ion-tab>
       <ion-tab label="Radio" icon="musical-notes"></ion-tab>
     </ion-tabs>
@@ -38,7 +38,7 @@
 
     <!-- Icons below text -->
     <ion-tabs tabbar-layout="icon-bottom" selected-index="1" color="dark">
-      <ion-tab label="Recents" icon="call"></ion-tab>
+      <ion-tab label="Hi" icon="call"></ion-tab>
       <ion-tab label="Favorites" badge="6" icon="heart"></ion-tab>
       <ion-tab label="Settings" icon="settings"></ion-tab>
     </ion-tabs>
@@ -46,7 +46,7 @@
 
     <!-- Icons right of text -->
     <ion-tabs tabbar-layout="icon-end" selected-index="0" color="danger">
-      <ion-tab label="Recents" icon="call"></ion-tab>
+      <ion-tab label="Hi" icon="call"></ion-tab>
       <ion-tab label="Favorites" badge="6" icon="heart"></ion-tab>
       <ion-tab label="Settings" icon="settings"></ion-tab>
     </ion-tabs>
@@ -54,7 +54,7 @@
 
     <!-- Icons left of text -->
     <ion-tabs tabbar-layout="icon-start" color="light">
-      <ion-tab label="Recents" icon="call"></ion-tab>
+      <ion-tab label="Hi" icon="call"></ion-tab>
       <ion-tab label="Favorites" badge="6" badge-color="danger" icon="heart"></ion-tab>
       <ion-tab label="Settings" icon="settings"></ion-tab>
     </ion-tabs>
@@ -62,7 +62,7 @@
 
     <!-- No icons -->
     <ion-tabs tabbar-layout="icon-hide" color="primary">
-      <ion-tab label="Recents" icon="call"></ion-tab>
+      <ion-tab label="Hi" icon="call"></ion-tab>
       <ion-tab label="Favorites" badge="6" badge-color="danger" icon="heart"></ion-tab>
       <ion-tab label="Settings" icon="settings"></ion-tab>
     </ion-tabs>
@@ -70,7 +70,7 @@
 
     <!-- No label -->
     <ion-tabs tabbar-layout="label-hide" color="secondary">
-      <ion-tab label="Recents" icon="call"></ion-tab>
+      <ion-tab label="Hi" icon="call"></ion-tab>
       <ion-tab label="Favorites" badge="6" badge-color="danger" icon="heart"></ion-tab>
       <ion-tab label="Settings" icon="settings"></ion-tab>
     </ion-tabs>


### PR DESCRIPTION
fixes #15273
