### PR TITLE
docs(tabs): document custom properties

### DIFF
--- a/core/src/components/tab-bar/readme.md
+++ b/core/src/components/tab-bar/readme.md
@@ -36,6 +36,15 @@ In order to have a custom tab bar, it should be provided in user's markup as dir
 | `translucent` | `translucent`  | If `true`, the tab bar will be translucent.                                                                                                                                                                                                                            | `boolean`                                                                                  | `false`      |
 
 
+## CSS Custom Properties
+
+| Name           | Description               |
+| -------------- | ------------------------- |
+| `--background` | Background of the tab bar |
+| `--border`     | Border of the tab bar     |
+| `--color`      | Color of the tab bar      |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/tab-bar/tab-bar.scss
+++ b/core/src/components/tab-bar/tab-bar.scss
@@ -1,6 +1,12 @@
 @import "../../themes/ionic.globals";
 
 :host {
+  /**
+   * @prop --background: Background of the tab bar
+   * @prop --border: Border of the tab bar
+   * @prop --color: Color of the tab bar
+   */
+
   @include padding-horizontal(
     var(--ion-safe-area-left),
     var(--ion-safe-area-right)

--- a/core/src/components/tab-button/readme.md
+++ b/core/src/components/tab-button/readme.md
@@ -20,6 +20,20 @@ See the [Tabs API Docs](../Tabs/) for more details on configuring Tabs.
 | `tab`      | `tab`      | A tab id must be provided for each `ion-tab`. It's used internally to reference the selected tab or by the router to switch between them.                                                                                                                              | `string`                                                                                                | `undefined` |
 
 
+## CSS Custom Properties
+
+| Name                    | Description                           |
+| ----------------------- | ------------------------------------- |
+| `--background`          | Background of the tab button          |
+| `--background-selected` | Background of the selected tab button |
+| `--color`               | Color of the tab button               |
+| `--color-selected`      | Color of the selected tab button      |
+| `--padding-bottom`      | Bottom padding of the tab button      |
+| `--padding-end`         | End padding of the tab button         |
+| `--padding-start`       | Start padding of the tab button       |
+| `--padding-top`         | Top padding of the tab button         |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/tab-button/tab-button.scss
+++ b/core/src/components/tab-button/tab-button.scss
@@ -1,6 +1,17 @@
 @import "../../themes/ionic.globals";
 
 :host {
+  /**
+   * @prop --background: Background of the tab button
+   * @prop --background-selected: Background of the selected tab button
+   * @prop --color: Color of the tab button
+   * @prop --color-selected: Color of the selected tab button
+   * @prop --padding-top: Top padding of the tab button
+   * @prop --padding-end: End padding of the tab button
+   * @prop --padding-bottom: Bottom padding of the tab button
+   * @prop --padding-start: Start padding of the tab button
+   */
+
   --badge-end: 4%;
 
   flex: 1;

--- a/core/src/components/tab-button/tab-button.scss
+++ b/core/src/components/tab-button/tab-button.scss
@@ -11,7 +11,6 @@
    * @prop --padding-bottom: Bottom padding of the tab button
    * @prop --padding-start: Start padding of the tab button
    */
-
   --badge-end: 4%;
 
   flex: 1;


### PR DESCRIPTION
This adds documentation for the custom properties in the new tabs API. The `ion-tabs` and `ion-tab` components are mostly style-less, so that leaves `ion-tab-bar` and `ion-tab-button`. **Note** that I skipped documenting tab-button's `--badge-end` property to suggest we reconsider that naming.