### PR TITLE
Update input.tsx

### DIFF
--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -372,6 +372,7 @@ export class Input implements ComponentInterface {
       (this.clearInput && !this.readonly && !this.disabled) && <button
         type="button"
         class="input-clear-icon"
+        tabindex="-1"
         onTouchStart={this.clearTextInput.bind(this)}
         onMouseDown={this.clearTextInput.bind(this)}
       />


### PR DESCRIPTION
Tabindex or tab in ion-input do not work with clearInput fix

#### Short description of what this resolves:
The clearInput button can no longer use the next tab.

#### Changes proposed in this pull request:

- Add tabindex to -1 to clear button

**Ionic Version**: 4.x

**Fixes**: #
