### PR TITLE
docs(img): fix typo

### DIFF
--- a/core/src/components/img/readme.md
+++ b/core/src/components/img/readme.md
@@ -1,6 +1,6 @@
 # ion-img
 
-Img is a tag that will lazyily load an image when ever the tag is in the viewport. This is extremely useful when generating a large list as images are only loaded when they're visible. The component uses [Intersection Observer](https://caniuse.com/#feat=intersectionobserver) internally, which is supported in most modern browser, but falls back to a `setTimeout` when it is not supported.
+Img is a tag that will lazily load an image when ever the tag is in the viewport. This is extremely useful when generating a large list as images are only loaded when they're visible. The component uses [Intersection Observer](https://caniuse.com/#feat=intersectionobserver) internally, which is supported in most modern browser, but falls back to a `setTimeout` when it is not supported.
 
 
 <!-- Auto Generated Below -->


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes a small typo

#### Changes proposed in this pull request:

- Change `lazyily ` to `lazily`

**Ionic Version**: 1.x / 2.x / 3.x / 4.x
4