### PR TITLE
feat(range): add neutral point

### DIFF
--- a/angular/src/directives/proxies.ts
+++ b/angular/src/directives/proxies.ts
@@ -586,7 +586,7 @@ export class IonRadioGroup {
 proxyInputs(IonRadioGroup, ['allowEmptySelection', 'name', 'value']);
 
 export declare interface IonRange extends StencilComponents<'IonRange'> {}
-@Component({ selector: 'ion-range', changeDetection: 0, template: '<ng-content></ng-content>', inputs: ['color', 'mode', 'debounce', 'name', 'dualKnobs', 'min', 'max', 'pin', 'snaps', 'step', 'disabled', 'value'] })
+@Component({ selector: 'ion-range', changeDetection: 0, template: '<ng-content></ng-content>', inputs: ['color', 'mode', 'neutralPoint', 'debounce', 'name', 'dualKnobs', 'min', 'max', 'pin', 'snaps', 'step', 'disabled', 'value'] })
 export class IonRange {
   ionChange!: EventEmitter<CustomEvent>;
   ionFocus!: EventEmitter<CustomEvent>;
@@ -598,7 +598,7 @@ export class IonRange {
     proxyOutputs(this, this.el, ['ionChange', 'ionFocus', 'ionBlur']);
   }
 }
-proxyInputs(IonRange, ['color', 'mode', 'debounce', 'name', 'dualKnobs', 'min', 'max', 'pin', 'snaps', 'step', 'disabled', 'value']);
+proxyInputs(IonRange, ['color', 'mode', 'neutralPoint', 'debounce', 'name', 'dualKnobs', 'min', 'max', 'pin', 'snaps', 'step', 'disabled', 'value']);
 
 export declare interface IonRefresher extends StencilComponents<'IonRefresher'> {}
 @Component({ selector: 'ion-refresher', changeDetection: 0, template: '<ng-content></ng-content>', inputs: ['pullMin', 'pullMax', 'closeDuration', 'snapbackDuration', 'disabled'] })

--- a/core/api.txt
+++ b/core/api.txt
@@ -800,10 +800,11 @@ ion-range,prop,max,number,100,false,false
 ion-range,prop,min,number,0,false,false
 ion-range,prop,mode,"ios" | "md",undefined,false,false
 ion-range,prop,name,string,'',false,false
+ion-range,prop,neutralPoint,number,0,false,false
 ion-range,prop,pin,boolean,false,false,false
 ion-range,prop,snaps,boolean,false,false,false
 ion-range,prop,step,number,1,false,false
-ion-range,prop,value,number | { lower: number; upper: number; },0,false,false
+ion-range,prop,value,null | number | { lower: number; upper: number; },null,false,false
 ion-range,event,ionBlur,void,true
 ion-range,event,ionChange,RangeChangeEventDetail,true
 ion-range,event,ionFocus,void,true

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -3309,6 +3309,10 @@ export namespace Components {
     */
     'name': string;
     /**
+    * The neutral point of the range slider. Default: value is `0` or the `min` when `neutralPoint < min` or `max` when `max < neutralPoint`.
+    */
+    'neutralPoint': number;
+    /**
     * If `true`, a pin with integer value is shown when the knob is pressed.
     */
     'pin': boolean;
@@ -3323,7 +3327,7 @@ export namespace Components {
     /**
     * the value of the range.
     */
-    'value': RangeValue;
+    'value': RangeValue | null;
   }
   interface IonRangeAttributes extends StencilHTMLAttributes {
     /**
@@ -3359,6 +3363,10 @@ export namespace Components {
     */
     'name'?: string;
     /**
+    * The neutral point of the range slider. Default: value is `0` or the `min` when `neutralPoint < min` or `max` when `max < neutralPoint`.
+    */
+    'neutralPoint'?: number;
+    /**
     * Emitted when the range loses focus.
     */
     'onIonBlur'?: (event: CustomEvent<void>) => void;
@@ -3385,7 +3393,7 @@ export namespace Components {
     /**
     * the value of the range.
     */
-    'value'?: RangeValue;
+    'value'?: RangeValue | null;
   }
 
   interface IonRefresherContent {

--- a/core/src/components/range/range.tsx
+++ b/core/src/components/range/range.tsx
@@ -54,7 +54,7 @@ export class Range implements ComponentInterface {
     if (max < neutralPoint) {
       this.neutralPoint = max;
     }
-    if (min < neutralPoint) {
+    if (neutralPoint < min) {
       this.neutralPoint = min;
     }
   }

--- a/core/src/components/range/range.tsx
+++ b/core/src/components/range/range.tsx
@@ -457,8 +457,8 @@ export class Range implements ComponentInterface {
     const barStyle = () => {
       const style: any = {};
 
-      style[start] = barPosition.left;
-      style[end] = barPosition.right;
+      style[start] = barPosition[start];
+      style[end] = barPosition[end];
 
       return style;
     };

--- a/core/src/components/range/range.tsx
+++ b/core/src/components/range/range.tsx
@@ -46,15 +46,16 @@ export class Range implements ComponentInterface {
    */
   @Prop() neutralPoint = 0;
   protected neutralPointChanged() {
-    if (!this.noUpdate) {
-      const { min, max, neutralPoint } = this;
+    if (this.noUpdate) {
+      return;
+    }
+    const { min, max, neutralPoint } = this;
 
-      if (max < neutralPoint) {
-        this.neutralPoint = max;
-      }
-      if (min < neutralPoint) {
-        this.neutralPoint = min;
-      }
+    if (max < neutralPoint) {
+      this.neutralPoint = max;
+    }
+    if (min < neutralPoint) {
+      this.neutralPoint = min;
     }
   }
 

--- a/core/src/components/range/range.tsx
+++ b/core/src/components/range/range.tsx
@@ -432,23 +432,25 @@ export class Range implements ComponentInterface {
     const start = isRTL ? 'right' : 'left';
     const end = isRTL ? 'left' : 'right';
 
-    const ticks = [];
+    const ticks: any[] = [];
 
     if (this.snaps) {
       for (let value = min; value <= max; value += step) {
         const ratio = valueToRatio(value, min, max);
 
-        ticks.push({
+        const tick: any = {
           ratio,
           active: this.isTickActive(ratio),
-          start: `${ratio * 100}%`
-        });
+        };
+
+        tick[start] = `${ratio * 100}%`;
+
+        ticks.push(tick);
       }
     }
 
     const tickStyle = (tick: any) => {
       const style: any = {};
-
       style[start] = tick[start];
 
       return style;

--- a/core/src/components/range/readme.md
+++ b/core/src/components/range/readme.md
@@ -44,7 +44,15 @@ left or right of the range.
   </ion-item>
 
   <ion-item>
+    <ion-range min="1000" max="2000" step="100" snaps="true" neutralPoint="1500" color="secondary"></ion-range>
+  </ion-item>
+
+  <ion-item>
     <ion-range dualKnobs="true" min="21" max="72" step="3" snaps="true"></ion-range>
+  </ion-item>
+
+  <ion-item>
+    <ion-range dual-knobs="true" neutralPoint="30" min="21" max="72" step="3" snaps="true"></ion-range>
   </ion-item>
 </ion-list>
 ```
@@ -77,7 +85,15 @@ left or right of the range.
   </ion-item>
 
   <ion-item>
+    <ion-range min="1000" max="2000" step="100" snaps="true" neutralPoint="1500" color="secondary"></ion-range>
+  </ion-item>
+
+  <ion-item>
     <ion-range dual-knobs="true" min="21" max="72" step="3" snaps="true"></ion-range>
+  </ion-item>
+
+  <ion-item>
+    <ion-range dual-knobs="true" neutralPoint="30" min="21" max="72" step="3" snaps="true"></ion-range>
   </ion-item>
 </ion-list>
 ```
@@ -86,20 +102,21 @@ left or right of the range.
 
 ## Properties
 
-| Property    | Attribute    | Description                                                                                                                                                                                                                                                            | Type                                          | Default     |
-| ----------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ----------- |
-| `color`     | `color`      | The color to use from your application's color palette. Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`. For more information on colors, see [theming](/docs/theming/basics). | `string \| undefined`                         | `undefined` |
-| `debounce`  | `debounce`   | How long, in milliseconds, to wait to trigger the `ionChange` event after each change in the range value.                                                                                                                                                              | `number`                                      | `0`         |
-| `disabled`  | `disabled`   | If `true`, the user cannot interact with the range.                                                                                                                                                                                                                    | `boolean`                                     | `false`     |
-| `dualKnobs` | `dual-knobs` | Show two knobs.                                                                                                                                                                                                                                                        | `boolean`                                     | `false`     |
-| `max`       | `max`        | Maximum integer value of the range.                                                                                                                                                                                                                                    | `number`                                      | `100`       |
-| `min`       | `min`        | Minimum integer value of the range.                                                                                                                                                                                                                                    | `number`                                      | `0`         |
-| `mode`      | `mode`       | The mode determines which platform styles to use.                                                                                                                                                                                                                      | `"ios" \| "md"`                               | `undefined` |
-| `name`      | `name`       | The name of the control, which is submitted with the form data.                                                                                                                                                                                                        | `string`                                      | `''`        |
-| `pin`       | `pin`        | If `true`, a pin with integer value is shown when the knob is pressed.                                                                                                                                                                                                 | `boolean`                                     | `false`     |
-| `snaps`     | `snaps`      | If `true`, the knob snaps to tick marks evenly spaced based on the step property value.                                                                                                                                                                                | `boolean`                                     | `false`     |
-| `step`      | `step`       | Specifies the value granularity.                                                                                                                                                                                                                                       | `number`                                      | `1`         |
-| `value`     | `value`      | the value of the range.                                                                                                                                                                                                                                                | `number \| { lower: number; upper: number; }` | `0`         |
+| Property       | Attribute       | Description                                                                                                                                                                                                                                                            | Type                                                  | Default     |
+| -------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | ----------- |
+| `color`        | `color`         | The color to use from your application's color palette. Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`. For more information on colors, see [theming](/docs/theming/basics). | `string \| undefined`                                 | `undefined` |
+| `debounce`     | `debounce`      | How long, in milliseconds, to wait to trigger the `ionChange` event after each change in the range value.                                                                                                                                                              | `number`                                              | `0`         |
+| `disabled`     | `disabled`      | If `true`, the user cannot interact with the range.                                                                                                                                                                                                                    | `boolean`                                             | `false`     |
+| `dualKnobs`    | `dual-knobs`    | Show two knobs.                                                                                                                                                                                                                                                        | `boolean`                                             | `false`     |
+| `max`          | `max`           | Maximum integer value of the range.                                                                                                                                                                                                                                    | `number`                                              | `100`       |
+| `min`          | `min`           | Minimum integer value of the range.                                                                                                                                                                                                                                    | `number`                                              | `0`         |
+| `mode`         | `mode`          | The mode determines which platform styles to use.                                                                                                                                                                                                                      | `"ios" \| "md"`                                       | `undefined` |
+| `name`         | `name`          | The name of the control, which is submitted with the form data.                                                                                                                                                                                                        | `string`                                              | `''`        |
+| `neutralPoint` | `neutral-point` | The neutral point of the range slider. Default: value is `0` or the `min` when `neutralPoint < min` or `max` when `max < neutralPoint`.                                                                                                                                | `number`                                              | `0`         |
+| `pin`          | `pin`           | If `true`, a pin with integer value is shown when the knob is pressed.                                                                                                                                                                                                 | `boolean`                                             | `false`     |
+| `snaps`        | `snaps`         | If `true`, the knob snaps to tick marks evenly spaced based on the step property value.                                                                                                                                                                                | `boolean`                                             | `false`     |
+| `step`         | `step`          | Specifies the value granularity.                                                                                                                                                                                                                                       | `number`                                              | `1`         |
+| `value`        | `value`         | the value of the range.                                                                                                                                                                                                                                                | `null \| number \| { lower: number; upper: number; }` | `null`      |
 
 
 ## Events

--- a/core/src/components/range/test/basic/index.html
+++ b/core/src/components/range/test/basic/index.html
@@ -102,6 +102,12 @@
           <ion-range dual-knobs="true" id="multiKnob"></ion-range>
         </ion-item>
         <ion-item>
+          <ion-range value="1300" min="1000" max="2000" step="100" snaps="true" neutral-point="1500" color="secondary"></ion-range>
+        </ion-item>
+        <ion-item>
+          <ion-range dual-knobs="true" neutral-point="30" min="21" max="72" step="3" snaps="true"></ion-range>
+        </ion-item>
+        <ion-item>
           <ion-range id="debounce" debounce="5000"></ion-range>
         </ion-item>
       </ion-list>

--- a/core/src/components/range/usage/angular.md
+++ b/core/src/components/range/usage/angular.md
@@ -23,7 +23,15 @@
   </ion-item>
 
   <ion-item>
+    <ion-range min="1000" max="2000" step="100" snaps="true" neutralPoint="1500" color="secondary"></ion-range>
+  </ion-item>
+
+  <ion-item>
     <ion-range dualKnobs="true" min="21" max="72" step="3" snaps="true"></ion-range>
+  </ion-item>
+
+  <ion-item>
+    <ion-range dual-knobs="true" neutralPoint="30" min="21" max="72" step="3" snaps="true"></ion-range>
   </ion-item>
 </ion-list>
 ```

--- a/core/src/components/range/usage/javascript.md
+++ b/core/src/components/range/usage/javascript.md
@@ -23,7 +23,15 @@
   </ion-item>
 
   <ion-item>
+    <ion-range min="1000" max="2000" step="100" snaps="true" neutralPoint="1500" color="secondary"></ion-range>
+  </ion-item>
+
+  <ion-item>
     <ion-range dual-knobs="true" min="21" max="72" step="3" snaps="true"></ion-range>
+  </ion-item>
+
+  <ion-item>
+    <ion-range dual-knobs="true" neutralPoint="30" min="21" max="72" step="3" snaps="true"></ion-range>
   </ion-item>
 </ion-list>
 ```


### PR DESCRIPTION
#### Short description of what this resolves:
Ability to set the neutral point of the picker. Active ticks and bar are measured from the neutral point instead of the min value.

![bildschirmfoto 2019-02-06 um 13 38 18](https://user-images.githubusercontent.com/2264672/52342005-82949980-2a14-11e9-89a4-e8525064c3b9.png)

#### Changes proposed in this pull request:

- added neutralPoint prop
- calculate active state of ticks and bar
- set intial value to neutralPoint if not set

**Ionic Version**:
4.0.0