### PR TITLE
docs(reorder): Fix incomplete docs

### DIFF
--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -3510,7 +3510,7 @@ export namespace Components {
     */
     'disabled'?: boolean;
     /**
-    * Event that needs to be listened to in order to complete the reorder action. Once the event has been emitted, the `complete()` method then needs to be called in order to finalize the reorder action
+    * Event that needs to be listened to in order to complete the reorder action. Once the event has been emitted, the `complete()` method then needs to be called in order to finalize the reorder action.
     */
     'onIonItemReorder'?: (event: CustomEvent<ItemReorderEventDetail>) => void;
   }

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -3510,7 +3510,7 @@ export namespace Components {
     */
     'disabled'?: boolean;
     /**
-    * Event that needs to be listen to in order to respond to reorder action. `ion-reorder-group` uses this event to delegate to the user the reordering of data array.   The complete() method exposed as
+    * Event that needs to be listened to in order to complete the reorder action. Once the event has been emitted, the `complete()` method then needs to be called in order to finalize the reorder action
     */
     'onIonItemReorder'?: (event: CustomEvent<ItemReorderEventDetail>) => void;
   }

--- a/core/src/components/reorder-group/readme.md
+++ b/core/src/components/reorder-group/readme.md
@@ -13,7 +13,7 @@ reorderGroup.addEventListener('ionItemReorder', (ev) => {
 });
 ```
 
-The event's detail includes all the relevant information about the reorder operation, including the `from` and `to` indexes. The meaning of this indexes are pretty self-explanatory, the item **from** index X, moved **to** the index Y.
+The event's detail includes all the relevant information about the reorder operation, including the `from` and `to` indexes. In other words, the item **from** index X, moved **to** the index Y.
 
 For example, in this list we move the item at index `0` to the index `3`:
 
@@ -42,7 +42,7 @@ Fortunately this `complete()` method can optionally accept an array as input and
 this.dataList = reorderGroup.complete(this.dataList);
 ```
 
-This utility is really handy when
+This utility is really handy when you do not want to manager re-ordering the list yourself.
 
 
 
