### PR TITLE
fix(searchbar): allow setting of toolbar color and searchbar color

### DIFF
--- a/core/src/components/searchbar/searchbar.ios.scss
+++ b/core/src/components/searchbar/searchbar.ios.scss
@@ -156,11 +156,11 @@
 // Searchbar in Toolbar Color
 // -----------------------------------------
 
-:host-context(ion-toolbar.ion-color) {
+:host-context(ion-toolbar.ion-color):not(.ion-color) {
   color: inherit;
 }
 
-:host-context(ion-toolbar.ion-color) .searchbar-cancel-button {
+:host-context(ion-toolbar.ion-color):not(.ion-color) .searchbar-cancel-button {
   color: currentColor;
 }
 
@@ -170,12 +170,12 @@
   opacity: $searchbar-ios-input-icon-opacity;
 }
 
-:host-context(ion-toolbar.ion-color) .searchbar-input {
+:host-context(ion-toolbar.ion-color):not(.ion-color) .searchbar-input {
   background: rgba(var(--ion-color-contrast-rgb), $searchbar-ios-input-background-color-alpha);
   color: currentColor;
 }
 
-:host-context(ion-toolbar.ion-color) .searchbar-clear-button {
+:host-context(ion-toolbar.ion-color):not(.ion-color) .searchbar-clear-button {
   color: currentColor;
 
   opacity: $searchbar-ios-input-icon-opacity;

--- a/core/src/components/searchbar/test/toolbar/index.html
+++ b/core/src/components/searchbar/test/toolbar/index.html
@@ -78,6 +78,11 @@
         <ion-toolbar color="dark">
           <ion-searchbar show-cancel-button placeholder="Filter Schedules"></ion-searchbar>
         </ion-toolbar>
+        
+        <h5 padding-start padding-top> Search - Dark Toolbar Danger Search </h5>
+        <ion-toolbar color="dark">
+          <ion-searchbar show-cancel-button color="primary" placeholder="Filter Schedules"></ion-searchbar>
+        </ion-toolbar>
 
         <ion-grid>
           <ion-row>

--- a/core/src/components/searchbar/test/toolbar/index.html
+++ b/core/src/components/searchbar/test/toolbar/index.html
@@ -79,7 +79,7 @@
           <ion-searchbar show-cancel-button placeholder="Filter Schedules"></ion-searchbar>
         </ion-toolbar>
         
-        <h5 padding-start padding-top> Search - Dark Toolbar Danger Search </h5>
+        <h5 padding-start padding-top> Search - Dark Toolbar, Primary Search </h5>
         <ion-toolbar color="dark">
           <ion-searchbar show-cancel-button color="primary" placeholder="Filter Schedules"></ion-searchbar>
         </ion-toolbar>


### PR DESCRIPTION
#### Short description of what this resolves:
This PR fixes an issue where users could not set a searchbar color in addition to a toolbar color

#### Changes proposed in this pull request:

- Only apply the toolbar color to the searchbar if the searchbar does not already have a color applied to it

**Ionic Version**:

**Fixes**: #17186
