### PR TITLE
docs(menu-controler): fix typo

### DIFF
--- a/angular/BREAKING.md
+++ b/angular/BREAKING.md
@@ -314,7 +314,7 @@ Content is now a drop-in replacement for `ion-scroll`, that means `ion-content` 
 
 ### resize() was removed
 
-In Ionic 4, `ion-content` layout is based in flex, that means their size will automatically adjust without requiring to call resize() programatically.
+In Ionic 4, `ion-content` layout is based in flex, that means their size will automatically adjust without requiring to call resize() programmatically.
 
 
 ### Attributes Renamed

--- a/angular/src/providers/menu-controller.ts
+++ b/angular/src/providers/menu-controller.ts
@@ -6,7 +6,7 @@ const CTRL = 'ion-menu-controller';
 export class MenuController {
 
   /**
-   * Programatically open the Menu.
+   * Programmatically open the Menu.
    * @param [menuId]  Optionally get the menu by its id, or side.
    * @return returns a promise when the menu is fully opened
    */
@@ -16,7 +16,7 @@ export class MenuController {
 
 
   /**
-   * Programatically close the Menu. If no `menuId` is given as the first
+   * Programmatically close the Menu. If no `menuId` is given as the first
    * argument then it'll close any menu which is open. If a `menuId`
    * is given then it'll close that exact menu.
    * @param [menuId]  Optionally get the menu by its id, or side.


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes a small typo

#### Changes proposed in this pull request:

- Change `programatically` to `programmatically`

**Ionic Version**: 1.x / 2.x / 3.x / 4.x
4
