### PR TITLE
is method takes 'desktop' instead on 'windows'

### DIFF
--- a/core/src/components/platform/readme.md
+++ b/core/src/components/platform/readme.md
@@ -9,7 +9,7 @@ The Platform service can be used to get information about your current device. Y
 
 | Method        | Description                                                                                                                                                   |
 |---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `is`          | Returns true/false based on platform. Available options are android, cordova, core, ios, ipad, iphone, mobile, mobileweb, phablet, tablet, windows, electron. |
+| `is`          | Returns true/false based on platform. Available options are android, cordova, core, ios, ipad, iphone, mobile, mobileweb, phablet, tablet, desktop, electron. |
 | `platforms`   | Returns an array of platforms that the current device matches.                                                                                                |
 | `versions`    | Returns an object that contains the major, minor, and patcher version of the current device.                                                                  |
 | `ready`       | Returns a promise that resolves when the native bridge is ready in Cordova, or when the DOM is fully loaded in the browser.                                   |


### PR DESCRIPTION
#### Short description of what this resolves:
The is method of Platform takes 'desktop' instead on 'windows'

#### Changes proposed in this pull request:
Update the documentation

**Ionic Version**: 1.x / 2.x / 3.x / 4.x
Ionic 4
