### PR TITLE
fix(img): remove space under img

### DIFF
--- a/core/src/components/img/img.scss
+++ b/core/src/components/img/img.scss
@@ -6,11 +6,11 @@
 }
 
 img {
+  display: block;
+  
   width: 100%;
   height: 100%;
 
   object-fit: inherit;
   object-position: inherit;
-  
-  vertical-align: bottom;
 }

--- a/core/src/components/img/img.scss
+++ b/core/src/components/img/img.scss
@@ -11,4 +11,6 @@ img {
 
   object-fit: inherit;
   object-position: inherit;
+  
+  vertical-align: bottom;
 }


### PR DESCRIPTION
#### Short description of what this resolves:
This isn't a bug per se, but rather the behavior of `img` that isn't really desirable. (https://stackoverflow.com/questions/5804256/image-inside-div-has-extra-space-below-the-image)

The result of this default behavior is to display the image `inline`, which causes a small gap to appear below the image. Instead, we have the img display `block`
#### Changes proposed in this pull request:

- Add `display: block` to the `img` element

**Ionic Version**:

**Fixes**: #17543
