### PR TITLE
feat(toast): add border properties

### DIFF
--- a/core/api.txt
+++ b/core/api.txt
@@ -1142,6 +1142,10 @@ ion-toast,event,ionToastDidUnload,void,true
 ion-toast,event,ionToastWillDismiss,OverlayEventDetail,true
 ion-toast,event,ionToastWillPresent,void,true
 ion-toast,css-prop,--background
+ion-toast,css-prop,--border-color
+ion-toast,css-prop,--border-radius
+ion-toast,css-prop,--border-style
+ion-toast,css-prop,--border-width
 ion-toast,css-prop,--button-color
 ion-toast,css-prop,--color
 

--- a/core/src/components/toast/readme.md
+++ b/core/src/components/toast/readme.md
@@ -170,11 +170,15 @@ Type: `Promise<void>`
 
 ## CSS Custom Properties
 
-| Name             | Description              |
-| ---------------- | ------------------------ |
-| `--background`   | Background of the toast  |
-| `--button-color` | Color of the button text |
-| `--color`        | Color of the toast text  |
+| Name              | Description                |
+| ----------------- | -------------------------- |
+| `--background`    | Background of the toast    |
+| `--border-color`  | Border color of the toast  |
+| `--border-radius` | Border radius of the toast |
+| `--border-style`  | Border style of the toast  |
+| `--border-width`  | Border width of the toast  |
+| `--button-color`  | Color of the button text   |
+| `--color`         | Color of the toast text    |
 
 
 ----------------------------------------------

--- a/core/src/components/toast/test/basic/index.html
+++ b/core/src/components/toast/test/basic/index.html
@@ -8,6 +8,15 @@
   <link href="../../../../../css/ionic.bundle.css" rel="stylesheet">
   <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
   <script src="../../../../../dist/ionic.js"></script>
+
+  <style>
+    ion-toast.toast-border {
+      --border-radius: 20px;
+      --border-width: 5px;
+      --border-style: double;
+      --border-color: yellow;
+    }
+  </style>
 </head>
 
 <body>
@@ -28,6 +37,7 @@
         <ion-button expand="block" onclick="presentToastWithOptions({message: 'click to close', showCloseButton: true, closeButtonText: 'closing time'})">Show Toast with Custom Close Button Text</ion-button>
         <ion-button expand="block" onclick="presentToastWithOptions({message: 'click to close', showCloseButton: true, translucent: true})">Show Translucent Toast</ion-button>
         <ion-button expand="block" onclick="presentToastWithOptions({message: 'click to close', showCloseButton: true, color: 'danger'})">Show Color Toast</ion-button>
+        <ion-button expand="block" onclick="presentToastWithOptions({message: 'click to close', showCloseButton: true, cssClass: 'toast-border'})">Show Toast with border</ion-button>
 
         <ion-toast-controller></ion-toast-controller>
 

--- a/core/src/components/toast/toast.ios.scss
+++ b/core/src/components/toast/toast.ios.scss
@@ -15,7 +15,6 @@
 .toast-wrapper {
   @include position-horizontal(10px, 10px);
   @include margin(auto);
-  @include border-radius($toast-ios-border-radius);
 
   display: block;
   position: absolute;
@@ -25,7 +24,11 @@
   z-index: $z-index-overlay-wrapper;
 }
 
-:host(.toast-translucent) .toast-wrapper {
+.toast-container {
+  @include border-radius(var(--border-radius, $toast-ios-border-radius));
+}
+
+:host(.toast-translucent) .toast-container {
   background: $toast-ios-translucent-background-color;
   backdrop-filter: $toast-ios-translucent-filter;
 }

--- a/core/src/components/toast/toast.ios.scss
+++ b/core/src/components/toast/toast.ios.scss
@@ -8,6 +8,7 @@
   --background: #{$toast-ios-background-color};
   --button-color: #{$toast-ios-button-color};
   --color: #{$toast-ios-title-color};
+  --border-radius: $toast-ios-border-radius;
 
   font-size: $toast-ios-title-font-size;
 }
