### PR TITLE
docs(fab-list): fix typo

### DIFF
--- a/core/src/components/fab-list/readme.md
+++ b/core/src/components/fab-list/readme.md
@@ -1,6 +1,6 @@
 # ion-fab-list
 
-The `ion-fab-list` element is a container for multiple fab buttons. This collection of fab buttons contains actions related to the main fab button and is flung out on click. To specifiy what side the buttons should appear on, set the `side` property to 'start', 'end', 'top', 'bottom'
+The `ion-fab-list` element is a container for multiple fab buttons. This collection of fab buttons contains actions related to the main fab button and is flung out on click. To specify what side the buttons should appear on, set the `side` property to 'start', 'end', 'top', 'bottom'
 
 <!-- Auto Generated Below -->
 


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes a small typo

#### Changes proposed in this pull request:

- Change `specifiy ` to `specify `

**Ionic Version**: 1.x / 2.x / 3.x / 4.x
4
