### PR TITLE
fix(split-pane): use proper grammar in warnings

### DIFF
--- a/core/src/components/split-pane/split-pane.tsx
+++ b/core/src/components/split-pane/split-pane.tsx
@@ -150,7 +150,7 @@ export class SplitPane implements ComponentInterface {
       const isMain = contentId !== undefined ? child.id === contentId : child.hasAttribute('main');
       if (isMain) {
         if (foundMain) {
-          console.warn('split pane can not have more than one main node');
+          console.warn('split pane cannot have more than one main node');
           return;
         }
         foundMain = true;
@@ -158,7 +158,7 @@ export class SplitPane implements ComponentInterface {
       setPaneClass(child, isMain);
     }
     if (!foundMain) {
-      console.warn('split pane could not found any main node');
+      console.warn('split pane does not have a specified main node');
     }
   }
 


### PR DESCRIPTION
#### Short description of what this resolves:

The former message said: split pane could not found any main node

That was grammatically incorrect and it made it sound like the split pane itself was doing the searching rather than being the entity that did not have a properly specified child "main" element.

On "cannot" vs. "can not" they are both technically correct according to Webster, but "cannot" seems to be preferred in this case with "can not" being preferred in cases where the "not" modifies another word, such as "can not only do this but also..."

#### Changes proposed in this pull request:

- Fix the wording of the warning messages

**Ionic Version**:
4.x
