### PR TITLE
Update BREAKING.md-Add missed menu title in the list

### DIFF
--- a/angular/BREAKING.md
+++ b/angular/BREAKING.md
@@ -37,6 +37,7 @@ A list of the breaking changes introduced to each component in Ionic Angular v4.
 - [Label](#label)
 - [List Header](#list-header)
 - [Loading](#loading)
+- [Menu](#menu)
 - [Menu Toggle](#menu-toggle)
 - [Modal](#modal)
 - [Nav](#nav)


### PR DESCRIPTION
#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x / 3.x / 4.x

**Fixes**: #
