### PR TITLE
fix: resize events will emit again in platform.resize

### DIFF
--- a/angular/src/providers/platform.ts
+++ b/angular/src/providers/platform.ts
@@ -39,7 +39,7 @@ export class Platform {
     proxyEvent(this.pause, document, 'pause');
     proxyEvent(this.resume, document, 'resume');
     proxyEvent(this.backButton, document, 'backbutton');
-    proxyEvent(this.resize, document, 'resize');
+    proxyEvent(this.resize, window, 'resize');
 
     let readyResolve: (value: string) => void;
     this._readyPromise = new Promise(res => { readyResolve = res; });


### PR DESCRIPTION
#### Short description of what this resolves:
`platform.resize` doesn't emit an event upon resizing, because it was bound to `document` instead of `window`.

**Ionic Version**: 4.x

