### PR TITLE
docs(): wrong dev imports for beta.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,8 +106,8 @@ If you are using @ionic/angular, please update the version number of any @angula
 "devDependencies": {
   "@angular-devkit/architect": "~0.10.5",
   "@angular-devkit/build-angular": "~0.10.5",
-  "@angular-devkit/core": "~0.7.5",
-  "@angular-devkit/schematics": "~0.7.5",
+  "@angular-devkit/core": "~7.0.5",
+  "@angular-devkit/schematics": "~7.0.5",
   "@angular/cli": "~7.0.3",
   "@angular/compiler": "~7.0.3",
   "@angular/compiler-cli": "~7.0.3",


### PR DESCRIPTION
Should be `@angular-devkit/core` and `@angular-devkit/schematics` not be `~7.0.5`, also your starter template is using ~7.0.0 https://github.com/ionic-team/starters/blob/master/angular/base/package.json