### PR TITLE
fix(toolbar): match MD button spec

### DIFF
--- a/core/src/components/buttons/buttons.md.scss
+++ b/core/src/components/buttons/buttons.md.scss
@@ -27,6 +27,8 @@
 :host-context(.ion-color)::slotted(*) .button {
   --color: initial;
   --color-activated: initial;
+  --color-focused: initial;
+  --background-focused: #{ion-color(primary, contrast, 0.1)};
 }
 
 


### PR DESCRIPTION
This fixes an issue where a Material Design button would disappear when focused within a toolbar with a color attribute.