### PR TITLE
docs(thumbnail): fix example positioning

### DIFF
--- a/core/src/components/thumbnail/test/preview/index.html
+++ b/core/src/components/thumbnail/test/preview/index.html
@@ -19,7 +19,7 @@
     </ion-header>
 
     <ion-content id="content" fullscreen>
-      <ion-thumbnail>
+      <ion-thumbnail padding>
         <img src="https://gravatar.com/avatar/dba6bae8c566f9d4041fb9cd9ada7741?d=identicon&f=y">
       </ion-thumbnail>
 


### PR DESCRIPTION
#### Short description of what this resolves:
Add padding to the thumbnail example

#### Changes proposed in this pull request:

- Add padding
**Ionic Version**: 1.x / 2.x / 3.x / 4.x
4