### PR TITLE
Fix deadlink to Navbar docs

### DIFF
--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -71,7 +71,7 @@ import { RootNode } from '../split-pane/split-pane';
  *
  * ### Navigation Bar Behavior
  *
- * If a [MenuToggle](../MenuToggle) button is added to the [Navbar](../../navbar/Navbar) of
+ * If a [MenuToggle](../MenuToggle) button is added to the [Navbar](../../toolbar/Navbar) of
  * a page, the button will only appear when the page it's in is currently a root page. The
  * root page is the initial page loaded in the app, or a page that has been set as the root
  * using the [setRoot](../../nav/NavController/#setRoot) method on the [NavController](../../nav/NavController).
@@ -84,7 +84,7 @@ import { RootNode } from '../split-pane/split-pane';
  *
  * ### Persistent Menus
  *
- * Persistent menus display the [MenuToggle](../MenuToggle) button in the [Navbar](../../navbar/Navbar)
+ * Persistent menus display the [MenuToggle](../MenuToggle) button in the [Navbar](../../toolbar/Navbar)
  * on all pages in the navigation stack. To make a menu persistent set `persistent` to `true` on the
  * `<ion-menu>` element. Note that this will only affect the `MenuToggle` button in the `Navbar` attached
  * to the `Menu` with `persistent` set to true, any other `MenuToggle` buttons will not be affected.


### PR DESCRIPTION
#### Short description of what this resolves:
"Navbar" links on https://ionicframework.com/docs/api/components/menu/Menu/ are deadlinks and are redirected to https://ionicframework.com/docs/v1/api/components/navbar/Navbar.
This patch corrects the two deadlinks to their where they are actually residing at.

#### Changes proposed in this pull request:

- Fix deadlinks

**Ionic Version**:  3.x

**Fixes**: Deadlinks
