### PR TITLE
Popover documentation link

### DIFF
--- a/core/src/components/popover/readme.md
+++ b/core/src/components/popover/readme.md
@@ -4,7 +4,7 @@ A Popover is a dialog that appears on top of the current page. It can be used fo
 
 ### Creating
 
-Popovers can be created using a [Popover Controller](../../components/popover-controller). They can be customized by passing popover options in the popover controller's create method.
+Popovers can be created using a [Popover Controller](../popover-controller). They can be customized by passing popover options in the popover controller's create method.
 
 ### Presenting
 

--- a/core/src/components/popover/readme.md
+++ b/core/src/components/popover/readme.md
@@ -4,7 +4,7 @@ A Popover is a dialog that appears on top of the current page. It can be used fo
 
 ### Creating
 
-Popovers can be created using a [Popover Controller](../../popover-controller). They can be customized by passing popover options in the popover controller's create method.
+Popovers can be created using a [Popover Controller](../../components/popover-controller). They can be customized by passing popover options in the popover controller's create method.
 
 ### Presenting
 

--- a/core/src/components/popover/readme.md
+++ b/core/src/components/popover/readme.md
@@ -4,7 +4,7 @@ A Popover is a dialog that appears on top of the current page. It can be used fo
 
 ### Creating
 
-Popovers can be created using a [Popover Controller](../../popover-controller/PopoverController). They can be customized by passing popover options in the popover controller's create method.
+Popovers can be created using a [Popover Controller](../../popover-controller). They can be customized by passing popover options in the popover controller's create method.
 
 ### Presenting
 


### PR DESCRIPTION
#### Short description of what this resolves:
ref to popover controller is misdirected

#### Changes proposed in this pull request:

links to controller documentation
-
-

**Ionic Version**: 1.x / 2.x / 3.x / 4.x
“fixes #16019”
**Fixes**: #
