### PR TITLE
docs(loading): add missing async to new loading example

### DIFF
--- a/angular/BREAKING.md
+++ b/angular/BREAKING.md
@@ -1065,6 +1065,12 @@ openLoading() {
   let loading = this.loadingCtrl.create({
     content: 'Loading...'
   });
+  
+  await loading.present();
+  
+  const { role, data } = await loading.onDidDismiss();
+    
+  console.log('Loading dismissed!');
 }
 ```
 

--- a/angular/BREAKING.md
+++ b/angular/BREAKING.md
@@ -1061,7 +1061,7 @@ openLoading() {
 **New Usage Example:**
 
 ```javascript
-openLoading() {
+async openLoading() {
   let loading = this.loadingCtrl.create({
     content: 'Loading...'
   });


### PR DESCRIPTION
#### Short description of what this resolves:
`async` was missing from the new loading example

#### Changes proposed in this pull request:

- Add `async` to new loading example

**Ionic Version**:

**Fixes**: #
