### PR TITLE
fix(Range): rtl support

### DIFF
--- a/core/src/components/range/range.tsx
+++ b/core/src/components/range/range.tsx
@@ -384,25 +384,27 @@ export class Range implements ComponentInterface {
     const { min, max, neutralPoint, ratioLower, ratioUpper } = this;
     const neutralPointRatio = valueToRatio(neutralPoint, min, max);
 
+    const isRTL = document.dir === 'rtl';
+    const start = isRTL ? 'right' : 'left';
+    const end = isRTL ? 'left' : 'right';
+    const style: any = {};
+
     // dual knob handling
-    let left = `${ratioLower * 100}%`;
-    let right = `${100 - ratioUpper * 100}%`;
+    style[start] = `${ratioLower * 100}%`;
+    style[end] = `${100 - ratioUpper * 100}%`;
 
     // single knob handling
     if (!this.dualKnobs) {
       if (this.ratioA < neutralPointRatio) {
-        right = `${neutralPointRatio * 100}%`;
-        left = `${this.ratioA * 100}%`;
+        style[end] = `${neutralPointRatio * 100}%`;
+        style[start] = `${this.ratioA * 100}%`;
       } else {
-        right = `${100 - this.ratioA * 100}%`;
-        left = `${neutralPointRatio * 100}%`;
+        style[end] = `${100 - this.ratioA * 100}%`;
+        style[start] = `${neutralPointRatio * 100}%`;
       }
     }
 
-    return {
-      left,
-      right
-    };
+    return style;
   }
 
   protected isTickActive(stepRatio: number) {
@@ -533,12 +535,13 @@ interface RangeKnob {
 
 function renderKnob({ knob, value, ratio, min, max, neutralPoint, disabled, pressed, pin, handleKeyboard }: RangeKnob) {
   const isRTL = document.dir === 'rtl';
-  const start = isRTL ? 'right' : 'left';
+  // const neutralPointRatio = valueToRatio(neutralPoint, min, max);
 
   const knobStyle = () => {
-    const style: any = {};
-
-    style[start] = `${ratio * 100}%`;
+    const style = {
+      left: '0'
+    };
+    style.left = isRTL ? `${100 - ratio * 100}%` : `${ratio * 100}%`;
 
     return style;
   };

--- a/core/src/components/range/range.tsx
+++ b/core/src/components/range/range.tsx
@@ -535,13 +535,11 @@ interface RangeKnob {
 
 function renderKnob({ knob, value, ratio, min, max, neutralPoint, disabled, pressed, pin, handleKeyboard }: RangeKnob) {
   const isRTL = document.dir === 'rtl';
-  // const neutralPointRatio = valueToRatio(neutralPoint, min, max);
+  const start = isRTL ? 'right' : 'left';
 
   const knobStyle = () => {
-    const style = {
-      left: '0'
-    };
-    style.left = isRTL ? `${100 - ratio * 100}%` : `${ratio * 100}%`;
+    const style: any = {};
+    style[start] = `${ratio * 100}%`;
 
     return style;
   };


### PR DESCRIPTION
#### Short description of what this resolves:
Range slider rtl support after introducing the neutralPoint feature.

#### Changes proposed in this pull request:

- correct calculation of barActive and knobStyles  

**Ionic Version**:
4.0.1

**Fixes**: in #17400 destroyed rtl support
