### PR TITLE
fix(toast): Make longer toasts available with pre-wrap

### DIFF
--- a/core/src/components/toast/toast.scss
+++ b/core/src/components/toast/toast.scss
@@ -54,5 +54,5 @@
 .toast-message {
   flex: 1;
 
-  white-space: pre;
+  white-space: pre-wrap;
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes longer toasts by changing `white-space: pre` to `white-space: pre-wrap`

**Ionic Version**: 4.0.0

**Fixes**: #16360
