### PR TITLE
Update disabled property documentation

### DIFF
--- a/core/src/components/checkbox/readme.md
+++ b/core/src/components/checkbox/readme.md
@@ -17,7 +17,7 @@ Checkboxes allow the selection of multiple options from a set of options. They a
 <ion-checkbox></ion-checkbox>
 
 <!-- Disabled Checkbox -->
-<ion-checkbox disabled="true"></ion-checkbox>
+<ion-checkbox [disabled]="true"></ion-checkbox>
 
 <!-- Checked Checkbox -->
 <ion-checkbox checked="true"></ion-checkbox>
@@ -102,7 +102,7 @@ export class HomePage {
 | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | -------------- |
 | `checked`  | `checked`  | If `true`, the checkbox is selected.                                                                                                                                                                                                                                   | `boolean`             | `false`        |
 | `color`    | `color`    | The color to use from your application's color palette. Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`. For more information on colors, see [theming](/docs/theming/basics). | `string \| undefined` | `undefined`    |
-| `disabled` | `disabled` | If `true`, the user cannot interact with the checkbox.                                                                                                                                                                                                                 | `boolean`             | `false`        |
+| `[disabled]` | `disabled` | If `true`, the user cannot interact with the checkbox.                                                                                                                                                                                                                 | `boolean`             | `false`        |
 | `mode`     | `mode`     | The mode determines which platform styles to use.                                                                                                                                                                                                                      | `"ios" \| "md"`       | `undefined`    |
 | `name`     | `name`     | The name of the control, which is submitted with the form data.                                                                                                                                                                                                        | `string`              | `this.inputId` |
 | `value`    | `value`    | The value of the toggle does not mean if it's checked or not, use the `checked` property for that.  The value of a toggle is analogous to the value of a `<input type="checkbox">`, it's only used when the toggle participates in a native `<form>`.                  | `string`              | `'on'`         |


### PR DESCRIPTION
I found disabled must be in brackets in order to be properly disabled when set to false.

#### Short description of what this resolves:
Disabled property correctly only visually shows a disabled checkbox when set to true. However, when set to false, the element remains disabled. The usage of brackets is needed for this to work properly.

#### Changes proposed in this pull request:

- update usage in example to include brackets for disabled
- update properties section to include brackets for disabled
-

**Ionic Version**: 4.0.0-rc.0

**Fixes**: #