### PR TITLE
fix(range): increase MD horizontal padding

### DIFF
--- a/core/src/components/range/range.md.vars.scss
+++ b/core/src/components/range/range.md.vars.scss
@@ -7,7 +7,7 @@
 $range-md-padding-vertical:                  8px !default;
 
 /// @prop - Padding start/end of the range
-$range-md-padding-horizontal:                8px !default;
+$range-md-padding-horizontal:                14px !default;
 
 /// @prop - Height of the range slider
 $range-md-slider-height:                     42px !default;


### PR DESCRIPTION
This increases the horizontal padding on Material Design
range to prevent clipping within item.

<img width="319" alt="screen shot 2018-11-13 at 10 24 39 am" src="https://user-images.githubusercontent.com/2547860/48428517-ce46e800-e730-11e8-9dcf-45de90fa66f6.png">