### PR TITLE
Allow user to provide a custom backButtonClick

### DIFF
--- a/src/components/toolbar/navbar.ts
+++ b/src/components/toolbar/navbar.ts
@@ -85,6 +85,15 @@ export class Navbar extends ToolbarBase {
    * @hidden
    */
   _sbPadding: boolean;
+  /**
+   * @hidden
+   */
+  _backButtonClick = (ev: UIEvent) => {
+    ev.preventDefault();
+    ev.stopPropagation();
+
+    this.navCtrl && this.navCtrl.pop(null, null);
+  }
 
   /**
    * @input {boolean} If true, the back button will be hidden.
@@ -95,6 +104,17 @@ export class Navbar extends ToolbarBase {
   }
   set hideBackButton(val: boolean) {
     this._hideBb = isTrueProperty(val);
+  }
+  
+  /**
+    * @input {(ev: UIEvent) => void} Takes a function override the default one
+    */
+  @Input()
+  get backButtonClick(): (ev: UIEvent) => void {
+    return this._backButtonClick;
+  }
+  set backButtonClick(val: (ev: UIEvent) => void){
+    this._backButtonClick = val;
   }
 
   constructor(
@@ -112,14 +132,6 @@ export class Navbar extends ToolbarBase {
     this._bbIcon = config.get('backButtonIcon');
     this._sbPadding = config.getBoolean('statusbarPadding');
     this._backText = config.get('backButtonText', 'Back');
-  }
-
-
-  backButtonClick(ev: UIEvent) {
-    ev.preventDefault();
-    ev.stopPropagation();
-
-    this.navCtrl && this.navCtrl.pop(null, null);
   }
 
   /**


### PR DESCRIPTION
#### Short description of what this resolves:
Override backButtonClick to enable the developer to provide a custom function when clicking the back button, ie. calling a confirm alert to leave the current page.

#### Changes proposed in this pull request:

- Allow user to provide a custom backButtonClick

**Ionic Version**: 3.x

**Fixes**: #
