### PR TITLE
docs(loading): update loading example

### DIFF
--- a/angular/BREAKING.md
+++ b/angular/BREAKING.md
@@ -1065,6 +1065,12 @@ openLoading() {
   let loading = this.loadingCtrl.create({
     content: 'Loading...'
   });
+  
+  await loading.present();
+  
+  const { role, data } = await loading.onDidDismiss();
+    
+  console.log('Loading dismissed!');
 }
 ```
 


### PR DESCRIPTION
#### Short description of what this resolves:
The Breaking Changes doc never got updated examples for Loading usage

#### Changes proposed in this pull request:

- Adds new info on how to use `onDidDismiss` since `dismissOnPageChange` got removed
-
-

**Ionic Version**:

**Fixes**: #
