### PR TITLE
fix(datetime): default to current date when no value given

### DIFF
--- a/core/src/components/datetime/datetime-util.ts
+++ b/core/src/components/datetime/datetime-util.ts
@@ -1,3 +1,16 @@
+/**
+ * Gets a date value given a format
+ * Defaults to the current date if
+ * no date given
+ */
+export function getDateValue(date: DatetimeData, format: string): number {
+  const getValue = getValueFromFormat(date, format);
+
+  if (getValue) { return getValue; }
+
+  const defaultDate = parseDate(new Date().toISOString());
+  return getValueFromFormat((defaultDate as DatetimeData), format);
+}
 
 export function renderDatetime(template: string, value: DatetimeData | undefined, locale: LocaleData): string | undefined {
   if (value === undefined) {

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -4,7 +4,7 @@ import { DatetimeChangeEventDetail, DatetimeOptions, Mode, PickerColumn, PickerC
 import { clamp, findItemLabel, renderHiddenInput } from '../../utils/helpers';
 import { hostContext } from '../../utils/theme';
 
-import { DatetimeData, LocaleData, convertDataToISO, convertFormatToKey, convertToArrayOfNumbers, convertToArrayOfStrings, dateDataSortValue, dateSortValue, dateValueRange, daysInMonth, getValueFromFormat, parseDate, parseTemplate, renderDatetime, renderTextFormat, updateDate } from './datetime-util';
+import { DatetimeData, LocaleData, convertDataToISO, convertFormatToKey, convertToArrayOfNumbers, convertToArrayOfStrings, dateDataSortValue, dateSortValue, dateValueRange, daysInMonth, getDateValue, parseDate, parseTemplate, renderDatetime, renderTextFormat, updateDate } from './datetime-util';
 
 @Component({
   tag: 'ion-datetime',
@@ -315,20 +315,6 @@ export class Datetime implements ComponentInterface {
     return pickerOptions;
   }
 
-  /**
-   * Gets a date value given a format
-   * Defaults to the current date if
-   * no date given
-   */
-  private getDateValue(date: DatetimeData, format: string): number {
-    const getValue = getValueFromFormat(date, format);
-
-    if (getValue) { return getValue; }
-
-    const defaultDate = parseDate(new Date().toISOString());
-    return getValueFromFormat((defaultDate as DatetimeData), format);
-  }
-
   private generateColumns(): PickerColumn[] {
     // if a picker format wasn't provided, then fallback
     // to use the display format
@@ -373,7 +359,7 @@ export class Datetime implements ComponentInterface {
 
       // cool, we've loaded up the columns with options
       // preselect the option for this column
-      const optValue = this.getDateValue(this.datetimeValue, format);
+      const optValue = getDateValue(this.datetimeValue, format);
       const selectedIndex = colOptions.findIndex(opt => opt.value === optValue);
 
       return {

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -315,6 +315,20 @@ export class Datetime implements ComponentInterface {
     return pickerOptions;
   }
 
+  /**
+   * Gets a date value given a format
+   * Defaults to the current date if
+   * no date given
+   */
+  private getDateValue(date: DatetimeData, format: string): number {
+    const getValue = getValueFromFormat(date, format);
+
+    if (getValue) { return getValue; }
+
+    const defaultDate = parseDate(new Date().toISOString());
+    return getValueFromFormat((defaultDate as DatetimeData), format);
+  }
+
   private generateColumns(): PickerColumn[] {
     // if a picker format wasn't provided, then fallback
     // to use the display format
@@ -359,7 +373,7 @@ export class Datetime implements ComponentInterface {
 
       // cool, we've loaded up the columns with options
       // preselect the option for this column
-      const optValue = getValueFromFormat(this.datetimeValue, format);
+      const optValue = this.getDateValue(this.datetimeValue, format);
       const selectedIndex = colOptions.findIndex(opt => opt.value === optValue);
 
       return {

--- a/core/src/components/datetime/test/datetime.spec.ts
+++ b/core/src/components/datetime/test/datetime.spec.ts
@@ -1,20 +1,14 @@
-import { Datetime } from '../datetime';
 import { DatetimeOptions } from '../datetime-interface';
-import { DatetimeData } from '../datetime-util';
+import { DatetimeData, getDateValue } from '../datetime-util';
 
 describe('Datetime', () => {
-  let datetime;
-  beforeEach(() => {
-    datetime = new Datetime();
-  });
-  
   describe('getDateValue()', () => {
     it('it should return the date value for the current day', () => {
       const today = new Date();
       
-      const dayValue = datetime.getDateValue({}, 'DD');
-      const monthvalue = datetime.getDateValue({}, 'MM');
-      const yearValue = datetime.getDateValue({}, 'YYYY');
+      const dayValue = getDateValue({}, 'DD');
+      const monthvalue = getDateValue({}, 'MM');
+      const yearValue = getDateValue({}, 'YYYY');
       
       expect(dayValue).toEqual(today.getDate());
       expect(monthvalue).toEqual(today.getMonth() + 1);
@@ -29,9 +23,9 @@ describe('Datetime', () => {
         day: date.getDate()
       }
       
-      const dayValue = datetime.getDateValue(dateTimeData, 'DD');
-      const monthvalue = datetime.getDateValue(dateTimeData, 'MM');
-      const yearValue = datetime.getDateValue(dateTimeData, 'YYYY');
+      const dayValue = getDateValue(dateTimeData, 'DD');
+      const monthvalue = getDateValue(dateTimeData, 'MM');
+      const yearValue = getDateValue(dateTimeData, 'YYYY');
       
       expect(dayValue).toEqual(date.getDate());
       expect(monthvalue).toEqual(date.getMonth() + 1);

--- a/core/src/components/datetime/test/datetime.spec.ts
+++ b/core/src/components/datetime/test/datetime.spec.ts
@@ -1,0 +1,41 @@
+import { Datetime } from '../datetime';
+import { DatetimeOptions } from '../datetime-interface';
+import { DatetimeData } from '../datetime-util';
+
+describe('Datetime', () => {
+  let datetime;
+  beforeEach(() => {
+    datetime = new Datetime();
+  });
+  
+  describe('getDateValue()', () => {
+    it('it should return the date value for the current day', () => {
+      const today = new Date();
+      
+      const dayValue = datetime.getDateValue({}, 'DD');
+      const monthvalue = datetime.getDateValue({}, 'MM');
+      const yearValue = datetime.getDateValue({}, 'YYYY');
+      
+      expect(dayValue).toEqual(today.getDate());
+      expect(monthvalue).toEqual(today.getMonth() + 1);
+      expect(yearValue).toEqual(today.getFullYear());
+    });
+    
+    it('it should return the date value for a given day', () => {
+      const date = new Date('15 October 1995');
+      const dateTimeData: DatetimeData = {
+        year: date.getFullYear(),
+        month: date.getMonth() + 1,
+        day: date.getDate()
+      }
+      
+      const dayValue = datetime.getDateValue(dateTimeData, 'DD');
+      const monthvalue = datetime.getDateValue(dateTimeData, 'MM');
+      const yearValue = datetime.getDateValue(dateTimeData, 'YYYY');
+      
+      expect(dayValue).toEqual(date.getDate());
+      expect(monthvalue).toEqual(date.getMonth() + 1);
+      expect(yearValue).toEqual(date.getFullYear());
+    });
+  });
+});


### PR DESCRIPTION
#### Short description of what this resolves:
This PR resolves an issue where the datetime component is not defaulting to the current date when no value is given

#### Changes proposed in this pull request:

-  Add `getDateValue` which will parse a given date OR default to the current date
- Add base spec tests to be built out in future tasks
-

**Ionic Version**:

**Fixes**: #14609
