### PR TITLE
test(all): use test() instead of it() where appropriate

### DIFF
--- a/core/src/components/action-sheet/test/alert-from-action-sheet/e2e.ts
+++ b/core/src/components/action-sheet/test/alert-from-action-sheet/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('action-sheet: alertFromActionSheet', async () => {
+test('action-sheet: alertFromActionSheet', async () => {
   const page = await newE2EPage({
     url: `/src/components/action-sheet/test/alert-from-action-sheet?ionic:_testing=true`
   });

--- a/core/src/components/action-sheet/test/basic/e2e.ts
+++ b/core/src/components/action-sheet/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('action-sheet: basic', async () => {
+test('action-sheet: basic', async () => {
   const page = await newE2EPage({
     url: `/src/components/action-sheet/test/basic?ionic:_testing=true`
   });

--- a/core/src/components/action-sheet/test/cancel-only/e2e.ts
+++ b/core/src/components/action-sheet/test/cancel-only/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('action-sheet: cancelOnly', async () => {
+test('action-sheet: cancelOnly', async () => {
   const page = await newE2EPage({
     url: `/src/components/action-sheet/test/cancel-only?ionic:_testing=true`
   });

--- a/core/src/components/action-sheet/test/custom-css/e2e.ts
+++ b/core/src/components/action-sheet/test/custom-css/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('action-sheet: cssClass', async () => {
+test('action-sheet: cssClass', async () => {
   const page = await newE2EPage({
     url: `/src/components/action-sheet/test/custom-css?ionic:_testing=true`
   });

--- a/core/src/components/action-sheet/test/icons/e2e.ts
+++ b/core/src/components/action-sheet/test/icons/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('action-sheet: icons', async () => {
+test('action-sheet: icons', async () => {
   const page = await newE2EPage({
     url: `/src/components/action-sheet/test/icons?ionic:_testing=true`
   });

--- a/core/src/components/action-sheet/test/no-backdrop-dismiss/e2e.ts
+++ b/core/src/components/action-sheet/test/no-backdrop-dismiss/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('action-sheet: noBackdropDismiss', async () => {
+test('action-sheet: noBackdropDismiss', async () => {
   const page = await newE2EPage({
     url: `/src/components/action-sheet/test/no-backdrop-dismiss?ionic:_testing=true`
   });

--- a/core/src/components/action-sheet/test/scroll-without-cancel/e2e.ts
+++ b/core/src/components/action-sheet/test/scroll-without-cancel/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('action-sheet: scrollWithoutCancel', async () => {
+test('action-sheet: scrollWithoutCancel', async () => {
   const page = await newE2EPage({
     url: `/src/components/action-sheet/test/scroll-without-cancel?ionic:_testing=true`
   });

--- a/core/src/components/action-sheet/test/scrollable-options/e2e.ts
+++ b/core/src/components/action-sheet/test/scrollable-options/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('action-sheet: scrollableOptions', async () => {
+test('action-sheet: scrollableOptions', async () => {
   const page = await newE2EPage({
     url: `/src/components/action-sheet/test/scrollable-options?ionic:_testing=true`
   });

--- a/core/src/components/alert/test/basic/e2e.ts
+++ b/core/src/components/alert/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('alert: basic', async () => {
+test('alert: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/alert/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/alert/test/standalone/e2e.ts
+++ b/core/src/components/alert/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('alert: standalone', async () => {
+test('alert: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/alert/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/avatar/test/standalone/e2e.ts
+++ b/core/src/components/avatar/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('avatar: standalone', async () => {
+test('avatar: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/avatar/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/badge/test/basic/e2e.ts
+++ b/core/src/components/badge/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('badge: basic', async () => {
+test('badge: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/badge/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/badge/test/standalone/e2e.ts
+++ b/core/src/components/badge/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('badge: standalone', async () => {
+test('badge: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/badge/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/button/test/anchor/e2e.ts
+++ b/core/src/components/button/test/anchor/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('button: anchor', async () => {
+test('button: anchor', async () => {
   const page = await newE2EPage({
     url: '/src/components/button/test/anchor?ionic:_testing=true'
   });

--- a/core/src/components/button/test/basic/e2e.ts
+++ b/core/src/components/button/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('button: basic', async () => {
+test('button: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/button/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/button/test/clear/e2e.ts
+++ b/core/src/components/button/test/clear/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('button: clear', async () => {
+test('button: clear', async () => {
   const page = await newE2EPage({
     url: '/src/components/button/test/clear?ionic:_testing=true'
   });

--- a/core/src/components/button/test/expand/e2e.ts
+++ b/core/src/components/button/test/expand/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('button: expand', async () => {
+test('button: expand', async () => {
   const page = await newE2EPage({
     url: '/src/components/button/test/expand?ionic:_testing=true'
   });

--- a/core/src/components/button/test/icon/e2e.ts
+++ b/core/src/components/button/test/icon/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('button: icon', async () => {
+test('button: icon', async () => {
   const page = await newE2EPage({
     url: '/src/components/button/test/icon?ionic:_testing=true'
   });

--- a/core/src/components/button/test/outline/e2e.ts
+++ b/core/src/components/button/test/outline/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('button: outline', async () => {
+test('button: outline', async () => {
   const page = await newE2EPage({
     url: '/src/components/button/test/outline?ionic:_testing=true'
   });

--- a/core/src/components/button/test/round/e2e.ts
+++ b/core/src/components/button/test/round/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('button: round', async () => {
+test('button: round', async () => {
   const page = await newE2EPage({
     url: '/src/components/button/test/round?ionic:_testing=true'
   });

--- a/core/src/components/button/test/size/e2e.ts
+++ b/core/src/components/button/test/size/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('button: size', async () => {
+test('button: size', async () => {
   const page = await newE2EPage({
     url: '/src/components/button/test/size?ionic:_testing=true'
   });

--- a/core/src/components/button/test/standalone/e2e.ts
+++ b/core/src/components/button/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('button: standalone', async () => {
+test('button: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/button/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/button/test/strong/e2e.ts
+++ b/core/src/components/button/test/strong/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('button: strong', async () => {
+test('button: strong', async () => {
   const page = await newE2EPage({
     url: '/src/components/button/test/strong?ionic:_testing=true'
   });

--- a/core/src/components/button/test/toolbar/e2e.ts
+++ b/core/src/components/button/test/toolbar/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('button: toolbar', async () => {
+test('button: toolbar', async () => {
   const page = await newE2EPage({
     url: '/src/components/button/test/toolbar?ionic:_testing=true'
   });

--- a/core/src/components/card-header/test/basic/e2e.ts
+++ b/core/src/components/card-header/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('card-header: basic', async () => {
+test('card-header: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/card-header/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/card/test/basic/e2e.ts
+++ b/core/src/components/card/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('card: basic', async () => {
+test('card: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/card/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/card/test/standalone/e2e.ts
+++ b/core/src/components/card/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('card: standalone', async () => {
+test('card: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/card/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/checkbox/test/basic/e2e.ts
+++ b/core/src/components/checkbox/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('checkbox: basic', async () => {
+test('checkbox: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/checkbox/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/checkbox/test/standalone/e2e.ts
+++ b/core/src/components/checkbox/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('checkbox: standalone', async () => {
+test('checkbox: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/checkbox/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/chip/test/basic/e2e.ts
+++ b/core/src/components/chip/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('chip: basic', async () => {
+test('chip: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/chip/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/chip/test/standalone/e2e.ts
+++ b/core/src/components/chip/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('chip: standalone', async () => {
+test('chip: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/chip/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/content/test/basic/e2e.ts
+++ b/core/src/components/content/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('content: basic', async () => {
+test('content: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/content/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/content/test/fullscreen/e2e.ts
+++ b/core/src/components/content/test/fullscreen/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('content: fullscreen', async () => {
+test('content: fullscreen', async () => {
   const page = await newE2EPage({
     url: '/src/components/content/test/fullscreen?ionic:_testing=true'
   });

--- a/core/src/components/content/test/standalone/e2e.ts
+++ b/core/src/components/content/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('content: standalone', async () => {
+test('content: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/content/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/datetime/test/basic/e2e.ts
+++ b/core/src/components/datetime/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('datetime: basic', async () => {
+test('datetime: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/datetime/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/datetime/test/standalone/e2e.ts
+++ b/core/src/components/datetime/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('datetime: standalone', async () => {
+test('datetime: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/datetime/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/fab-button/test/standalone/e2e.ts
+++ b/core/src/components/fab-button/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('fab-button: standalone', async () => {
+test('fab-button: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/fab-button/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/fab/test/basic/e2e.ts
+++ b/core/src/components/fab/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('fab: basic', async () => {
+test('fab: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/fab/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/fab/test/standalone/e2e.ts
+++ b/core/src/components/fab/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('fab: standalone', async () => {
+test('fab: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/fab/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/grid/test/basic/e2e.ts
+++ b/core/src/components/grid/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('grid: basic', async () => {
+test('grid: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/grid/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/grid/test/offsets/e2e.ts
+++ b/core/src/components/grid/test/offsets/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('grid: offsets', async () => {
+test('grid: offsets', async () => {
   const page = await newE2EPage({
     url: '/src/components/grid/test/offsets?ionic:_testing=true'
   });

--- a/core/src/components/grid/test/padding/e2e.ts
+++ b/core/src/components/grid/test/padding/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('grid: padding', async () => {
+test('grid: padding', async () => {
   const page = await newE2EPage({
     url: '/src/components/grid/test/padding?ionic:_testing=true'
   });

--- a/core/src/components/grid/test/sizes/e2e.ts
+++ b/core/src/components/grid/test/sizes/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('grid: sizes', async () => {
+test('grid: sizes', async () => {
   const page = await newE2EPage({
     url: '/src/components/grid/test/sizes?ionic:_testing=true'
   });

--- a/core/src/components/grid/test/standalone/e2e.ts
+++ b/core/src/components/grid/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('grid: standalone', async () => {
+test('grid: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/grid/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/icon/test/basic/e2e.ts
+++ b/core/src/components/icon/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('icon: basic', async () => {
+test('icon: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/icon/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/icon/test/items/e2e.ts
+++ b/core/src/components/icon/test/items/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('icon: items', async () => {
+test('icon: items', async () => {
   const page = await newE2EPage({
     url: '/src/components/icon/test/items?ionic:_testing=true'
   });

--- a/core/src/components/icon/test/standalone/e2e.ts
+++ b/core/src/components/icon/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('icon: standalone', async () => {
+test('icon: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/icon/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/img/test/basic/e2e.ts
+++ b/core/src/components/img/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('img: basic', async () => {
+test('img: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/img/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/img/test/standalone/e2e.ts
+++ b/core/src/components/img/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('img: standalone', async () => {
+test('img: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/img/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/infinite-scroll/test/basic/e2e.ts
+++ b/core/src/components/infinite-scroll/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('infinite-scroll: basic', async () => {
+test('infinite-scroll: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/infinite-scroll/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/infinite-scroll/test/standalone/e2e.ts
+++ b/core/src/components/infinite-scroll/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('infinite-scroll: standalone', async () => {
+test('infinite-scroll: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/infinite-scroll/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/infinite-scroll/test/top/e2e.ts
+++ b/core/src/components/infinite-scroll/test/top/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('infinite-scroll: basic', async () => {
+test('infinite-scroll: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/infinite-scroll/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/input/test/basic/e2e.ts
+++ b/core/src/components/input/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('input: basic', async () => {
+test('input: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/input/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/input/test/standalone/e2e.ts
+++ b/core/src/components/input/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('input: standalone', async () => {
+test('input: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/input/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/item-sliding/test/basic/e2e.ts
+++ b/core/src/components/item-sliding/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('item-sliding: basic', async () => {
+test('item-sliding: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/item-sliding/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/item-sliding/test/standalone/e2e.ts
+++ b/core/src/components/item-sliding/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('item-sliding: standalone', async () => {
+test('item-sliding: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/item-sliding/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/item/test/basic/e2e.ts
+++ b/core/src/components/item/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('item: basic', async () => {
+test('item: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/item/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/item/test/buttons/e2e.ts
+++ b/core/src/components/item/test/buttons/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('item: buttons', async () => {
+test('item: buttons', async () => {
   const page = await newE2EPage({
     url: '/src/components/item/test/buttons?ionic:_testing=true'
   });

--- a/core/src/components/item/test/colors/e2e.ts
+++ b/core/src/components/item/test/colors/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('item: colors', async () => {
+test('item: colors', async () => {
   const page = await newE2EPage({
     url: '/src/components/item/test/colors?ionic:_testing=true'
   });

--- a/core/src/components/item/test/dividers/e2e.ts
+++ b/core/src/components/item/test/dividers/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('item: dividers', async () => {
+test('item: dividers', async () => {
   const page = await newE2EPage({
     url: '/src/components/item/test/dividers?ionic:_testing=true'
   });

--- a/core/src/components/item/test/groups/e2e.ts
+++ b/core/src/components/item/test/groups/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('item: groups', async () => {
+test('item: groups', async () => {
   const page = await newE2EPage({
     url: '/src/components/item/test/groups?ionic:_testing=true'
   });

--- a/core/src/components/item/test/icons/e2e.ts
+++ b/core/src/components/item/test/icons/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('item: icons', async () => {
+test('item: icons', async () => {
   const page = await newE2EPage({
     url: '/src/components/item/test/icons?ionic:_testing=true'
   });

--- a/core/src/components/item/test/images/e2e.ts
+++ b/core/src/components/item/test/images/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('item: images', async () => {
+test('item: images', async () => {
   const page = await newE2EPage({
     url: '/src/components/item/test/images?ionic:_testing=true'
   });

--- a/core/src/components/item/test/inputs/e2e.ts
+++ b/core/src/components/item/test/inputs/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('item: inputs', async () => {
+test('item: inputs', async () => {
   const page = await newE2EPage({
     url: '/src/components/item/test/inputs?ionic:_testing=true'
   });

--- a/core/src/components/item/test/lines/e2e.ts
+++ b/core/src/components/item/test/lines/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('item: lines', async () => {
+test('item: lines', async () => {
   const page = await newE2EPage({
     url: '/src/components/item/test/lines?ionic:_testing=true'
   });

--- a/core/src/components/item/test/media/e2e.ts
+++ b/core/src/components/item/test/media/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('item: media', async () => {
+test('item: media', async () => {
   const page = await newE2EPage({
     url: '/src/components/item/test/media?ionic:_testing=true'
   });

--- a/core/src/components/item/test/reorder/e2e.ts
+++ b/core/src/components/item/test/reorder/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('item: reorder', async () => {
+test('item: reorder', async () => {
   const page = await newE2EPage({
     url: '/src/components/item/test/reorder?ionic:_testing=true'
   });

--- a/core/src/components/item/test/sliding/e2e.ts
+++ b/core/src/components/item/test/sliding/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('item: sliding', async () => {
+test('item: sliding', async () => {
   const page = await newE2EPage({
     url: '/src/components/item/test/sliding?ionic:_testing=true'
   });

--- a/core/src/components/item/test/standalone/e2e.ts
+++ b/core/src/components/item/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('item: standalone', async () => {
+test('item: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/item/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/item/test/text/e2e.ts
+++ b/core/src/components/item/test/text/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('item: text', async () => {
+test('item: text', async () => {
   const page = await newE2EPage({
     url: '/src/components/item/test/text?ionic:_testing=true'
   });

--- a/core/src/components/label/test/basic/e2e.ts
+++ b/core/src/components/label/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('label: basic', async () => {
+test('label: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/label/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/label/test/standalone/e2e.ts
+++ b/core/src/components/label/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('label: standalone', async () => {
+test('label: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/label/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/list/test/basic/e2e.ts
+++ b/core/src/components/list/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('list: basic', async () => {
+test('list: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/list/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/list/test/inset/e2e.ts
+++ b/core/src/components/list/test/inset/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('list: inset', async () => {
+test('list: inset', async () => {
   const page = await newE2EPage({
     url: '/src/components/list/test/inset?ionic:_testing=true'
   });

--- a/core/src/components/list/test/lines/e2e.ts
+++ b/core/src/components/list/test/lines/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('list: lines', async () => {
+test('list: lines', async () => {
   const page = await newE2EPage({
     url: '/src/components/list/test/lines?ionic:_testing=true'
   });

--- a/core/src/components/list/test/standalone/e2e.ts
+++ b/core/src/components/list/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('list: standalone', async () => {
+test('list: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/list/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/loading/test/basic/e2e.ts
+++ b/core/src/components/loading/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('loading: basic', async () => {
+test('loading: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/loading/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/loading/test/standalone/e2e.ts
+++ b/core/src/components/loading/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('loading: standalone', async () => {
+test('loading: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/loading/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/menu-button/test/standalone/e2e.ts
+++ b/core/src/components/menu-button/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('menu-button: standalone', async () => {
+test('menu-button: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/menu-button/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/modal/test/basic/e2e.ts
+++ b/core/src/components/modal/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('modal: basic', async () => {
+test('modal: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/modal/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/modal/test/standalone/e2e.ts
+++ b/core/src/components/modal/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('modal: standalone', async () => {
+test('modal: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/modal/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/nav/test/basic/e2e.ts
+++ b/core/src/components/nav/test/basic/e2e.ts
@@ -2,7 +2,7 @@ import { newE2EPage } from '@stencil/core/testing';
 
 const navChanged = () => new Promise(resolve => window.addEventListener('ionNavDidChange', resolve));
 
-it('nav: basic', async () => {
+test('nav: basic', async () => {
 
   const page = await newE2EPage({
     url: '/src/components/nav/test/basic?ionic:_testing=true'

--- a/core/src/components/nav/test/nested/e2e.ts
+++ b/core/src/components/nav/test/nested/e2e.ts
@@ -3,7 +3,7 @@ import { newE2EPage } from '@stencil/core/testing';
 const navChanged = () => new Promise(resolve => window.addEventListener('ionNavDidChange', resolve));
 
 // TODO: get this to pass
-it.skip('nav: nested', async () => {
+test.skip('nav: nested', async () => {
 
   const page = await newE2EPage({
     url: '/src/components/nav/test/nested?ionic:_testing=true'

--- a/core/src/components/nav/test/routing/e2e.ts
+++ b/core/src/components/nav/test/routing/e2e.ts
@@ -2,7 +2,7 @@ import { newE2EPage } from '@stencil/core/testing';
 
 const navChanged = () => new Promise(resolve => window.addEventListener('ionRouteDidChange', resolve));
 
-it('nav: routing', async () => {
+test('nav: routing', async () => {
 
   const page = await newE2EPage({
     url: '/src/components/nav/test/routing?ionic:_testing=true'

--- a/core/src/components/note/test/basic/e2e.ts
+++ b/core/src/components/note/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('note: basic', async () => {
+test('note: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/note/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/note/test/standalone/e2e.ts
+++ b/core/src/components/note/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('note: standalone', async () => {
+test('note: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/note/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/popover/test/basic/e2e.ts
+++ b/core/src/components/popover/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('popover: basic', async () => {
+test('popover: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/popover/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/popover/test/standalone/e2e.ts
+++ b/core/src/components/popover/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('popover: standalone', async () => {
+test('popover: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/popover/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/radio-group/test/standalone/e2e.ts
+++ b/core/src/components/radio-group/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('radio-group: standalone', async () => {
+test('radio-group: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/radio-group/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/radio/test/basic/e2e.ts
+++ b/core/src/components/radio/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('radio: basic', async () => {
+test('radio: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/radio/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/radio/test/standalone/e2e.ts
+++ b/core/src/components/radio/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('radio: standalone', async () => {
+test('radio: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/radio/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/range/test/basic/e2e.ts
+++ b/core/src/components/range/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('range: basic', async () => {
+test('range: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/range/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/range/test/standalone/e2e.ts
+++ b/core/src/components/range/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('range: standalone', async () => {
+test('range: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/range/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/refresher/test/basic/e2e.ts
+++ b/core/src/components/refresher/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('refresher: basic', async () => {
+test('refresher: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/refresher/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/reorder-group/test/basic/e2e.ts
+++ b/core/src/components/reorder-group/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('reorder: basic', async () => {
+test('reorder: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/reorder-group/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/reorder-group/test/standalone/e2e.ts
+++ b/core/src/components/reorder-group/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('reorder: standalone', async () => {
+test('reorder: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/reorder-group/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/searchbar/test/basic/e2e.ts
+++ b/core/src/components/searchbar/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('searchbar: basic', async () => {
+test('searchbar: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/searchbar/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/searchbar/test/standalone/e2e.ts
+++ b/core/src/components/searchbar/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('searchbar: standalone', async () => {
+test('searchbar: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/searchbar/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/searchbar/test/toolbar/e2e.ts
+++ b/core/src/components/searchbar/test/toolbar/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('searchbar: toolbar', async () => {
+test('searchbar: toolbar', async () => {
   const page = await newE2EPage({
     url: '/src/components/searchbar/test/toolbar?ionic:_testing=true'
   });

--- a/core/src/components/segment/test/basic/e2e.ts
+++ b/core/src/components/segment/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('segment: basic', async () => {
+test('segment: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/segment/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/segment/test/modes/e2e.ts
+++ b/core/src/components/segment/test/modes/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('segment: modes', async () => {
+test('segment: modes', async () => {
   const page = await newE2EPage({
     url: '/src/components/segment/test/modes?ionic:_testing=true'
   });

--- a/core/src/components/segment/test/standalone/e2e.ts
+++ b/core/src/components/segment/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('segment: standalone', async () => {
+test('segment: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/segment/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/select/test/basic/e2e.ts
+++ b/core/src/components/select/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('select: basic', async () => {
+test('select: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/select/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/select/test/multiple-value/e2e.ts
+++ b/core/src/components/select/test/multiple-value/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('select: multiple-value', async () => {
+test('select: multiple-value', async () => {
   const page = await newE2EPage({
     url: '/src/components/select/test/multiple-value?ionic:_testing=true'
   });

--- a/core/src/components/select/test/single-value/e2e.ts
+++ b/core/src/components/select/test/single-value/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('select: single-value', async () => {
+test('select: single-value', async () => {
   const page = await newE2EPage({
     url: '/src/components/select/test/single-value?ionic:_testing=true'
   });

--- a/core/src/components/select/test/standalone/e2e.ts
+++ b/core/src/components/select/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('select: standalone', async () => {
+test('select: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/select/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/slides/test/basic/e2e.ts
+++ b/core/src/components/slides/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('slides: basic', async () => {
+test('slides: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/slides/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/slides/test/standalone/e2e.ts
+++ b/core/src/components/slides/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('slides: standalone', async () => {
+test('slides: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/slides/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/spinner/test/basic/e2e.ts
+++ b/core/src/components/spinner/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('spinner: basic', async () => {
+test('spinner: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/spinner/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/spinner/test/color/e2e.ts
+++ b/core/src/components/spinner/test/color/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('spinner: color', async () => {
+test('spinner: color', async () => {
   const page = await newE2EPage({
     url: '/src/components/spinner/test/color?ionic:_testing=true'
   });

--- a/core/src/components/spinner/test/standalone/e2e.ts
+++ b/core/src/components/spinner/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('spinner: standalone', async () => {
+test('spinner: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/spinner/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/split-pane/test/basic/e2e.ts
+++ b/core/src/components/split-pane/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('split-pane: basic', async () => {
+test('split-pane: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/split-pane/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/tab-bar/test/scenarios/e2e.ts
+++ b/core/src/components/tab-bar/test/scenarios/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('tab-bar: scenarios', async () => {
+test('tab-bar: scenarios', async () => {
   const page = await newE2EPage({
     url: '/src/components/tab-bar/test/scenarios?ionic:_testing=true'
   });

--- a/core/src/components/tabs/test/basic/e2e.ts
+++ b/core/src/components/tabs/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('tab-group: basic', async () => {
+test('tab-group: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/tab-group/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/tabs/test/placements/e2e.ts
+++ b/core/src/components/tabs/test/placements/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('tab-group: placements', async () => {
+test('tab-group: placements', async () => {
   const page = await newE2EPage({
     url: '/src/components/tab-group/test/placements?ionic:_testing=true'
   });

--- a/core/src/components/text/test/basic/e2e.ts
+++ b/core/src/components/text/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('text: basic', async () => {
+test('text: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/text/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/textarea/test/basic/e2e.ts
+++ b/core/src/components/textarea/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('textarea: basic', async () => {
+test('textarea: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/textarea/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/textarea/test/standalone/e2e.ts
+++ b/core/src/components/textarea/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('textarea: standalone', async () => {
+test('textarea: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/textarea/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/thumbnail/test/basic/e2e.ts
+++ b/core/src/components/thumbnail/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('thumbnail: basic', async () => {
+test('thumbnail: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/thumbnail/test/basic'
   });

--- a/core/src/components/thumbnail/test/standalone/e2e.ts
+++ b/core/src/components/thumbnail/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('thumbnail: standalone', async () => {
+test('thumbnail: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/thumbnail/test/standalone'
   });

--- a/core/src/components/toast/test/basic/e2e.ts
+++ b/core/src/components/toast/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('toast: basic', async () => {
+test('toast: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/toast/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/toast/test/standalone/e2e.ts
+++ b/core/src/components/toast/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('toast: standalone', async () => {
+test('toast: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/toast/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/toggle/test/basic/e2e.ts
+++ b/core/src/components/toggle/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('toggle: basic', async () => {
+test('toggle: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/toggle/test/basic?ionic:_testing=true'
   });

--- a/core/src/components/toggle/test/standalone/e2e.ts
+++ b/core/src/components/toggle/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('toggle: standalone', async () => {
+test('toggle: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/toggle/test/standalone?ionic:_testing=true'
   });

--- a/core/src/components/toolbar/test/basic/e2e.ts
+++ b/core/src/components/toolbar/test/basic/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('toolbar: basic', async () => {
+test('toolbar: basic', async () => {
   const page = await newE2EPage({
     url: '/src/components/toolbar/test/basic'
   });

--- a/core/src/components/toolbar/test/colors/e2e.ts
+++ b/core/src/components/toolbar/test/colors/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('toolbar: colors', async () => {
+test('toolbar: colors', async () => {
   const page = await newE2EPage({
     url: '/src/components/toolbar/test/colors'
   });

--- a/core/src/components/toolbar/test/scenarios/e2e.ts
+++ b/core/src/components/toolbar/test/scenarios/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('toolbar: scenarios', async () => {
+test('toolbar: scenarios', async () => {
   const page = await newE2EPage({
     url: '/src/components/toolbar/test/scenarios'
   });

--- a/core/src/components/toolbar/test/standalone/e2e.ts
+++ b/core/src/components/toolbar/test/standalone/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('toolbar: standalone', async () => {
+test('toolbar: standalone', async () => {
   const page = await newE2EPage({
     url: '/src/components/toolbar/test/standalone'
   });

--- a/core/src/themes/test/css-variables/e2e.ts
+++ b/core/src/themes/test/css-variables/e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-it('themes: css-variables', async () => {
+test('themes: css-variables', async () => {
   const page = await newE2EPage({
     url: '/src/themes/test/css-variables?ionic:_testing=true'
   });


### PR DESCRIPTION
This replaces uses of Jest's it() function in end-to-end tests with the alias test() where it makes sense semantically.