@@ -25,7 +26,7 @@
 }
 
 .toast-container {
-  @include border-radius(var(--border-radius, $toast-ios-border-radius));
+  @include border-radius(var(--border-radius));
 }
 
 :host(.toast-translucent) .toast-container {

--- a/core/src/components/toast/toast.ios.vars.scss
+++ b/core/src/components/toast/toast.ios.vars.scss
@@ -12,7 +12,7 @@ $toast-ios-translucent-background-color-alpha:    .8 !default;
 /// @prop - Background Color of the toast wrapper when translucent
 $toast-ios-translucent-background-color:          rgba(var(--ion-background-color-rgb, $background-color-rgb), $toast-ios-translucent-background-color-alpha) !default;
 
-/// @prop - Border radius of the toast wrapper
+/// @prop - Border radius of the toast container
 $toast-ios-border-radius:                         14px !default;
 
 /// @prop - Color of the toast title

--- a/core/src/components/toast/toast.md.scss
+++ b/core/src/components/toast/toast.md.scss
@@ -13,7 +13,6 @@
 }
 
 .toast-wrapper {
-  @include border-radius(4px);
   @include position-horizontal(8px, 8px);
   @include margin(auto);
 
@@ -22,11 +21,15 @@
 
   max-width: $toast-max-width;
 
-  box-shadow: $toast-md-box-shadow;
-
   opacity: .01;
 
   z-index: $z-index-overlay-wrapper;
+}
+
+.toast-container {
+  @include border-radius(var(--border-radius, $toast-md-border-radius));
+
+  box-shadow: $toast-md-box-shadow;
 }
 
 .toast-message {

--- a/core/src/components/toast/toast.md.scss
+++ b/core/src/components/toast/toast.md.scss
@@ -8,6 +8,7 @@
   --button-color: #{ion-color(primary, base)};
   --background: #{$toast-md-background};
   --color: #{$toast-md-color};
+  --border-radius: $toast-md-border-radius;
 
   font-size: $toast-md-font-size;
 }
@@ -27,7 +28,7 @@
 }
 
 .toast-container {
-  @include border-radius(var(--border-radius, $toast-md-border-radius));
+  @include border-radius(var(--border-radius));
 
   box-shadow: $toast-md-box-shadow;
 }

--- a/core/src/components/toast/toast.md.vars.scss
+++ b/core/src/components/toast/toast.md.vars.scss
@@ -15,6 +15,9 @@ $toast-md-font-size:                               14px !default;
 /// @prop - Color of the toast
 $toast-md-color:                                   $background-color-step-50 !default;
 
+/// @prop - Border radius of the toast container
+$toast-md-border-radius:                           4px !default;
+
 /// @prop - Font size of the toast message
 $toast-md-message-line-height:                     20px !default;
 

--- a/core/src/components/toast/toast.scss
+++ b/core/src/components/toast/toast.scss
@@ -6,6 +6,10 @@
 :host {
   /**
    * @prop --background: Background of the toast
+   * @prop --border-color: Border color of the toast
+   * @prop --border-radius: Border radius of the toast
+   * @prop --border-width: Border width of the toast
+   * @prop --border-style: Border style of the toast
    * @prop --button-color: Color of the button text
    * @prop --color: Color of the toast text
    */
@@ -34,17 +38,19 @@
   --button-color: inherit;
 }
 
-.toast-wrapper {
-  background: var(--background);
-}
-
 .toast-container {
   display: flex;
 
   align-items: center;
-  pointer-events: auto;
+
+  border-width: var(--border-width);
+  border-style: var(--border-style);
+  border-color: var(--border-color);
+
+  background: var(--background);
 
   contain: content;
+  pointer-events: auto;
 }
 
 .toast-button {

--- a/core/src/components/toast/toast.scss
+++ b/core/src/components/toast/toast.scss
@@ -13,7 +13,10 @@
    * @prop --button-color: Color of the button text
    * @prop --color: Color of the toast text
    */
-  --button-color: inherit;
+  --button-color: inherit; 
+  --border-width: 0; 
+  --border-style: none; 
+  --border-color: initial; 
 
   @include position(0, null, null, 0);
 


### PR DESCRIPTION
#### Short description of what this resolves:
Border of a toast can be customized by adding border properties. This properties match other Ionic components like button, checkbox, item and many more:

```
   * @prop --border-color: Border color of the toast
   * @prop --border-radius: Border radius of the toast
   * @prop --border-width: Border width of the toast
   * @prop --border-style: Border style of the toast
```

To make it work, the border and background of a toast has to be set at the `.toast-container` (not `.toast-wrapper`).

One example to show a custom border has been added.

**Preview:**

![2018-12-11_08-50-17](https://user-images.githubusercontent.com/20501666/49785952-79dc5b80-fd22-11e8-9266-ef8c27c97933.jpg)

#### Changes proposed in this pull request:

Feature Request: #16666
