### PR TITLE
fix(menu-controller): seperate md and ios style

### DIFF
--- a/core/src/components/menu-controller/menu-controller.ios.scss
+++ b/core/src/components/menu-controller/menu-controller.ios.scss
@@ -1,0 +1,10 @@
+@import "../menu/menu.ios.vars";
+@import "./menu-controller";
+
+.menu-content-reveal {
+  box-shadow: $menu-ios-box-shadow-reveal;
+}
+
+.menu-content-push {
+  box-shadow: $menu-ios-box-shadow-push;
+}

--- a/core/src/components/menu-controller/menu-controller.md.scss
+++ b/core/src/components/menu-controller/menu-controller.md.scss
@@ -1,0 +1,10 @@
+@import "../menu/menu.md.vars";
+@import "./menu-controller";
+
+.menu-content-reveal {
+  box-shadow: $menu-md-box-shadow;
+}
+
+.menu-content-push {
+  box-shadow: $menu-md-box-shadow;
+}

--- a/core/src/components/menu-controller/menu-controller.scss
+++ b/core/src/components/menu-controller/menu-controller.scss
@@ -1,6 +1,3 @@
-@import "../menu/menu.ios.vars";
-@import "../menu/menu.md.vars";
-
 .menu-content {
   @include transform(translate3d(0, 0, 0));
 }
@@ -12,20 +9,4 @@
   // the containing element itself should be clickable but
   // everything inside of it should not clickable when menu is open
   pointer-events: none;
-}
-
-.ios .menu-content-reveal {
-  box-shadow: $menu-ios-box-shadow-reveal;
-}
-
-.ios .menu-content-push {
-  box-shadow: $menu-ios-box-shadow-push;
-}
-
-.md .menu-content-reveal {
-  box-shadow: $menu-md-box-shadow;
-}
-
-.md .menu-content-push {
-  box-shadow: $menu-md-box-shadow;
 }

--- a/core/src/components/menu-controller/menu-controller.ts
+++ b/core/src/components/menu-controller/menu-controller.ts
@@ -8,7 +8,10 @@ import { menuRevealAnimation } from './animations/reveal';
 
 @Component({
   tag: 'ion-menu-controller',
-  styleUrl: 'menu-controller.scss'
+  styleUrls: {
+    ios: 'menu-controller.ios.scss',
+    md: 'menu-controller.md.scss'
+  },
 })
 export class MenuController implements MenuControllerI {
 


### PR DESCRIPTION
#### Short description of what this resolves:
Seperate the md and ios style of the menu controller. This maybe can already fix  #16649

#### Changes proposed in this pull request:

**Fixes**:  #16649
