### PR TITLE
fix(loading): add backdropDismiss closes #16527

### DIFF
--- a/core/src/components/loading/loading.tsx
+++ b/core/src/components/loading/loading.tsx
@@ -201,7 +201,7 @@ export class Loading implements ComponentInterface, OverlayInterface {
 
   render() {
     return [
-      <ion-backdrop visible={this.showBackdrop} tappable={false} />,
+      <ion-backdrop visible={this.showBackdrop} tappable={this.backdropDismiss} />,
       <div class="loading-wrapper" role="dialog">
         {this.spinner && (
           <div class="loading-spinner">


### PR DESCRIPTION
#### Short description of what this resolves:
backdropDismiss wasn't set correctly


**Ionic Version**:  4.0.0-beta.17

**Fixes**: #16527
