### PR TITLE
docs(): Fix all broken links in api documentation

### DIFF
--- a/core/src/components/action-sheet/readme.md
+++ b/core/src/components/action-sheet/readme.md
@@ -4,7 +4,7 @@ An Action Sheet is a dialog that displays a set of options. It appears on top of
 
 ### Creating
 
-An action sheet can be created by the [Action Sheet Controller](../../action-sheet-controller/ActionSheetController) from an array of `buttons`, with each button including properties for its `text`, and optionally a `handler` and `role`. If a handler returns `false` then the action sheet will not be dismissed. An action sheet can also optionally have a `title`, `subTitle` and an `icon`.
+An action sheet can be created by the [Action Sheet Controller](/docs/api/action-sheet-controller) from an array of `buttons`, with each button including properties for its `text`, and optionally a `handler` and `role`. If a handler returns `false` then the action sheet will not be dismissed. An action sheet can also optionally have a `title`, `subTitle` and an `icon`.
 
 ### Buttons
 

--- a/core/src/components/alert-controller/readme.md
+++ b/core/src/components/alert-controller/readme.md
@@ -1,6 +1,6 @@
 # ion-alert-controller
 
-Alert controllers programmatically control the alert component. Alerts can be created and dismissed from the alert controller. View the [Alert](../alert) documentation for a full list of options to pass upon creation.
+Alert controllers programmatically control the alert component. Alerts can be created and dismissed from the alert controller. View the [Alert](/docs/api/alert) documentation for a full list of options to pass upon creation.
 
 
 ```javascript

--- a/core/src/components/col/readme.md
+++ b/core/src/components/col/readme.md
@@ -1,6 +1,6 @@
 # ion-col
 
-Columns are cellular components of the [grid](../grid) system and go inside of a [row](../row).
+Columns are cellular components of the [grid](/docs/api/grid) system and go inside of a [row](/docs/api/row).
 They will expand to fill their row. All content within a grid should go inside of a column.
 
 See [Grid Layout](/docs/layout/grid) for more information.

--- a/core/src/components/fab/readme.md
+++ b/core/src/components/fab/readme.md
@@ -1,6 +1,6 @@
 # ion-fab
 
-Fabs are container elements that contain one or more fab buttons. They should be placed in a fixed position that does not scroll with the content. Fab should have one main fab-button. Fabs can also contain fab-lists which contain related buttons that show when the main fab button is clicked. The same fab container can contain several [fab-list](../../fab-list/FabList) elements with different side values.
+Fabs are container elements that contain one or more fab buttons. They should be placed in a fixed position that does not scroll with the content. Fab should have one main fab-button. Fabs can also contain fab-lists which contain related buttons that show when the main fab button is clicked. The same fab container can contain several [fab-list](/docs/api/fab-list) elements with different side values.
 
 <!-- Auto Generated Below -->
 

--- a/core/src/components/grid/readme.md
+++ b/core/src/components/grid/readme.md
@@ -3,7 +3,7 @@
 
 The grid is a powerful mobile-first flexbox system for building custom layouts.
 
-It is composed of three units — a grid, [row(s)](../row) and [column(s)](../col). Columns will expand to fill the row, and will resize to fit additional columns. It is based on a 12 column layout with different breakpoints based on the screen size. The number of columns can be customized using CSS.
+It is composed of three units — a grid, [row(s)](/docs/api/row) and [column(s)](/docs/api/col). Columns will expand to fill the row, and will resize to fit additional columns. It is based on a 12 column layout with different breakpoints based on the screen size. The number of columns can be customized using CSS.
 
 See [Grid Layout](/docs/layout/grid) for more information.
 

--- a/core/src/components/item-sliding/readme.md
+++ b/core/src/components/item-sliding/readme.md
@@ -1,16 +1,16 @@
 # ion-item-sliding
 
-A sliding item contains an item that can be dragged to reveal buttons. It requires an [item](../item) component as a child. All options to reveal should be placed in the [item options](../item-options) element.
+A sliding item contains an item that can be dragged to reveal buttons. It requires an [item](/docs/api/item) component as a child. All options to reveal should be placed in the [item options](/docs/api/item-options) element.
 
 
 ### Swipe Direction
 
-By default, the buttons are placed on the `"end"` side. This means that options are revealed when the sliding item is swiped from end to start, i.e. from right to left in LTR, but from left to right in RTL. To place them on the opposite side, so that they are revealed when swiping in the opposite direction, set the `side` attribute to `"start"` on the [`ion-item-options`]((../item-options) element. Up to two `ion-item-options` can be used at the same time in order to reveal two different sets of options depending on the swiping direction.
+By default, the buttons are placed on the `"end"` side. This means that options are revealed when the sliding item is swiped from end to start, i.e. from right to left in LTR, but from left to right in RTL. To place them on the opposite side, so that they are revealed when swiping in the opposite direction, set the `side` attribute to `"start"` on the [`ion-item-options`]((/docs/api/item-options) element. Up to two `ion-item-options` can be used at the same time in order to reveal two different sets of options depending on the swiping direction.
 
 
 ### Options Layout
 
-By default if an icon is placed with text in the [item option](../item-option), it will display the icon on top of the text, but the icon slot can be changed to any of the following to position it in the option.
+By default if an icon is placed with text in the [item option](/docs/api/item-option), it will display the icon on top of the text, but the icon slot can be changed to any of the following to position it in the option.
 
 | Slot        | description                                                              |
 | ----------- | ------------------------------------------------------------------------ |

--- a/core/src/components/loading-controller/readme.md
+++ b/core/src/components/loading-controller/readme.md
@@ -1,6 +1,6 @@
 # ion-loading-controller
 
-Loading controllers programmatically control the loading component. Loadings can be created and dismissed from the loading controller. View the [Loading](../loading) documentation for a full list of options to pass upon creation.
+Loading controllers programmatically control the loading component. Loadings can be created and dismissed from the loading controller. View the [Loading](/docs/api/loading) documentation for a full list of options to pass upon creation.
 
 
 

--- a/core/src/components/loading/readme.md
+++ b/core/src/components/loading/readme.md
@@ -5,7 +5,7 @@ An overlay that can be used to indicate activity while blocking user interaction
 
 ### Creating
 
-Loading indicators can be created using a [Loading Controller](../../loading-controller/LoadingController). They can be customized by passing loading options in the loading controller's create method. The spinner name should be passed in the `spinner` property, and any optional HTML can be passed in the `content` property. If a value is not passed to `spinner` the loading indicator will use the spinner specified by the platform.
+Loading indicators can be created using a [Loading Controller](/docs/api/loading-controller). They can be customized by passing loading options in the loading controller's create method. The spinner name should be passed in the `spinner` property, and any optional HTML can be passed in the `content` property. If a value is not passed to `spinner` the loading indicator will use the spinner specified by the platform.
 
 
 ### Dismissing

--- a/core/src/components/modal-controller/readme.md
+++ b/core/src/components/modal-controller/readme.md
@@ -1,6 +1,6 @@
 # ion-modal-controller
 
-Modal controllers programmatically control the modal component. Modals can be created and dismissed from the modal controller. View the [Modal](../modal) documentation for a full list of options to pass upon creation.
+Modal controllers programmatically control the modal component. Modals can be created and dismissed from the modal controller. View the [Modal](/docs/api/modal) documentation for a full list of options to pass upon creation.
 
 
 <!-- Auto Generated Below -->

--- a/core/src/components/modal/readme.md
+++ b/core/src/components/modal/readme.md
@@ -5,7 +5,7 @@ A Modal is a dialog that appears on top of the app's content, and must be dismis
 
 ### Creating
 
-Modals can be created using a [Modal Controller](../../modal-controller/ModalController). They can be customized by passing modal options in the modal controller's create method.
+Modals can be created using a [Modal Controller](/docs/api/modal-controller). They can be customized by passing modal options in the modal controller's create method.
 
 
 ### Passing paramaters

--- a/core/src/components/popover-controller/readme.md
+++ b/core/src/components/popover-controller/readme.md
@@ -1,6 +1,6 @@
 # ion-popover-controller
 
-Popover controllers programmatically control the popover component. Popovers can be created and dismissed from the popover controller. View the [Popover](../popover) documentation for a full list of options to pass upon creation.
+Popover controllers programmatically control the popover component. Popovers can be created and dismissed from the popover controller. View the [Popover](/docs/api/popover) documentation for a full list of options to pass upon creation.
 
 
 <!-- Auto Generated Below -->

--- a/core/src/components/popover/readme.md
+++ b/core/src/components/popover/readme.md
@@ -4,7 +4,7 @@ A Popover is a dialog that appears on top of the current page. It can be used fo
 
 ### Creating
 
-Popovers can be created using a [Popover Controller](https://beta.ionicframework.com/docs/api/popover-controller). They can be customized by passing popover options in the popover controller's create method.
+Popovers can be created using a [Popover Controller](/docs/api/popover-controller). They can be customized by passing popover options in the popover controller's create method.
 
 ### Presenting
 

--- a/core/src/components/radio-group/readme.md
+++ b/core/src/components/radio-group/readme.md
@@ -1,6 +1,6 @@
 # ion-radio-group
 
-A radio group is a group of [radio buttons](../radio). It allows
+A radio group is a group of [radio buttons](/docs/api/radio). It allows
 a user to select at most one radio button from a set. Checking one radio
 button that belongs to a radio group unchecks any previous checked
 radio button within the same group.

--- a/core/src/components/radio/readme.md
+++ b/core/src/components/radio/readme.md
@@ -2,7 +2,7 @@
 
 Radios are generally used as a set of related options inside of a group, but they can also be used alone. Pressing on a radio will check it. They can also be checked programmatically by setting the `checked` property.
 
-An `ion-radio-group` can be used to group a set of radios. When radios are inside of a [radio group](../radio-group), only one radio in the group will be checked at any time. Pressing a radio will check it and uncheck the previously selected radio, if there is one. If a radio is not in a group with another radio, then both radios will have the ability to be checked at the same time.
+An `ion-radio-group` can be used to group a set of radios. When radios are inside of a [radio group](/docs/api/radio-group), only one radio in the group will be checked at any time. Pressing a radio will check it and uncheck the previously selected radio, if there is one. If a radio is not in a group with another radio, then both radios will have the ability to be checked at the same time.
 
 
 

--- a/core/src/components/reorder-group/readme.md
+++ b/core/src/components/reorder-group/readme.md
@@ -1,6 +1,6 @@
 # ion-reorder-group
 
-The reorder group is a wrapper component for items with the `ion-reorder` component, Check [Reorder documentation](../reorder/) for further information about the anchor component that is used to drag items within the `ion-reorder-group` list.
+The reorder group is a wrapper component for items with the `ion-reorder` component, Check the [reorder documentation](/docs/api/reorder/) for further information about the anchor component that is used to drag items within the `ion-reorder-group` list.
 
 Once the user drags an item and drops it in a new position, the `ionItemReorder` event is dispatched. A handler for it must be implemented by the developer to commit changes.
 

--- a/core/src/components/router/readme.md
+++ b/core/src/components/router/readme.md
@@ -3,6 +3,7 @@
 Router is a component for handling routing inside vanilla JavaScript projects. For Angular projects, use `ion-router-outlet` and the Angular router.
 
 Apps should have a single `ion-router` component in the codebase.
+
 This component controls all interactions with the browser history and it aggregates updates through an event system.
 
 `ion-router` is just a URL coordinator for the navigation outlets of ionic: `ion-nav` and `ion-tabs`.
@@ -11,7 +12,7 @@ That means the `ion-router` never touches the DOM, it does NOT show the componen
 
 In order to configure this relationship between components (to load/select) and URLs, `ion-router` uses a declarative syntax using JSX/HTML to define a tree of routes.
 
-If you're using Angular, please see [ion-router-outlet](../router-outlet) instead.
+If you're using Angular, please see [ion-router-outlet](/docs/api/router-outlet) instead.
 
 
 

--- a/core/src/components/row/readme.md
+++ b/core/src/components/row/readme.md
@@ -1,7 +1,7 @@
 # ion-row
 
-Rows are horizontal components of the [grid](../grid) system and contain varying numbers of
-[columns](../col). They ensure the columns are positioned properly.
+Rows are horizontal components of the [grid](/docs/api/grid) system and contain varying numbers of
+[columns](/docs/api/col). They ensure the columns are positioned properly.
 
 See [Grid Layout](/docs/layout/grid) for more information.
 

--- a/core/src/components/segment-button/readme.md
+++ b/core/src/components/segment-button/readme.md
@@ -1,6 +1,6 @@
 # ion-segment-button
 
-Segment buttons are groups of related buttons inside of a [Segment](../../segment/Segment). They are displayed in a horizontal row. A segment button can be checked by default by adding the `checked` attribute or by setting the `value` of the segment to the `value` of the segment button. Only one segment button should be selected at a time.
+Segment buttons are groups of related buttons inside of a [Segment](/docs/api/segment). They are displayed in a horizontal row. A segment button can be checked by default by adding the `checked` attribute or by setting the `value` of the segment to the `value` of the segment button. Only one segment button should be selected at a time.
 
 
 <!-- Auto Generated Below -->

--- a/core/src/components/select-option/readme.md
+++ b/core/src/components/select-option/readme.md
@@ -1,6 +1,6 @@
 # ion-select-option
 
-SelectOption is a component that is a child element of Select. For more information, see the [Select docs](../select).
+SelectOption is a component that is a child element of Select. For more information, see the [Select docs](/docs/api/select).
 
 
 <!-- Auto Generated Below -->

--- a/core/src/components/select/readme.md
+++ b/core/src/components/select/readme.md
@@ -9,7 +9,7 @@ If `value` is set on the `<ion-select>`, the selected option will be chosen base
 
 ## Interfaces
 
-By default, select uses the [AlertController API](../../alert/AlertController) to open up the overlay of options in an alert. The interface can be changed to use the [ActionSheetController API](../../action-sheet/ActionSheetController) or [PopoverController API](../../popover/PopoverController) by passing `action-sheet` or `popover`, respectively, to the `interface` property. Read on to the other sections for the limitations of the different interfaces.
+By default, select uses the [AlertController API](/docs/api/alert-controller) to open up the overlay of options in an alert. The interface can be changed to use the [ActionSheetController API](/docs/api/action-sheet-controller) or [PopoverController API](/docs/api/popover-controller) by passing `action-sheet` or `popover`, respectively, to the `interface` property. Read on to the other sections for the limitations of the different interfaces.
 
 
 ## Single Selection
@@ -33,7 +33,7 @@ The `action-sheet` and `popover` interfaces do not have an `OK` button, clicking
 
 ## Interface Options
 
-Since select uses the alert, action sheet and popover interfaces, options can be passed to these components through the `interfaceOptions` property. This can be used to pass a custom header, subheader, css class, and more. See the [AlertController API docs](../../alert/AlertController/#create), [ActionSheetController API docs](../../action-sheet/ActionSheetController/#create), and [PopoverController API docs](../../popover/PopoverController/#create) for the properties that each interface accepts.
+Since select uses the alert, action sheet and popover interfaces, options can be passed to these components through the `interfaceOptions` property. This can be used to pass a custom header, subheader, css class, and more. See the [AlertController API docs](/docs/api/alert-controller#create), [ActionSheetController API docs](/docs/api/action-sheet-controller#create), and [PopoverController API docs](/docs/api/popover-controller#create) for the properties that each interface accepts.
 
 
 <!-- Auto Generated Below -->

--- a/core/src/components/slide/readme.md
+++ b/core/src/components/slide/readme.md
@@ -1,10 +1,10 @@
 # ion-slide
 
-The Slide component is a child component of [Slides](../slides). The template
+The Slide component is a child component of [Slides](/docs/api/slides). The template
 should be written as `ion-slide`. Any slide content should be written
-in this component and it should be used in conjunction with [Slides](../slides).
+in this component and it should be used in conjunction with [Slides](/docs/api/slides).
 
-See the [Slides API Docs](../slides) for more usage information.
+See the [Slides API Docs](/docs/api/slides) for more usage information.
 
 
 <!-- Auto Generated Below -->

--- a/core/src/components/slides/readme.md
+++ b/core/src/components/slides/readme.md
@@ -1,7 +1,7 @@
 # ion-slides
 
 The Slides component is a multi-section container. Each section can be swiped
-or dragged between. It contains any number of [Slide](../Slide) components.
+or dragged between. It contains any number of [Slide](/docs/api/slide) components.
 
 
 Adopted from Swiper.js:

--- a/core/src/components/tab-bar/readme.md
+++ b/core/src/components/tab-bar/readme.md
@@ -1,6 +1,6 @@
 # ion-tab-bar
 
-The tab bar is a UI component that contains a set of [tab buttons](../tab-button). A tab bar must be provided inside of [tabs](../tabs) to communicate with each [tab](../tab).
+The tab bar is a UI component that contains a set of [tab buttons](/docs/api/tab-button). A tab bar must be provided inside of [tabs](/docs/api/tabs) to communicate with each [tab](/docs/api/tab).
 
 
 <!-- Auto Generated Below -->

--- a/core/src/components/tab-button/readme.md
+++ b/core/src/components/tab-button/readme.md
@@ -1,8 +1,8 @@
 # ion-tab-button
 
-A tab button is a UI component that is placed inside of a [tab bar](../tab-bar). The tab button can specify the layout of the icon and label and connect to a [tab view](../tab).
+A tab button is a UI component that is placed inside of a [tab bar](/docs/api/tab-bar). The tab button can specify the layout of the icon and label and connect to a [tab view](/docs/api/tab).
 
-See the [tabs documentation](../tabs) for more details on configuring tabs.
+See the [tabs documentation](/docs/api/tabs) for more details on configuring tabs.
 
 
 <!-- Auto Generated Below -->

--- a/core/src/components/tab/readme.md
+++ b/core/src/components/tab/readme.md
@@ -1,8 +1,8 @@
 # ion-tab
 
-The tab component is a child component of [tabs](../tabs). Each tab can contain a top level navigation stack for an app or a single view. An app can have many tabs, all with their own independent navigation.
+The tab component is a child component of [tabs](/docs/api/tabs). Each tab can contain a top level navigation stack for an app or a single view. An app can have many tabs, all with their own independent navigation.
 
-See the [tabs documentation](../tabs/) for more details on configuring tabs.
+See the [tabs documentation](/docs/api/tabs) for more details on configuring tabs.
 
 
 <!-- Auto Generated Below -->

--- a/core/src/components/tabs/readme.md
+++ b/core/src/components/tabs/readme.md
@@ -1,7 +1,7 @@
 # ion-tabs
 
 Tabs are a top level navigation component to implement a tab-based navigation.
-The component is a container of individual [Tab](../tab/) components.
+The component is a container of individual [Tab](/docs/api/tab) components.
 
 `ion-tabs` is a styleless component that works as a router outlet in order to handle navigation.
 This component does not provide any UI feedback or mechanism to switch between tabs.

--- a/core/src/components/toast-controller/readme.md
+++ b/core/src/components/toast-controller/readme.md
@@ -1,6 +1,6 @@
 # ion-toast-controller
 
-ToastController is a component use to create Toast components. Please see the docs for [Toast](../toast).
+ToastController is a component use to create Toast components. Please see the docs for [Toast](/docs/api/toast).
 
 
 <!-- Auto Generated Below -->

--- a/core/src/components/virtual-scroll/readme.md
+++ b/core/src/components/virtual-scroll/readme.md
@@ -83,7 +83,7 @@ scrolling. In order to better control images, Ionic provides `<ion-img>`
 to manage HTTP requests and image rendering. While scrolling through items
 quickly, `<ion-img>` knows when and when not to make requests, when and
 when not to render images, and only loads the images that are viewable
-after scrolling. [Read more about `ion-img`.](../../img/Img/)
+after scrolling. [Read more about `ion-img`.](/docs/api/img/)
 
 It's also important for app developers to ensure image sizes are locked in,
 and after images have fully loaded they do not change size and affect any
@@ -132,7 +132,7 @@ dimensions are measured correctly.
 #### iOS Cordova WKWebView
 
 When deploying to iOS with Cordova, it's highly recommended to use the
-[WKWebView plugin](http://blog.ionic.io/cordova-ios-performance-improvements-drop-in-speed-with-wkwebview/)
+[WKWebView plugin](https://blog.ionicframework.com/cordova-ios-performance-improvements-drop-in-speed-with-wkwebview/)
 in order to take advantage of iOS's higher performing webview. Additionally,
 WKWebView is superior at scrolling efficiently in comparison to the older
 UIWebView.


### PR DESCRIPTION
#### Short description of what this resolves:
New website for Ionic 4.0 adopted a different structure and left many internal links broken.

#### Changes proposed in this pull request:

- Replace all internal links with correct links where broken
- Update blog link to new blog url
- Add https to external links where appropriate

**Ionic Version**: 4.0
