### PR TITLE
fix(reorder): increase gesture priority

### DIFF
--- a/core/src/components/reorder-group/reorder-group.tsx
+++ b/core/src/components/reorder-group/reorder-group.tsx
@@ -67,7 +67,7 @@ export class ReorderGroup implements ComponentInterface {
       el: this.doc.body,
       queue: this.queue,
       gestureName: 'reorder',
-      gesturePriority: 90,
+      gesturePriority: 110,
       threshold: 0,
       direction: 'y',
       passive: false,

--- a/core/src/components/reorder-group/test/basic/index.html
+++ b/core/src/components/reorder-group/test/basic/index.html
@@ -34,12 +34,22 @@
             <ion-reorder slot="end"></ion-reorder>
           </ion-item>
 
-          <ion-item button onclick="openAlert()">
-            <ion-label>
-              Item 2 (default ion-reorder)
-            </ion-label>
-            <ion-reorder slot="end"></ion-reorder>
-          </ion-item>
+          <ion-item-sliding>
+            <ion-item button onclick="openAlert()">
+              <ion-label>
+                Item 2 (default ion-reorder with ion-item-sliding)
+              </ion-label>
+              <ion-reorder slot="end"></ion-reorder>
+            </ion-item>
+            <ion-item-options side="start">
+              <ion-item-option>Favorite</ion-item-option>
+              <ion-item-option color="danger">Share</ion-item-option>
+            </ion-item-options>
+
+            <ion-item-options side="end">
+              <ion-item-option>Unread</ion-item-option>
+            </ion-item-options>
+          </ion-item-sliding>
 
           <ion-item button onclick="openAlert()">
             <ion-label>


### PR DESCRIPTION
#### Short description of what this resolves:

Allow `ion-item-sliding` items to be reordered inside an `ion-reorder-group`.

#### Changes proposed in this pull request:

- Increase the `gesturePriority` of `ion-reorder-group` from `100` to `110`.
- Add a test case for `ion-item-sliding` in the `reorder-group` basic test.

I'm not sure if there is a reason this was lower priority than `ion-item-sliding` before, but this seems to resolve the issue.

**Ionic Version**: 4.0.2

**Fixes**: #16120
