### PR TITLE
fix(action-sheet): set 100% height to fix scrollable options

### DIFF
--- a/core/src/components/action-sheet/action-sheet.scss
+++ b/core/src/components/action-sheet/action-sheet.scss
@@ -23,8 +23,8 @@
   --width: #{$action-sheet-width};
   --max-width: #{$action-sheet-max-width};
   --min-height: auto;
-  --height: auto;
-  --max-height: auto;
+  --height: 100%;
+  --max-height: 100%;
 
   @include font-smoothing();
   @include position(0, 0, 0, 0);


### PR DESCRIPTION
#### Short description of what this resolves:
An action sheet with too many buttons is overflowing off the screen (at the top). Sets height and max-height to 100% on the wrapper.

http://localhost:3333/src/components/action-sheet/test/scrollable-options

| `master` | `fix-action-sheet-scrollable` |
| ---------| --------------|
| ![localhost_3333_src_components_action-sheet_test_scrollable-options iphone 6_7_8 1](https://user-images.githubusercontent.com/6577830/50117401-e5d72c00-021a-11e9-944e-811c78146866.png) | ![localhost_3333_src_components_action-sheet_test_scrollable-options iphone 6_7_8](https://user-images.githubusercontent.com/6577830/50117375-d3f58900-021a-11e9-9327-30ed338d5065.png) | 