### PR TITLE
fix(button): activated button on ios shows proper shade

### DIFF
--- a/core/src/components/button/button.ios.scss
+++ b/core/src/components/button/button.ios.scss
@@ -34,6 +34,10 @@
   --opacity: #{$button-ios-opacity-activated};
 }
 
+:host(.button-solid.activated.ion-color) .button-native {
+  background: current-color(shade);
+}
+
 // iOS Outline Button
 // --------------------------------------------------
 


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes an issue where the "tinted" color was not being used on buttons with ion-colors applied to them

#### Changes proposed in this pull request:

- Added a rule to apply the tinted color when a button with an ion-color is activated

**Ionic Version**:

**Fixes**: #17436 
