### PR TITLE
fix(angular): default value of BooleanValueAccessor should be false

### DIFF
--- a/angular/src/directives/control-value-accessors/boolean-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/boolean-value-accessor.ts
@@ -21,7 +21,7 @@ export class BooleanValueAccessor extends ValueAccessor {
   }
 
   writeValue(value: any) {
-    this.el.nativeElement.checked = this.lastValue = value == null ? '' : value;
+    this.el.nativeElement.checked = this.lastValue = value == null ? false : value;
     setIonicClasses(this.el);
   }
 


### PR DESCRIPTION
#### Short description of what this resolves:
Default value should be false, not empty string. If empty string was given and checkbox was part of angular form, it was checked by default.
