### PR TITLE
Update readme.md

### DIFF
--- a/core/src/components/infinite-scroll/readme.md
+++ b/core/src/components/infinite-scroll/readme.md
@@ -106,7 +106,7 @@ infiniteScroll.addEventListener('ionInfinite', function(event) {
 });
 
 function toggleInfiniteScroll() {
-  infiniteScroll.disabled = !infiniteScroll.disabled;
+  this.infiniteScroll.disabled = !this.infiniteScroll.disabled;
 }
 ```
 

--- a/core/src/components/infinite-scroll/readme.md
+++ b/core/src/components/infinite-scroll/readme.md
@@ -38,7 +38,7 @@ Separating the `ion-infinite-scroll` and `ion-infinite-scroll-content` component
 
 ```typescript
 import { Component, ViewChild } from '@angular/core';
-import { InfiniteScroll } from '@ionic/angular';
+import { IonInfiniteScroll } from '@ionic/angular';
 
 @Component({
   selector: 'infinite-scroll-example',
@@ -46,7 +46,7 @@ import { InfiniteScroll } from '@ionic/angular';
   styleUrls: ['./infinite-scroll-example.css']
 })
 export class InfiniteScrollExample {
-  @ViewChild(InfiniteScroll) infiniteScroll: InfiniteScroll;
+  @ViewChild(IonInfiniteScroll) infiniteScroll: IonInfiniteScroll;
 
   constructor() {}
 
@@ -64,7 +64,7 @@ export class InfiniteScrollExample {
   }
 
   toggleInfiniteScroll() {
-    infiniteScroll.disabled = !infiniteScroll.disabled;
+    this.infiniteScroll.disabled = !this.infiniteScroll.disabled;
   }
 }
 ```
@@ -106,7 +106,7 @@ infiniteScroll.addEventListener('ionInfinite', function(event) {
 });
 
 function toggleInfiniteScroll() {
-  this.infiniteScroll.disabled = !this.infiniteScroll.disabled;
+  infiniteScroll.disabled = !infiniteScroll.disabled;
 }
 ```
 

--- a/core/src/components/infinite-scroll/usage/angular.md
+++ b/core/src/components/infinite-scroll/usage/angular.md
@@ -17,7 +17,7 @@
 
 ```typescript
 import { Component, ViewChild } from '@angular/core';
-import { InfiniteScroll } from '@ionic/angular';
+import { IonInfiniteScroll } from '@ionic/angular';
 
 @Component({
   selector: 'infinite-scroll-example',
@@ -25,7 +25,7 @@ import { InfiniteScroll } from '@ionic/angular';
   styleUrls: ['./infinite-scroll-example.css']
 })
 export class InfiniteScrollExample {
-  @ViewChild(InfiniteScroll) infiniteScroll: InfiniteScroll;
+  @ViewChild(IonInfiniteScroll) infiniteScroll: IonInfiniteScroll;
 
   constructor() {}
 
@@ -43,7 +43,7 @@ export class InfiniteScrollExample {
   }
 
   toggleInfiniteScroll() {
-    infiniteScroll.disabled = !infiniteScroll.disabled;
+    this.infiniteScroll.disabled = !this.infiniteScroll.disabled;
   }
 }
 ```


### PR DESCRIPTION
#### Short description of what this resolves:
original code **does not work**, needs to refer to the instance member when accessing to infinite scroll outside the function which receives the `infiniteScroll `event. On the other hand, since v4 rc, export from ionic/angular should be `IonInfiniteScroll` instead of `InfiniteScroll`

#### Changes proposed in this pull request:

- `infiniteScroll.disabled` to `this.infiniteScroll.disabled`
- `IonInfiniteScroll` to `InfiniteScroll`

**Ionic Version**: 4
