### PR TITLE
fix(button): Contain strict to contain content

### DIFF
--- a/core/src/components/button/button.scss
+++ b/core/src/components/button/button.scss
@@ -160,7 +160,7 @@
 
   clear: both;
 
-  contain: strict;
+  contain: content;
 }
 
 :host(.button-block) .button-native::after {
@@ -182,7 +182,7 @@
 
   width: 100%;
 
-  contain: strict;
+  contain: content;
 }
 
 :host(.button-full:not(.button-round)) .button-native {


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes a problem with `contain: strict` on ion-button on expand full and block.

I think that `contain: content;` should work on all other use cases like  `contain: strict`, but the screenshot tests will show us :)

**Fixes**: #16552
