### PR TITLE
v4 - Adds ionItemReorder event to ion-reorder-group

### DIFF
--- a/core/src/components/reorder-group/reorder-group.tsx
+++ b/core/src/components/reorder-group/reorder-group.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Prop, QueueApi, State, Watch } from '@stencil/core';
+import { Component, Element, Event, EventEmitter, Prop, QueueApi, State, Watch } from '@stencil/core';
 
 import { Gesture, GestureDetail } from '../../interface';
 import { hapticSelectionChanged, hapticSelectionEnd, hapticSelectionStart } from '../../utils/haptic';
@@ -41,6 +41,8 @@ export class ReorderGroup {
     }
   }
 
+  @Event() ionItemReorder!: EventEmitter;
+
   async componentDidLoad() {
     const contentEl = this.el.closest('ion-content');
     if (contentEl) {
@@ -62,6 +64,7 @@ export class ReorderGroup {
       onMove: this.onMove.bind(this),
       onEnd: this.onEnd.bind(this),
     });
+
     this.disabledChanged();
   }
 
@@ -193,8 +196,19 @@ export class ReorderGroup {
     } else {
       reorderInactive();
     }
+    this.onEmit(fromIndex, toIndex);
 
     hapticSelectionEnd();
+  }
+
+  private onEmit(fromIndex: number, toIndex: number) {
+    if (fromIndex !== toIndex) {
+      const indexes = {
+        fromIndex,
+        toIndex
+      };
+      this.ionItemReorder.emit(indexes);
+    }
   }
 
   private itemIndexForTop(deltaY: number): number {

--- a/core/src/components/reorder-group/reorder-group.tsx
+++ b/core/src/components/reorder-group/reorder-group.tsx
@@ -195,20 +195,13 @@ export class ReorderGroup {
       setTimeout(reorderInactive, 200);
     } else {
       reorderInactive();
+      this.ionItemReorder.emit({
+        from: fromIndex,
+        to: toIndex
+      });
     }
-    this.onEmit(fromIndex, toIndex);
 
     hapticSelectionEnd();
-  }
-
-  private onEmit(fromIndex: number, toIndex: number) {
-    if (fromIndex !== toIndex) {
-      const indexes = {
-        fromIndex,
-        toIndex
-      };
-      this.ionItemReorder.emit(indexes);
-    }
   }
 
   private itemIndexForTop(deltaY: number): number {


### PR DESCRIPTION
#### Short description of what this resolves:

Adds an event hook for when a user reorders an item inside an `ion-reorder-group`. Example output is similar to:
```
{
   fromIndex: 2
   toIndex: 1
}
```


#### Changes proposed in this pull request:

- Adds `(ionItemReorder)` event 

**Ionic Version**: 4

**Fixes**: #14640 
