### PR TITLE
Fixes the build on Windows

### DIFF
--- a/angular/scripts/build-core.js
+++ b/angular/scripts/build-core.js
@@ -29,7 +29,7 @@ function buildSchematics(){
       path.join(__dirname, '..', 'tsconfig.schematics.json'),
     ];
 
-    const p = spawn(cmd, args, { cwd: typescriptPath, stdio: 'inherit' });
+    const p = spawn(cmd, args, { cwd: typescriptPath, stdio: 'inherit', shell: true });
     p.on('close', (code) => {
       if (code > 0) {
         console.log(`ng-add build exited with ${code}`);

--- a/core/tslint.json
+++ b/core/tslint.json
@@ -18,7 +18,6 @@
     "no-floating-promises": false,
     "no-invalid-template-strings": true,
     "ban-export-const-enum": true,
-    "linebreak-style": false,
 
     "jsx-key": false,
     "jsx-self-close": false,

--- a/core/tslint.json
+++ b/core/tslint.json
@@ -18,6 +18,7 @@
     "no-floating-promises": false,
     "no-invalid-template-strings": true,
     "ban-export-const-enum": true,
+    "linebreak-style": false,
 
     "jsx-key": false,
     "jsx-self-close": false,


### PR DESCRIPTION
#### Short description of what this resolves:
- Added shell: true to build script

- Added "linbreak-style": false to tslint.
If this is true, following is happen:
![code_2018-12-09_10-15-31](https://user-images.githubusercontent.com/20501666/49695487-145e6280-fb9c-11e8-8215-8e6b7ec892fa.jpg)

