### PR TITLE
v4 ft: Allows custom tab placement inside tabs content

### DIFF
--- a/core/src/components/tabs/tabs.tsx
+++ b/core/src/components/tabs/tabs.tsx
@@ -303,7 +303,7 @@ export class Tabs implements NavOutlet {
       <div class="tabs-inner">
         <slot></slot>
       </div>,
-
+      <slot name="tabbar"></slot>,
       !this.tabbarHidden && (
         <ion-tabbar
           tabs={this.tabs.slice()}


### PR DESCRIPTION
#### Short description of what this resolves:

This allows you to place custom tabbar implementations inside the shadowDOM to allow the bar to place correctly and fill the container space accurately.


#### Changes proposed in this pull request:

- Add `tabbar` slot to the `ion-tabs` web component


**Ionic Version**: 4

Notice how in the before gif I cannot reach the end of the container because it does not account for my tabbar. In the after, the content is projected in the same slot and calculates against the sizing of the bar. 

Before:

![Before](https://i.gyazo.com/849ed9c0784f102b611be69991f6144d.gif)

After:

![After](https://i.gyazo.com/122509c4c9c1ab0bb61924d2b65096a4.gif)
