### PR TITLE
docs(virtual-scroll): fix closing virtual-scroll tag in docs

### DIFF
--- a/core/src/components/virtual-scroll/readme.md
+++ b/core/src/components/virtual-scroll/readme.md
@@ -106,7 +106,7 @@ images while scrolling quickly.
     </ion-avatar>
     {{ item.firstName }} {{ item.lastName }}
   </ion-item>
-</ion-list>
+</ion-virtual-scroll>
 ```
 
 ### Custom Components
@@ -124,7 +124,7 @@ dimensions are measured correctly.
       {{ item }}
     </my-custom-item>
   </div>
-</ion-list>
+</ion-virtual-scroll>
 ```
 
 ## Virtual Scroll Performance Tips


### PR DESCRIPTION
#### Short description of what this resolves:

This PR fixes unmatched virtual-scroll closing tag in the docs.

**Ionic Version**: 4.x
