### PR TITLE
chore(bot): implement the noReply automated workflow

### DIFF
--- a/.github/PROCESS.md
+++ b/.github/PROCESS.md
@@ -29,3 +29,45 @@ Issues and pull requests that need review. Pull requests will automatically move
 #### Done :tada:
 
 Issues and pull requests that are completed. Issues will automatically move here when they are closed. Pull requests will automatically moved here when they are merged or closed with unmerged commits.
+
+## Triaging Issues
+
+### Issues to Triage
+
+The issues that need to be triaged all have the `triage` label. In many cases the issue can be automatically processed by the Ionic Issue Bot by applying a specific label.
+
+Once another label is applied to the issue, the `triage` label is automatically be removed by the bot.
+
+### Wrong Repo
+
+If an issue does not pertain to the Ionic Framework but does pertain to another repo, it should be moved to that repo. The bot has been set up to automatically create the issue in other repositories while closing and locking the issue in this repository. Use one of the following labels to perform that action:
+
+- ionitron: cli
+- ionitron: docs
+- ionitron: stencil
+- ionitron: native
+
+### Ionic Pro Issues
+
+If the issue is associated with Ionic Pro the submitter should be told to use the [Ionic Pro Support Forum](https://ionic.zendesk.com/hc/en-us/requests/new). The issue should be closed and locked. Use the `ionitron: ionic pro` label to accomplish this.
+
+### Support Questions
+
+If the issue is a support question, the submitter should be redirected to our [forum](https://forum.ionicframework.com) or [slack channel](https://ionicworldwide.herokuapp.com/). The issue should be closed and locked. Use the `ionitron: support` label to accomplish this.
+
+### Incomplete Template
+
+If the issue template has not been filled out completely, the issue should be closed and locked. The submitter should be informed top re-submit the issue making sure they fill the form out completely. Use the `ionitron: missing template` label to accomplish this.
+
+### Issues with Open Questions
+
+In many cases, the template is mostly filled out but just missing a thing or two or you may have a question or need clarification. In such a case, the submitter should be asked to supply that information.
+
+1. create a comment requesting the additional information or clarification
+1. add the `needs reply` label to the task
+
+NOTE: be sure to perform those actions in the order stated. If you add the comment second it will trigger the removal of the label.
+
+If there is a response to the question, the bot will remove the `needs reply` and apply the `triage` label. The issue will then go through the triage handling again.
+
+if there is no response within 30 days, the issue will be closed and locked.

--- a/.github/PROCESS.md
+++ b/.github/PROCESS.md
@@ -30,7 +30,7 @@ Issues and pull requests that need review. Pull requests will automatically move
 
 Issues and pull requests that are completed. Issues will automatically move here when they are closed. Pull requests will automatically moved here when they are merged or closed with unmerged commits.
 
-## Triaging Issues
+## Managing Issues
 
 ### Issues to Triage
 

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -39,11 +39,30 @@ stale:
   exemptLabels:
     - good first issue
     - triage
+    - has reply
   exemptProjects: true
   exemptMilestones: true
   label: "ionitron: stale issue"
   message: >
     Thanks for the issue! This issue is being closed due to inactivity. If this is still
+    an issue with the latest version of Ionic, please create a new issue and ensure the
+    template is fully filled out.
+
+
+    Thank you for using Ionic!
+  close: true
+  lock: true
+  dryRun: false
+
+noReply:
+  days: 30
+  maxIssuesPerRun: 100
+  label: needs reply
+  responseLabel: has reply
+  exemptProjects: true
+  exemptMilestones: true
+  message: >
+    Thanks for the issue! This issue is being closed due to the lack of a reply. If this is still
     an issue with the latest version of Ionic, please create a new issue and ensure the
     template is fully filled out.
 

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -39,7 +39,6 @@ stale:
   exemptLabels:
     - good first issue
     - triage
-    - has reply
   exemptProjects: true
   exemptMilestones: true
   label: "ionitron: stale issue"
@@ -58,7 +57,7 @@ noReply:
   days: 30
   maxIssuesPerRun: 100
   label: needs reply
-  responseLabel: has reply
+  responseLabel: triage
   exemptProjects: true
   exemptMilestones: true
   message: >


### PR DESCRIPTION
#### Short description of what this resolves:

Implements the noReply automated workflow via the ionic-issue-bot

#### Changes proposed in this pull request:

- will close and lock "needs reply" issues after 30 without a reply
- once a reply is entered, "needs reply" label is removed and "has reply" label is applied
- items with "has reply" are ignored by the stale sweeper

The general workflow from the perspective of our devs:

1. determines that more data is needed
1. Ionic dev writes a comment (important to do this FIRST)
1. Ionic dev add "needs reply" label (important to do this SECOND)
1. ideally, someone (anyone) replies and "needs reply" is replaced with "has reply"
1. Ionic dev determines if reply is adequate and processes further or perhaps repeats the "needs reply" bits