### PR TITLE
fix(tabs): update link

### DIFF
--- a/core/src/components/tabs/readme.md
+++ b/core/src/components/tabs/readme.md
@@ -1,7 +1,7 @@
 # ion-tabs
 
 Tabs are a top level navigation component to implement a tab-based navigation.
-The component is a container of individual [Tab](../Tab/) components.
+The component is a container of individual [Tab](../tab/) components.
 
 `ion-tabs` is a styleless component that works as a router outlet in order to handle navigation.
 This component does not provide any UI feedback or mechanism to switch between tabs.


### PR DESCRIPTION


#### Short description of what this resolves:

On a call with someone who noted that our documentation has some broken links and specifically pointed out this link, so I don't know if there are others, but this one appears to just be a casing issue so far as I can tell.

