### PR TITLE
fix(item-sliding): use a white item background instead of transparent

### DIFF
--- a/core/src/components/item/item.md.scss
+++ b/core/src/components/item/item.md.scss
@@ -7,7 +7,7 @@
 
 :host {
   --min-height: #{$item-md-min-height};
-  --background: var(--ion-item-background, transparent);
+  --background: #{$item-md-background};
   --background-activated: var(--background);
   --border-color: #{$item-md-border-bottom-color};
   --color: #{$item-md-color};


### PR DESCRIPTION
updates the item background to use the global md variable

fixes #16474
