### PR TITLE
docs(row): fix links to grid and col components

### DIFF
--- a/core/src/components/row/readme.md
+++ b/core/src/components/row/readme.md
@@ -1,7 +1,7 @@
 # ion-row
 
-Rows are horizontal components of the [grid](../Grid) system and contain varying numbers of
-[columns](../Col). They ensure the columns are positioned properly.
+Rows are horizontal components of the [grid](../grid) system and contain varying numbers of
+[columns](../col). They ensure the columns are positioned properly.
 
 See [Grid Layout](/docs/layout/grid) for more information.
 


### PR DESCRIPTION
#### Short description of what this resolves:
Came to fix all three pages (col, row, grid), but seems like the others are fixed and just not live yet (#16859, #16538).

Applied the same fix as those to cross-link the pages.
