### PR TITLE
fix(core): matchBreakpoint will return true if breakPoint is empty string

### DIFF
--- a/core/src/utils/media.ts
+++ b/core/src/utils/media.ts
@@ -11,7 +11,7 @@ export const SIZE_TO_MEDIA: any = {
 // at the breakpoint passed
 // e.g. matchBreakpoint('sm') => true if screen width exceeds 576px
 export function matchBreakpoint(win: Window, breakpoint: string | undefined) {
-  if (breakpoint === undefined) {
+  if (breakpoint === undefined || breakpoint === '') {
     return true;
   }
   const mediaQuery = SIZE_TO_MEDIA[breakpoint];


### PR DESCRIPTION
Short description of what this resolves:

Correct breakpoint will be returned so ion-col is working correctly

Ionic Version: 4.0

Closes #15495
