### PR TITLE
fix(loading): add missing backdropDismiss property

### DIFF
--- a/core/src/components/loading/loading-interface.ts
+++ b/core/src/components/loading/loading-interface.ts
@@ -8,7 +8,7 @@ export interface LoadingOptions {
   duration?: number;
   translucent?: boolean;
   animated?: boolean;
-
+  backdropDismiss?: boolean;
   mode?: Mode;
   keyboardClose?: boolean;
   id?: string;


### PR DESCRIPTION
#### Short description of what this resolves:
In loading component, backdropDismiss property is missing.

#### Changes proposed in this pull request:

- In **loading** component, add missing backdropDismiss property 

**Ionic Version**: 4.x

**Fixes**: https://github.com/ionic-team/ionic/issues/17369
