### PR TITLE
fix(overlay): register backbutton handler only when needed

### DIFF
--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -34,7 +34,11 @@ export function connectListeners(doc: Document) {
   if (lastId === 0) {
     lastId = 1;
     doc.addEventListener('ionBackButton', ev => {
-      (ev as BackButtonEvent).detail.register(100, () => closeTopOverlay(doc));
+      const lastOverlay = getOverlay(doc);
+      // We use the overlayIndex property to be sure this node is an overlay
+      if (lastOverlay && lastOverlay.overlayIndex) {
+        (ev as BackButtonEvent).detail.register(100, () => closeTopOverlay(doc));
+      }
     });
 
     doc.addEventListener('keyup', ev => {


### PR DESCRIPTION
#### Short description of what this resolves:

When listening to `ionBackButton` events, only registers the `backbutton` handler if there is actually an overlay. This will give a chance to handlers with lower priority to eventually run.

#### Changes proposed in this pull request:
- in the `ionBackButton` listener for overlays, only register the handler if there is actually an overlay

**Ionic Version**: 4.0.0-beta.11

**Fixes**:  #15601
