### PR TITLE
fix(ion-datetime): convert DatetimeData to ISO string

### DIFF
--- a/angular/src/directives/control-value-accessors/select-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/select-value-accessor.ts
@@ -32,7 +32,7 @@ export class SelectValueAccessor implements ControlValueAccessor {
     });
   }
 
-  @HostListener('ionChange', ['$event.target.value'])
+  @HostListener('ionChange', ['$event.detail.value'])
   _handleChangeEvent(value: any) {
     this.onChange(value);
 

--- a/core/src/components/datetime/datetime-util.spec.ts
+++ b/core/src/components/datetime/datetime-util.spec.ts
@@ -1,0 +1,210 @@
+import { convertDataToISO } from './datetime-util';
+
+describe('datetime-util', () => {
+  describe('convertDataToISO', () => {
+    it('prints an emptry string for an empty datetime', () => {
+      expect(convertDataToISO({})).toEqual('');
+    });
+
+    describe('date', () => {
+      it('prints the year', () => {
+        expect(convertDataToISO({ year: 2018 })).toEqual('2018');
+      });
+
+      it('pads out the year', () => {
+        expect(convertDataToISO({ year: 1 })).toEqual('0001');
+      });
+
+      it('prints the month', () => {
+        expect(convertDataToISO({ year: 2018, month: 12 })).toEqual('2018-12');
+      });
+
+      it('pads the month', () => {
+        expect(convertDataToISO({ year: 2018, month: 3 })).toEqual('2018-03');
+      });
+
+      it('prints the day', () => {
+        expect(convertDataToISO({ year: 2018, month: 12, day: 25 })).toEqual(
+          '2018-12-25'
+        );
+      });
+
+      it('pads the day', () => {
+        expect(convertDataToISO({ year: 2018, month: 3, day: 13 })).toEqual(
+          '2018-03-13'
+        );
+      });
+    });
+
+    describe('time', () => {
+      it('prints the hour and minute', () => {
+        expect(convertDataToISO({ hour: 15, minute: 32 })).toEqual('15:32');
+      });
+
+      it('pads the hour and minute', () => {
+        expect(convertDataToISO({ hour: 3, minute: 4 })).toEqual('03:04');
+      });
+
+      it('prints seconds', () => {
+        expect(convertDataToISO({ hour: 15, minute: 32, second: 42 })).toEqual('15:32:42');
+      });
+
+      it('pads seconds', () => {
+        expect(convertDataToISO({ hour: 15, minute: 32, second: 2 })).toEqual('15:32:02');
+      });
+
+      it('prints milliseconds', () => {
+        expect(convertDataToISO({ hour: 15, minute: 32, second:42, millisecond: 143 })).toEqual('15:32:42.143');
+      });
+
+      it('pads milliseconds', () => {
+        expect(convertDataToISO({ hour: 15, minute: 32, second:42, millisecond: 7 })).toEqual('15:32:42.007');
+      });
+    });
+
+    describe('date-time', () => {
+      it('prints the hours and minutes', () => {
+        expect(
+          convertDataToISO({
+            year: 2018,
+            month: 12,
+            day: 25,
+            hour: 14,
+            minute: 42
+          })
+        ).toEqual('2018-12-25T14:42:00Z');
+      });
+
+      it('pads the hours and minutes', () => {
+        expect(
+          convertDataToISO({
+            year: 2018,
+            month: 12,
+            day: 25,
+            hour: 0,
+            minute: 2
+          })
+        ).toEqual('2018-12-25T00:02:00Z');
+      });
+
+      it('prints the seconds', () => {
+        expect(
+          convertDataToISO({
+            year: 2018,
+            month: 12,
+            day: 25,
+            hour: 14,
+            minute: 42,
+            second: 36
+          })
+        ).toEqual('2018-12-25T14:42:36Z');
+      });
+
+      it('pads the seconds', () => {
+        expect(
+          convertDataToISO({
+            year: 2018,
+            month: 12,
+            day: 25,
+            hour: 14,
+            minute: 42,
+            second: 3
+          })
+        ).toEqual('2018-12-25T14:42:03Z');
+      });
+
+      it('prints the milliseconds', () => {
+        expect(
+          convertDataToISO({
+            year: 2018,
+            month: 12,
+            day: 25,
+            hour: 14,
+            minute: 42,
+            second: 23,
+            millisecond: 250
+          })
+        ).toEqual('2018-12-25T14:42:23.250Z');
+      });
+
+      it('pads the milliseconds', () => {
+        expect(
+          convertDataToISO({
+            year: 2018,
+            month: 12,
+            day: 25,
+            hour: 14,
+            minute: 42,
+            second: 23,
+            millisecond: 25
+          })
+        ).toEqual('2018-12-25T14:42:23.025Z');
+      });
+
+      it('appends a whole hour positive offset timezone', () => {
+        expect(
+          convertDataToISO({
+            year: 2018,
+            month: 12,
+            day: 25,
+            hour: 14,
+            minute: 42,
+            tzOffset: 360
+          })
+        ).toEqual('2018-12-25T14:42:00+06:00');
+      });
+
+      it('appends a partial hour positive offset timezone', () => {
+        expect(
+          convertDataToISO({
+            year: 2018,
+            month: 12,
+            day: 25,
+            hour: 14,
+            minute: 42,
+            tzOffset: 390
+          })
+        ).toEqual('2018-12-25T14:42:00+06:30');
+      });
+
+      it('appends a whole hour negative offset timezone', () => {
+        expect(
+          convertDataToISO({
+            year: 2018,
+            month: 12,
+            day: 25,
+            hour: 14,
+            minute: 42,
+            tzOffset: -300
+          })
+        ).toEqual('2018-12-25T14:42:00-05:00');
+      });
+
+      it('appends a whole hour positive offset timezone', () => {
+        expect(
+          convertDataToISO({
+            year: 2018,
+            month: 12,
+            day: 25,
+            hour: 14,
+            minute: 42,
+            tzOffset: -435
+          })
+        ).toEqual('2018-12-25T14:42:00-07:15');
+      });
+
+      it('appends a zero offset timezone', () => {
+        expect(
+          convertDataToISO({
+            year: 2018,
+            month: 12,
+            day: 25,
+            hour: 14,
+            minute: 42,
+            tzOffset: 0
+          })
+        ).toEqual('2018-12-25T14:42:00-00:00');
+      });
+    });
+  });
+});

--- a/core/src/components/datetime/datetime-util.ts
+++ b/core/src/components/datetime/datetime-util.ts
@@ -356,7 +356,7 @@ export function convertDataToISO(data: DatetimeData): string {
 
           } else {
             // YYYY-MM-DDTHH:mm:SS+/-HH:mm
-            rtn += (data.tzOffset > 0 ? '+' : '-') + twoDigit(Math.floor(data.tzOffset / 60)) + ':' + twoDigit(data.tzOffset % 60);
+            rtn += (data.tzOffset > 0 ? '+' : '-') + twoDigit(Math.floor(Math.abs(data.tzOffset / 60))) + ':' + twoDigit(data.tzOffset % 60);
           }
         }
       }

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -4,7 +4,7 @@ import { InputChangeEvent, Mode, PickerColumn, PickerColumnOption, PickerOptions
 import { clamp, deferEvent } from '../../utils/helpers';
 import { hostContext } from '../../utils/theme';
 
-import { DatetimeData, LocaleData, convertFormatToKey, convertToArrayOfNumbers, convertToArrayOfStrings, dateDataSortValue, dateSortValue, dateValueRange, daysInMonth, getValueFromFormat, parseDate, parseTemplate, renderDatetime, renderTextFormat, updateDate } from './datetime-util';
+import { DatetimeData, LocaleData, convertDataToISO, convertFormatToKey, convertToArrayOfNumbers, convertToArrayOfStrings, dateDataSortValue, dateSortValue, dateValueRange, daysInMonth, getValueFromFormat, parseDate, parseTemplate, renderDatetime, renderTextFormat, updateDate } from './datetime-util';
 
 @Component({
   tag: 'ion-datetime',
@@ -189,7 +189,7 @@ export class Datetime implements ComponentInterface {
     this.updateValue();
     this.emitStyle();
     this.ionChange.emit({
-      value: this.value
+      value: convertDataToISO(this.datetimeValue)
     });
   }
 


### PR DESCRIPTION
#### Short description of what this resolves:

Modifies the datetime component to emit the ISO string for the value changed when the value changes. The value itself gets set to the picker structure, so that is no good as something to emit.

NOTE: it may at some point be better to rewrite the component to _not_ use `this.value` as the value returned from the picker, but that would be a much larger and much more error prone rewrite at this point. I would want proper tests in place first.

#### Changes proposed in this pull request:

- emit the ISO date representation of the value rather than the value itself
- modify the CVA to pick up the emitted value rather than the actual value in the target
- start adding unit tests

**Ionic Version**: 4.x

**Fixes**: #15408
