### PR TITLE
feat(slides): expose updateAutoHeight() method

### DIFF
--- a/angular/src/directives/proxies.ts
+++ b/angular/src/directives/proxies.ts
@@ -814,7 +814,7 @@ export class IonSlides {
   constructor(c: ChangeDetectorRef, r: ElementRef) {
     c.detach();
     const el = r.nativeElement;
-    proxyMethods(this, el, ['update', 'slideTo', 'slideNext', 'slidePrev', 'getActiveIndex', 'getPreviousIndex', 'length', 'isEnd', 'isBeginning', 'startAutoplay', 'stopAutoplay', 'lockSwipeToNext', 'lockSwipeToPrev', 'lockSwipes']);
+    proxyMethods(this, el, ['update', 'slideTo', 'slideNext', 'slidePrev', 'getActiveIndex', 'getPreviousIndex', 'length', 'isEnd', 'isBeginning', 'startAutoplay', 'stopAutoplay', 'lockSwipeToNext', 'lockSwipeToPrev', 'lockSwipes', 'updateAutoHeight']);
     proxyInputs(this, el, ['mode', 'options', 'pager', 'scrollbar']);
     proxyOutputs(this, el, ['ionSlidesDidLoad', 'ionSlideTap', 'ionSlideDoubleTap', 'ionSlideWillChange', 'ionSlideDidChange', 'ionSlideNextStart', 'ionSlidePrevStart', 'ionSlideNextEnd', 'ionSlidePrevEnd', 'ionSlideTransitionStart', 'ionSlideTransitionEnd', 'ionSlideDrag', 'ionSlideReachStart', 'ionSlideReachEnd', 'ionSlideTouchStart', 'ionSlideTouchEnd']);
   }

--- a/core/api.txt
+++ b/core/api.txt
@@ -992,6 +992,7 @@ ion-slides,method,slideTo,slideTo(index: number, speed?: number | undefined, run
 ion-slides,method,startAutoplay,startAutoplay() => Promise<void>
 ion-slides,method,stopAutoplay,stopAutoplay() => Promise<void>
 ion-slides,method,update,update() => Promise<void>
+ion-slides,method,updateAutoHeight,updateAutoHeight(speed?: number | undefined) => Promise<void>
 ion-slides,event,ionSlideDidChange,void,true
 ion-slides,event,ionSlideDoubleTap,void,true
 ion-slides,event,ionSlideDrag,void,true

--- a/core/package.json
+++ b/core/package.json
@@ -35,7 +35,7 @@
     "@stencil/utils": "latest",
     "@types/jest": "^23.3.1",
     "@types/puppeteer": "1.6.4",
-    "@types/swiper": "4.2.4",
+    "@types/swiper": "4.4.0",
     "@types/node": "10.11.0",
     "agadoo": "^1.0.0",
     "autoprefixer": "^9.0.2",

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -4286,6 +4286,10 @@ export namespace Components {
     * Update the underlying slider implementation. Call this if you've added or removed child slides.
     */
     'update': () => Promise<void>;
+    /**
+    * Force swiper to update its height (when autoHeight enabled) for the duration equal to 'speed' parameter
+    */
+    'updateAutoHeight': (speed?: number | undefined) => Promise<void>;
   }
   interface IonSlidesAttributes extends StencilHTMLAttributes {
     /**

--- a/core/src/components/slides/readme.md
+++ b/core/src/components/slides/readme.md
@@ -294,6 +294,22 @@ Type: `Promise<void>`
 
 
 
+### `updateAutoHeight(speed?: number | undefined) => Promise<void>`
+
+Force swiper to update its height (when autoHeight enabled) for the duration equal to 'speed' parameter
+
+#### Parameters
+
+| Name    | Type                  | Description |
+| ------- | --------------------- | ----------- |
+| `speed` | `number \| undefined` |             |
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 
 ## CSS Custom Properties
 

--- a/core/src/components/slides/slides.tsx
+++ b/core/src/components/slides/slides.tsx
@@ -285,6 +285,16 @@ export class Slides implements ComponentInterface {
     swiper.allowTouchMove = !shouldLockSwipes;
   }
 
+  /**
+   * Force swiper to update its height (when autoHeight enabled) for the duration equal to 'speed' parameter
+   */
+  @Method()
+  async updateAutoHeight(speed?: number) {
+    const swiper = await this.getSwiper();
+    // Casting to `any` since @types/swiper is out of date
+    (swiper as any).updateAutoHeight(speed);
+  }
+
   private async initSwiper() {
     const finalOptions = this.normalizeOptions();
 

--- a/core/src/components/slides/slides.tsx
+++ b/core/src/components/slides/slides.tsx
@@ -291,8 +291,7 @@ export class Slides implements ComponentInterface {
   @Method()
   async updateAutoHeight(speed?: number) {
     const swiper = await this.getSwiper();
-    // Casting to `any` since @types/swiper is out of date
-    (swiper as any).updateAutoHeight(speed);
+    swiper.updateAutoHeight(speed);
   }
 
   private async initSwiper() {


### PR DESCRIPTION
#### Short description of what this resolves:
This PR resolves the inability to force the underlying Swiper on ion-slides to update its height (when autoHeight enabled) at any time.

#### Changes proposed in this pull request:

- Expose updateAutoHeight() on ion-slides

**Ionic Version**: 4.x

**Fixes**: #15079
