### PR TITLE
docs(ion-router): fix some typos

### DIFF
--- a/core/src/components/router/readme.md
+++ b/core/src/components/router/readme.md
@@ -7,9 +7,9 @@ This component controls all interactions with the browser history and it aggrega
 
 `ion-router` is just a URL coordinator for the navigation outlets of ionic: `ion-nav` and `ion-tabs`.
 
-That means the ion-router never touches the DOM, it does NOT show the components or emit any kind of lifecycle events, it just tell `ion-nav` and `ion-tabs` what and when to "show" based in the browser's URL.
+That means the `ion-router` never touches the DOM, it does NOT show the components or emit any kind of lifecycle events, it just tells `ion-nav` and `ion-tabs` what and when to "show" based on the browser's URL.
 
-In order to configure this relationship between components (to load/select) and URLs, ion-router uses a declarative syntax using JSX/HTML to define a tree of routes.
+In order to configure this relationship between components (to load/select) and URLs, `ion-router` uses a declarative syntax using JSX/HTML to define a tree of routes.
 
 If you're using Angular, please see [ion-router-outlet](../router-outlet) instead.
 


### PR DESCRIPTION
#### Short description of what this resolves:

Just fixes two typoes in the `ion-router` docs.

**Ionic Version**: 4.x

