### PR TITLE
docs(popover): Add missing comma in example

### DIFF
--- a/core/src/components/popover/readme.md
+++ b/core/src/components/popover/readme.md
@@ -52,7 +52,7 @@ async function presentPopover(ev) {
 
   const popover = await popoverController.create({
     component: 'popover-example-page',
-    translucent: true
+    translucent: true,
     event: ev,
   });
   return await popover.present();

--- a/core/src/components/popover/readme.md
+++ b/core/src/components/popover/readme.md
@@ -52,8 +52,8 @@ async function presentPopover(ev) {
 
   const popover = await popoverController.create({
     component: 'popover-example-page',
-    translucent: true,
     event: ev,
+    translucent: true
   });
   return await popover.present();
 }

--- a/core/src/components/popover/usage/javascript.md
+++ b/core/src/components/popover/usage/javascript.md
@@ -5,8 +5,8 @@ async function presentPopover(ev) {
 
   const popover = await popoverController.create({
     component: 'popover-example-page',
-    translucent: true
     event: ev,
+    translucent: true
   });
   return await popover.present();
 }


### PR DESCRIPTION
#### Short description of what this resolves:
A minor typo in the documentation. I know that the guidelines say that an issue should be created first but that seemed like an overkill in this case. I hope that's okay.

#### Changes proposed in this pull request:

- Adding the missing comma

**Ionic Version**:

**Fixes**: #
