### PR TITLE
feat(platform): add mobileweb platform

### DIFF
--- a/angular/src/providers/platform.ts
+++ b/angular/src/providers/platform.ts
@@ -98,8 +98,9 @@ export class Platform {
    * | phablet         | on a phablet device.               |
    * | tablet          | on a tablet device.                |
    * | electron        | in Electron on a desktop device.   |
-   * | pwa             | as a PWA app.   |
+   * | pwa             | as a PWA app.                      |
    * | mobile          | on a mobile device.                |
+   * | mobileweb       | on a mobile device in a browser.   |
    * | desktop         | on a desktop device.               |
    * | hybrid          | is a cordova or capacitor app.     |
    *

--- a/core/src/utils/platform.ts
+++ b/core/src/utils/platform.ts
@@ -11,6 +11,7 @@ export const PLATFORMS_MAP = {
   'electron': isElectron,
   'pwa': isPWA,
   'mobile': isMobile,
+  'mobileweb': isMobileWeb,
   'desktop': isDesktop,
   'hybrid': isHybrid
 };
@@ -35,6 +36,10 @@ export function setupPlatforms(win: any) {
     platforms.forEach(p => classList.add(`plt-${p}`));
   }
   return platforms;
+}
+
+function isMobileWeb(win: Window): boolean {
+  return isMobile(win) && !isHybrid(win);
 }
 
 function detectPlatforms(win: Window): string[] {


### PR DESCRIPTION
#### Short description of what this resolves:
Adds the `mobileweb` platform to the list of platforms

#### Changes proposed in this pull request:

- Add `mobileweb` option to `PLATFORMS_MAP` 
- Add function to check if device is `mobileweb`

**Ionic Version**:

**Fixes**: #17335
