### PR TITLE
fix(menu-button): Not visible if toolbar has primary color

### DIFF
--- a/core/src/components/menu-button/menu-button.ios.scss
+++ b/core/src/components/menu-button/menu-button.ios.scss
@@ -5,7 +5,7 @@
 // --------------------------------------------------
 
 :host {
-  color: #{ion-color(primary, base)};
+  --color: #{$menu-button-ios-color};
 }
 
 :host(.activated) {

--- a/core/src/components/menu-button/menu-button.md.scss
+++ b/core/src/components/menu-button/menu-button.md.scss
@@ -3,6 +3,9 @@
 
 // MD Menu Button
 // --------------------------------------------------
+:host {
+  --color: #{$back-button-md-color};
+}
 
 button {
   @include padding(0, 8px);

--- a/core/src/components/menu-button/menu-button.md.scss
+++ b/core/src/components/menu-button/menu-button.md.scss
@@ -4,7 +4,7 @@
 // MD Menu Button
 // --------------------------------------------------
 :host {
-  --color: #{$back-button-md-color};
+  --color: #{$menu-button-md-color};
 }
 
 button {

--- a/core/src/components/menu-button/menu-button.scss
+++ b/core/src/components/menu-button/menu-button.scss
@@ -4,6 +4,8 @@
 // --------------------------------------------------
 
 :host {
+  color: var(--color);
+  
   pointer-events: all;
 
   text-align: center;
@@ -51,4 +53,11 @@ ion-icon {
   @include padding(0);
 
   pointer-events: none;
+}
+
+// Menu Button with Color
+// --------------------------------------------------
+
+:host(.ion-color) .button-native {
+  color: current-color(base);
 }


### PR DESCRIPTION
#### Short description of what this resolves:

The menu-button was not visible if the toolbar got the primary color.

Should it merged? It's just a first step because the back-button has already MANY css variables, the menu button has not. So I think the menu button has to be extended afterwards. So this PR only fixes the color!

#### Changes proposed in this pull request:

- Menu Button is now visible

**Ionic Version**: 4

**Fixes**: #15546 #15545