@@ -180,7 +180,7 @@ reorderGroup.addEventListener('ionItemReorder', ({detail}) => {
 
 | Event            | Description                                                                                                                                                                                          | Type                                  |
 | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| `ionItemReorder` | Event that needs to be listen to in order to respond to reorder action. `ion-reorder-group` uses this event to delegate to the user the reordering of data array.   The complete() method exposed as | `CustomEvent<ItemReorderEventDetail>` |
+| `ionItemReorder` | Event that needs to be listened to in order to complete the reorder action. The user will then need to call the `complete()` method to finalize the reorder action. | `CustomEvent<ItemReorderEventDetail>` |
 
 
 ## Methods

--- a/core/src/components/reorder-group/readme.md
+++ b/core/src/components/reorder-group/readme.md
@@ -180,7 +180,7 @@ reorderGroup.addEventListener('ionItemReorder', ({detail}) => {
 
 | Event            | Description                                                                                                                                                                                          | Type                                  |
 | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| `ionItemReorder` | Event that needs to be listened to in order to complete the reorder action. The user will then need to call the `complete()` method to finalize the reorder action. | `CustomEvent<ItemReorderEventDetail>` |
+| `ionItemReorder` | Event that needs to be listened to in order to complete the reorder action. Once the event has been emitted, the `complete()` method then needs to be called in order to finalize the reorder action. | `CustomEvent<ItemReorderEventDetail>` |
 
 
 ## Methods

--- a/core/src/components/reorder-group/readme.md
+++ b/core/src/components/reorder-group/readme.md
@@ -176,7 +176,7 @@ reorderGroup.addEventListener('ionItemReorder', ({detail}) => {
 
 | Event            | Description                                                                                                                                                                                          | Type                                  |
 | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| `ionItemReorder` | Event that needs to be listen to in order to respond to reorder action. `ion-reorder-group` uses this event to delegate to the user the reordering of data array.   The complete() method exposed as | `CustomEvent<ItemReorderEventDetail>` |
+| `ionItemReorder` | Event that needs to be listened to in order to complete the reorder action. Once the event has been emitted, the `complete()` method then needs to be called in order to finalize the reorder action | `CustomEvent<ItemReorderEventDetail>` |
 
 
 ## Methods

--- a/core/src/components/reorder-group/readme.md
+++ b/core/src/components/reorder-group/readme.md
@@ -42,10 +42,6 @@ Fortunately this `complete()` method can optionally accept an array as input and
 this.dataList = reorderGroup.complete(this.dataList);
 ```
 
-This utility is really handy when you do not want to manager re-ordering the list yourself.
-
-
-
 <!-- Auto Generated Below -->
 
 

--- a/core/src/components/reorder-group/readme.md
+++ b/core/src/components/reorder-group/readme.md
@@ -13,7 +13,7 @@ reorderGroup.addEventListener('ionItemReorder', (ev) => {
 });
 ```
 
-The event's detail includes all the relevant information about the reorder operation, including the `from` and `to` indexes. In other words, the item **from** index X, moved **to** the index Y.
+The event's detail includes all the relevant information about the reorder operation, including the `from` and `to` indexes. In the context of reordering, an item moves `from` index X `to` index Y.
 
 For example, in this list we move the item at index `0` to the index `3`:
 

--- a/core/src/components/reorder-group/readme.md
+++ b/core/src/components/reorder-group/readme.md
@@ -176,7 +176,7 @@ reorderGroup.addEventListener('ionItemReorder', ({detail}) => {
 
 | Event            | Description                                                                                                                                                                                          | Type                                  |
 | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| `ionItemReorder` | Event that needs to be listened to in order to complete the reorder action. Once the event has been emitted, the `complete()` method then needs to be called in order to finalize the reorder action. | `CustomEvent<ItemReorderEventDetail>` |
+| `ionItemReorder` | Event that needs to be listen to in order to respond to reorder action. `ion-reorder-group` uses this event to delegate to the user the reordering of data array.   The complete() method exposed as | `CustomEvent<ItemReorderEventDetail>` |
 
 
 ## Methods

--- a/core/src/components/reorder-group/readme.md
+++ b/core/src/components/reorder-group/readme.md
@@ -174,9 +174,9 @@ reorderGroup.addEventListener('ionItemReorder', ({detail}) => {
 
 ## Events
 
-| Event            | Description                                                                                                                                                                                          | Type                                  |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| `ionItemReorder` | Event that needs to be listened to in order to complete the reorder action. Once the event has been emitted, the `complete()` method then needs to be called in order to finalize the reorder action | `CustomEvent<ItemReorderEventDetail>` |
+| Event            | Description                                                                                                                                                                                           | Type                                  |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `ionItemReorder` | Event that needs to be listened to in order to complete the reorder action. Once the event has been emitted, the `complete()` method then needs to be called in order to finalize the reorder action. | `CustomEvent<ItemReorderEventDetail>` |
 
 
 ## Methods

--- a/core/src/components/reorder-group/reorder-group.tsx
+++ b/core/src/components/reorder-group/reorder-group.tsx
@@ -50,11 +50,9 @@ export class ReorderGroup implements ComponentInterface {
   }
 
   /**
-   * Event that needs to be listen to in order to respond to reorder action.
-   * `ion-reorder-group` uses this event to delegate to the user the reordering of data array.
-   *
-   *
-   * The complete() method exposed as
+   * Event that needs to be listened to in order to complete the reorder action.
+   * Once the event has been emitted, the `complete()` method then needs
+   * to be called in order to finalize the reorder action
    */
   @Event() ionItemReorder!: EventEmitter<ItemReorderEventDetail>;
 

--- a/core/src/components/reorder-group/reorder-group.tsx
+++ b/core/src/components/reorder-group/reorder-group.tsx
@@ -52,7 +52,7 @@ export class ReorderGroup implements ComponentInterface {
   /**
    * Event that needs to be listened to in order to complete the reorder action.
    * Once the event has been emitted, the `complete()` method then needs
-   * to be called in order to finalize the reorder action
+   * to be called in order to finalize the reorder action.
    */
   @Event() ionItemReorder!: EventEmitter<ItemReorderEventDetail>;
 

--- a/core/src/components/reorder-group/test/basic/index.html
+++ b/core/src/components/reorder-group/test/basic/index.html
@@ -25,7 +25,7 @@
 
     <ion-content id="content">
       <ion-list>
-        <ion-reorder-group id="reorder">
+        <ion-reorder-group id="reorder" disabled="false">
 
           <ion-item button onclick="openAlert()">
             <ion-label>

--- a/core/src/components/reorder-group/test/basic/index.html
+++ b/core/src/components/reorder-group/test/basic/index.html
@@ -25,7 +25,7 @@
 
     <ion-content id="content">
       <ion-list>
-        <ion-reorder-group id="reorder" disabled="false">
+        <ion-reorder-group id="reorder">
 
           <ion-item button onclick="openAlert()">
             <ion-label>

--- a/core/src/components/reorder/readme.md
+++ b/core/src/components/reorder/readme.md
@@ -2,7 +2,7 @@
 
 Reorder is a component that allows an item to be dragged to change its order. It must be used within an `ion-reorder-group` to provide a visual drag and drop interface.
 
-`ion-reorder` is the anchor users will use to drag and drop items inside the `ion-reorder-group`. It must be added to `ion-item` in order for them to be draggable.
+`ion-reorder` is the anchor users will use to drag and drop items inside the `ion-reorder-group`.
 
 ```html
 <ion-item>
@@ -13,8 +13,12 @@ Reorder is a component that allows an item to be dragged to change its order. It
 </ion-item>
 ```
 
-The position of the 
+## Properties
 
+| Property   | Attribute  | Description                            | Type      |
+| ---------- | ---------- | -------------------------------------- | --------- |
+| `slot`     | `slot`     | If `start`, the reorder icon will be shown at before the label. If `end`, the reorder icon will be show after the label | `string` |
+| `name`     | `name`     | The name of the icon to use for the reorder handle. | `string` ||
 
 <!-- Auto Generated Below -->
 

--- a/core/src/components/reorder/readme.md
+++ b/core/src/components/reorder/readme.md
@@ -13,12 +13,6 @@ Reorder is a component that allows an item to be dragged to change its order. It
 </ion-item>
 ```
 
-## Properties
-
-| Property   | Attribute  | Description                            | Type      |
-| ---------- | ---------- | -------------------------------------- | --------- |
-| `slot`     | `slot`     | If `start`, the reorder icon will be shown before the label. If `end`, the reorder icon will be show after the label | `string` |
-
 <!-- Auto Generated Below -->
 
 

--- a/core/src/components/reorder/readme.md
+++ b/core/src/components/reorder/readme.md
@@ -18,7 +18,6 @@ Reorder is a component that allows an item to be dragged to change its order. It
 | Property   | Attribute  | Description                            | Type      |
 | ---------- | ---------- | -------------------------------------- | --------- |
 | `slot`     | `slot`     | If `start`, the reorder icon will be shown before the label. If `end`, the reorder icon will be show after the label | `string` |
-| `name`     | `name`     | The name of the icon to use for the reorder handle. | `string` ||
 
 <!-- Auto Generated Below -->
 

--- a/core/src/components/reorder/readme.md
+++ b/core/src/components/reorder/readme.md
@@ -17,7 +17,7 @@ Reorder is a component that allows an item to be dragged to change its order. It
 
 | Property   | Attribute  | Description                            | Type      |
 | ---------- | ---------- | -------------------------------------- | --------- |
-| `slot`     | `slot`     | If `start`, the reorder icon will be shown at before the label. If `end`, the reorder icon will be show after the label | `string` |
+| `slot`     | `slot`     | If `start`, the reorder icon will be shown before the label. If `end`, the reorder icon will be show after the label | `string` |
 | `name`     | `name`     | The name of the icon to use for the reorder handle. | `string` ||
 
 <!-- Auto Generated Below -->


### PR DESCRIPTION
#### Short description of what this resolves:
Fixed the incomplete documentation for `reorder` and `reorder-group`

#### Changes proposed in this pull request:

- Fix typos in the doc
- Add `properties` for `reorder`
- Remove incomplete/incorrect information

**Ionic Version**:

**Fixes**: https://github.com/ionic-team/ionic-docs/issues/160
