### PR TITLE
docs(virtual-scroll): fix typos

### DIFF
--- a/core/src/components/virtual-scroll/readme.md
+++ b/core/src/components/virtual-scroll/readme.md
@@ -133,8 +133,8 @@ dimensions are measured correctly.
 
 When deploying to iOS with Cordova, it's highly recommended to use the
 [WKWebView plugin](http://blog.ionic.io/cordova-ios-performance-improvements-drop-in-speed-with-wkwebview/)
-in order to take advantage of iOS's higher performimg webview. Additionally,
-WKWebView is superior at scrolling efficiently in comparision to the older
+in order to take advantage of iOS's higher performing webview. Additionally,
+WKWebView is superior at scrolling efficiently in comparison to the older
 UIWebView.
 
 #### Lock in element dimensions and locations


### PR DESCRIPTION
#### Short description of what this resolves:
Fix small typos

#### Changes proposed in this pull request:

- Change `performimg` to `performing`
- Change `comparision` to `comparison`

**Ionic Version**: 1.x / 2.x / 3.x / 4.x
4
