### PR TITLE
docs(textarea): fix label positions

### DIFF
--- a/core/src/components/textarea/test/preview/index.html
+++ b/core/src/components/textarea/test/preview/index.html
@@ -26,7 +26,7 @@
         </ion-item>
 
         <ion-item>
-          <ion-label color="primary" fixed>Fixed Label</ion-label>
+          <ion-label color="primary" position="fixed">Fixed Label</ion-label>
           <ion-textarea placeholder="Textarea"></ion-textarea>
         </ion-item>
 
@@ -35,12 +35,12 @@
         </ion-item>
 
         <ion-item>
-          <ion-label color="primary" stacked>Stacked Label</ion-label>
+          <ion-label color="primary" position="stacked">Stacked Label</ion-label>
           <ion-textarea placeholder="Textarea"></ion-textarea>
         </ion-item>
 
         <ion-item>
-          <ion-label color="primary" floating>Floating Label</ion-label>
+          <ion-label color="primary" position="floating">Floating Label</ion-label>
           <ion-textarea></ion-textarea>
         </ion-item>
 


### PR DESCRIPTION
#### Short description of what this resolves:
Adds the correct label position property

#### Changes proposed in this pull request:

- Add correct properties

**Ionic Version**: 1.x / 2.x / 3.x / 4.x
4