### PR TITLE
fix(platform): add additional check for safari PWA

### DIFF
--- a/core/src/utils/platform.ts
+++ b/core/src/utils/platform.ts
@@ -104,7 +104,7 @@ function isElectron(win: Window): boolean {
 }
 
 function isPWA(win: Window): boolean {
-  return win.matchMedia('(display-mode: standalone)').matches;
+  return win.matchMedia('(display-mode: standalone)').matches || (win.navigator as any).standalone;
 }
 
 function testUserAgent(win: Window, expr: RegExp) {


### PR DESCRIPTION
#### Short description of what this resolves:
Adds an additional check for PWAs on iOS

#### Changes proposed in this pull request:

- Check `standalone` status via navigator for iOS

**Ionic Version**:

**Fixes**: #17336
