### PR TITLE
chore: Add rollup as dev dependency

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -47,6 +47,7 @@
     "np": "^3.0.4",
     "pixelmatch": "4.0.2",
     "puppeteer": "1.8.0",
+    "rollup": "^0.66.4",
     "rollup-plugin-node-resolve": "^3.4.0",
     "stylelint": "~9.6.0",
     "stylelint-order": "~1.0.0",


### PR DESCRIPTION
#### Short description of what this resolves:

If rollup is not installed as global dependency, you cannot execute `npm run build` (because it runs `build.vendor`). So I added rollup as dev dependency

**Ionic Version**: 4
