### PR TITLE
fix(config): update types for scrollPadding, inputBlurring and hideCaretOnScroll to boolean

### DIFF
--- a/core/src/utils/config.ts
+++ b/core/src/utils/config.ts
@@ -168,10 +168,10 @@ export interface IonicConfig {
   // PRIVATE configs
   keyboardHeight?: number;
   inputShims?: boolean;
-  scrollPadding?: string;
-  inputBlurring?: string;
+  scrollPadding?: boolean;
+  inputBlurring?: boolean;
   scrollAssist?: boolean;
-  hideCaretOnScroll?: string;
+  hideCaretOnScroll?: boolean;
 
   // INTERNAL configs
   persistConfig?: boolean;


### PR DESCRIPTION
#### Short description of what this resolves:
it fix the definition of scrollPadding, inputBlurring and hideCaretOnScroll in config.ts by declaring it as boolean instead of string

**Ionic Version**:
v4
