### PR TITLE
docs(avatar): refactor component preview

### DIFF
--- a/core/src/components/avatar/test/preview/index.html
+++ b/core/src/components/avatar/test/preview/index.html
@@ -18,7 +18,7 @@
       </ion-toolbar>
     </ion-header>
 
-    <ion-content fullscreen>
+    <ion-content fullscreen padding>
       <ion-avatar>
         <img src="https://gravatar.com/avatar/dba6bae8c566f9d4041fb9cd9ada7741?d=identicon&f=y">
       </ion-avatar>


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes the "ugly" avatar component preview

<img width="440" alt="bildschirmfoto 2018-09-19 um 14 54 57" src="https://user-images.githubusercontent.com/15234844/45754451-07287c00-bc1c-11e8-811a-1e0b51ad4721.png">


#### Changes proposed in this pull request:

- Add `padding` to `ioni-content`

**Ionic Version**: 1.x / 2.x / 3.x / 4.x
4
