### PR TITLE
fix(refresher): close animation and hidden on pull down - Fixes #16254

### DIFF
--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -49,7 +49,6 @@ export class Refresher implements ComponentInterface {
    */
   @Prop() pullMax: number = this.pullMin + 60;
 
-  // TODO: NEVER USED
   /**
    * Time it takes to close the refresher.
    */
@@ -323,7 +322,7 @@ export class Refresher implements ComponentInterface {
     // reset set the styles on the scroll element
     // set that the refresh is actively cancelling/completing
     this.state = state;
-    this.setCss(0, '', true, delay);
+    this.setCss(0, this.closeDuration, true, delay);
 
     // TODO: stop gesture
   }

--- a/core/src/themes/ionic.globals.scss
+++ b/core/src/themes/ionic.globals.scss
@@ -46,7 +46,7 @@ $z-index-click-block:            99999;
 
 $z-index-fixed-content:          999;
 $z-index-scroll-content:         1;
-$z-index-refresher:              0;
+$z-index-refresher:              -1;
 
 $z-index-page-container:         0;
 $z-index-toolbar:                10;


### PR DESCRIPTION
There are several bugs in refresher in Ionic v4 like mentioned in #16254

[x] FIXED: The refresher itself lies above the content, instead of below. This means that the instant you start to pull, it is completely visible above your content, instead of sliding out from underneath it.
[x] FIXED: After completing the refresher action, the content jumps back instantly, instead of sliding back up.
[x] Was already fixed: There is a console.log('start') still in compiled @ionic/core code which triggers when starting to you start to drag on a page with the refresher.

### BEFORE

![2018-12-12_12-37-37](https://user-images.githubusercontent.com/20501666/49867434-cdc26f80-fe0a-11e8-8bdc-92abd28a5a1b.gif)

### AFTER

![2018-12-12_13-20-11](https://user-images.githubusercontent.com/20501666/49869441-ad95af00-fe10-11e8-94d3-f024e26cec17.gif)

It has now the same optical look like in v3 and is working in Chrome and Firefox. This is how it looks in Firefox:

![2018-12-12_10-41-48](https://user-images.githubusercontent.com/20501666/49860671-92b84000-fdfa-11e8-804c-f77e11864a3c.gif)

**Ionic Version**:
**Fixes**: #16254 