### PR TITLE
fix(#15604): slideNext parameters are optional

### DIFF
--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -4223,7 +4223,7 @@ export namespace Components {
     /**
     * Transition to the next slide.
     */
-    'slideNext': (speed: number, runCallbacks: boolean) => Promise<void>;
+    'slideNext': (speed?: number | undefined, runCallbacks?: boolean | undefined) => Promise<void>;
     /**
     * Transition to the previous slide.
     */


### PR DESCRIPTION
#### Short description of what this resolves:

`IonSlides.slideNext` parameters are optional and not mandatory, fix the definition

**Ionic Version**: 1.x / 2.x / 3.x / 4.x

v4.0.0-beta.11

**Related issue**

https://github.com/ionic-team/ionic/issues/15604
