### PR TITLE
fix(slides): fix slideNext and slidePrev parameters wrong order

### DIFF
--- a/core/src/components/slides/slides.tsx
+++ b/core/src/components/slides/slides.tsx
@@ -162,7 +162,7 @@ export class Slides {
    */
   @Method()
   slideNext(speed?: number, runCallbacks?: boolean) {
-    this.swiper.slideNext(runCallbacks, speed);
+    this.swiper.slideNext(speed, runCallbacks);
   }
 
   /**
@@ -170,7 +170,7 @@ export class Slides {
    */
   @Method()
   slidePrev(speed?: number, runCallbacks?: boolean) {
-    this.swiper.slidePrev(runCallbacks, speed);
+    this.swiper.slidePrev(speed, runCallbacks);
   }
 
   /**


### PR DESCRIPTION
#### Short description of what this resolves:

As described in https://github.com/ionic-team/ionic/issues/15407 the speed parameter is currently ignore by `swipe. slideNext` and `swipe. slidePrev`

The reason behind, I think, is the fact that the order of the parameter to call the Swiper API (http://idangero.us/swiper/api/) is not correct. The callback is provided before the speed which should actually be the contrary

#### Changes proposed in this pull request:

- inverse the order of the parameters provided to the swiper `slideNext` and `slidePrev` functions

**Ionic Version**: 1.x / 2.x / 3.x / 4.x

4.x / core

**Fixes**: #

Fix https://github.com/ionic-team/ionic/issues/15407
