### PR TITLE
fix(view-controller): fix memory leak when destroying ViewController

### DIFF
--- a/src/navigation/view-controller.ts
+++ b/src/navigation/view-controller.ts
@@ -40,6 +40,7 @@ export class ViewController {
   private _dismissData: any;
   private _dismissRole: string;
   private _detached: boolean;
+  private _boundHandleOrientationChange: () => void;
 
   _cmp: ComponentRef<any>;
   _nav: NavController;
@@ -113,7 +114,9 @@ export class ViewController {
 
     this._cssClass = rootCssClass;
     this._ts = Date.now();
-    window.addEventListener('orientationchange', this.handleOrientationChange.bind(this));
+
+    this._boundHandleOrientationChange = this.handleOrientationChange.bind(this);
+    window.addEventListener('orientationchange', this._boundHandleOrientationChange);
   }
 
   handleOrientationChange() {
@@ -542,7 +545,7 @@ export class ViewController {
         renderer.setElementAttribute(cmpEle, 'style', null);
       }
 
-      window.removeEventListener('orientationchange', this.handleOrientationChange.bind(this));
+      window.removeEventListener('orientationchange', this._boundHandleOrientationChange);
       // completely destroy this component. boom.
       this._cmp.destroy();
     }


### PR DESCRIPTION
There's a memory leak when opening modals and popovers (and every other classes that inherits from ViewController) which causes the application to crash.

#### Short description of what this resolves:
This fixes a memory leak that was caused by an event listener that was added in ViewController's constructor but wasn't properly removed when ViewController was destroyed.

Related : https://github.com/ionic-team/ionic/issues/12574#issuecomment-368843850

**Ionic Version**: 3.9.2
