### PR TITLE
fix(tab-bar): align tab text to the center

### DIFF
--- a/core/src/components/tab-bar/tab-bar.scss
+++ b/core/src/components/tab-bar/tab-bar.scss
@@ -17,6 +17,8 @@
   background: var(--background);
   color: var(--color);
 
+  text-align: center;
+
   contain: strict;
   user-select: none;
   z-index: $z-index-toolbar;

--- a/core/src/components/tab-bar/test/scenarios/index.html
+++ b/core/src/components/tab-bar/test/scenarios/index.html
@@ -77,7 +77,7 @@
 
       <ion-tab-button tab='2' layout="icon-top">
         <ion-badge>6</ion-badge>
-        <ion-label>Favorites</ion-label>
+        <ion-label>hi</ion-label>
         <ion-icon name="heart"></ion-icon>
       </ion-tab-button>
 


### PR DESCRIPTION
#### Short description of what this resolves:
Aligns the tab-bar text to the center by default

**Ionic Version**: 1.x / 2.x / 3.x / <b>4.x</b>

**Fixes**: #15273

| `master`   | `fix-tab-bar-align` |
| -----------| --------------------|
 ![](https://user-images.githubusercontent.com/6577830/47670142-e17b8480-db82-11e8-8685-f48c48ce5bae.png) | ![](https://user-images.githubusercontent.com/6577830/47670140-e04a5780-db82-11e8-8a17-d676262c32b4.png) |

