### PR TITLE
fix(button): disable :hover on non supported devices

### DIFF
--- a/core/src/components/button/button.ios.scss
+++ b/core/src/components/button/button.ios.scss
@@ -26,9 +26,10 @@
 
 // iOS Solid Button
 // --------------------------------------------------
-
-:host(.button-solid:hover) {
-  --opacity: #{$button-ios-opacity-hover};
+@media (any-hover: hover) {
+  :host(.button-solid:hover) {
+    --opacity: #{$button-ios-opacity-hover};
+  }
 }
 
 :host(.button-solid.activated) {
@@ -55,9 +56,10 @@
 
 // iOS Clear Button
 // --------------------------------------------------
-
-:host(.button-clear:hover) {
-  --opacity: #{$button-ios-clear-opacity-hover};
+@media (any-hover: hover) {
+  :host(.button-clear:hover) {
+    --opacity: #{$button-ios-clear-opacity-hover};
+  }
 }
 
 :host(.button-clear.activated) {

--- a/core/src/components/buttons/buttons.ios.scss
+++ b/core/src/components/buttons/buttons.ios.scss
@@ -40,8 +40,10 @@
 // iOS Toolbar Button Solid
 // --------------------------------------------------
 
-::slotted(*) .button-solid-ios:hover {
-  opacity: .4;
+@media (any-hover: hover) {
+  ::slotted(*) .button-solid-ios:hover {
+    opacity: .4;
+  }
 }
 
 

--- a/core/src/components/searchbar/searchbar.ios.scss
+++ b/core/src/components/searchbar/searchbar.ios.scss
@@ -151,8 +151,10 @@
   color: #{current-color(base)};
 }
 
-:host(.ion-color) .searchbar-cancel-button:hover {
-  color: #{current-color(tint)};
+@media (any-hover: hover) {
+  :host(.ion-color) .searchbar-cancel-button:hover {
+    color: #{current-color(tint)};
+  }
 }
 
 // Searchbar in Toolbar Color

--- a/core/src/components/tabbar/tab-button.scss
+++ b/core/src/components/tabbar/tab-button.scss
@@ -34,7 +34,12 @@
   background: var(--background-focused);
 }
 
-.tab-btn:hover,
+@media (any-hover: hover) {
+  .tab-btn:hover {
+    color: var(--color-selected);
+  }
+}
+
 .tab-btn-selected {
   color: var(--color-selected);
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Fix the problem with buttons on iOS not loosing the opacity when clicked

#### Changes proposed in this pull request:

- use @media (any-hover: hover) to detect if device supports any kind of hover 

**Ionic Version**:  4.x

**Fixes**: #15667, #14934
