### PR TITLE
docs(route): fix typo

### DIFF
--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -3612,7 +3612,7 @@ export namespace Components {
     */
     'componentProps'?: {[key: string]: any};
     /**
-    * Used internaly by `ion-router` to know when this route did change.
+    * Used internally by `ion-router` to know when this route did change.
     */
     'onIonRouteDataChanged'?: (event: CustomEvent<any>) => void;
     /**

--- a/core/src/components/route/readme.md
+++ b/core/src/components/route/readme.md
@@ -20,7 +20,7 @@ Router is a component that can take a component, and render it when the Browser 
 
 | Event                 | Description                                                        |
 | --------------------- | ------------------------------------------------------------------ |
-| `ionRouteDataChanged` | Used internaly by `ion-router` to know when this route did change. |
+| `ionRouteDataChanged` | Used internally by `ion-router` to know when this route did change. |
 
 
 ----------------------------------------------

--- a/core/src/components/route/route.tsx
+++ b/core/src/components/route/route.tsx
@@ -29,7 +29,7 @@ export class Route implements ComponentInterface {
   @Prop() componentProps?: {[key: string]: any};
 
   /**
-   * Used internaly by `ion-router` to know when this route did change.
+   * Used internally by `ion-router` to know when this route did change.
    */
   @Event() ionRouteDataChanged!: EventEmitter<any>;
 


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes a small typo

#### Changes proposed in this pull request:

- Change `internaly` to `internally`

**Ionic Version**: 1.x / 2.x / 3.x / 4.x
4
