### PR TITLE
docs(changelog): add missing text-transformation-css import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   @import "~@ionic/core/css/padding.css";
   @import "~@ionic/core/css/float-elements.css";
   @import "~@ionic/core/css/text-alignment.css";
+  @import "~@ionic/core/css/text-transformation.css";
   @import "~@ionic/core/css/flex-utils.css";
 ```
 
@@ -33,6 +34,7 @@
   @import "~@ionic/angular/css/padding.css";
   @import "~@ionic/angular/css/float-elements.css";
   @import "~@ionic/angular/css/text-alignment.css";
+  @import "~@ionic/angular/css/text-transformation.css";
   @import "~@ionic/angular/css/flex-utils.css";
 ```
 


### PR DESCRIPTION
#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x / 3.x / 4.x

**Fixes**: #
