### PR TITLE
Updated InfiniteScroll Angular docs

### DIFF
--- a/core/src/components/infinite-scroll/usage/angular.md
+++ b/core/src/components/infinite-scroll/usage/angular.md
@@ -16,7 +16,8 @@
 ```
 
 ```typescript
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { InfiniteScroll } from '@ionic/angular';
 
 @Component({
   selector: 'infinite-scroll-example',


### PR DESCRIPTION
Added import statements to make the angular typescript example easier to adopt for individual use cases.

#### Short description of what this resolves:

Improves documentation


#### Changes proposed in this pull request:

- Added missing import statements in infinite scroll component

**Ionic Version**: 1.x / 2.x / 3.x / 4.x

**Fixes**: #
