### PR TITLE
fix(transpiling): will work in old browsers

### DIFF
--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -22,7 +22,7 @@
     "outDir": ".tmp",
     "pretty": true,
     "removeComments": false,
-    "target": "es2017"
+    "target": "es5"
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes "Uncaught SyntaxError: Use of const in strict mode." in old browsers.

#### Changes proposed in this pull request:
- This modification is based on this comment: #15438 

**Ionic Version**: 4.0.0-beta.16

**Fixes**: #15438 and #15038
