### PR TITLE
fix(col): fix CSS is undefined error on IE11

### DIFF
--- a/core/src/components/col/col.tsx
+++ b/core/src/components/col/col.tsx
@@ -2,7 +2,7 @@ import { Component, ComponentInterface, Element, Listen, Prop } from '@stencil/c
 
 import { matchBreakpoint } from '../../utils/media';
 
-const SUPPORTS_VARS = !!(window.CSS && CSS && CSS.supports && CSS.supports('--a: 0'));
+const SUPPORTS_VARS = !!(window.CSS && window.CSS.supports && window.CSS.supports('--a: 0'));
 const BREAKPOINTS = ['', 'xs', 'sm', 'md', 'lg', 'xl'];
 
 @Component({

--- a/core/src/components/col/col.tsx
+++ b/core/src/components/col/col.tsx
@@ -2,7 +2,7 @@ import { Component, ComponentInterface, Element, Listen, Prop } from '@stencil/c
 
 import { matchBreakpoint } from '../../utils/media';
 
-const SUPPORTS_VARS = !!(CSS && CSS.supports && CSS.supports('--a: 0'));
+const SUPPORTS_VARS = !!(window.CSS && CSS && CSS.supports && CSS.supports('--a: 0'));
 const BREAKPOINTS = ['', 'xs', 'sm', 'md', 'lg', 'xl'];
 
 @Component({


### PR DESCRIPTION
#### Short description of what this resolves:
Resolve a bug when using the component ion-col with a stencil app on IE11
Related to issue #15881 

#### Changes proposed in this pull request:

- update ion-col component

**Ionic Version**: 4.x

#### Fixes: #15881 