### PR TITLE
fix(datetime): fix edge cases with datetime and invalid values

### DIFF
--- a/core/src/components/datetime/datetime-util.ts
+++ b/core/src/components/datetime/datetime-util.ts
@@ -247,8 +247,12 @@ export function parseDate(val: string | undefined | null): DatetimeData | undefi
  * Note: This is not meant for time strings
  * such as "01:47"
  */
-export const getLocalDateTime = (dateString = ''): Date => {
-  const date = (dateString.length > 0) ? new Date(dateString) : new Date();
+export const getLocalDateTime = (dateString: any = ''): Date => {
+  let date = (typeof dateString === 'string' && dateString.length > 0) ? new Date(dateString) : new Date();
+
+  if (Number.isNaN(date.getTime())) {
+    date = new Date();
+  }
 
   return new Date(
     Date.UTC(
@@ -267,10 +271,7 @@ export function updateDate(existingData: DatetimeData, newData: any): boolean {
 
   if (!newData || typeof newData === 'string') {
     const localDateTime = getLocalDateTime(newData);
-
-    if (!Number.isNaN(localDateTime.getTime())) {
-      newData = localDateTime.toISOString();
-    }
+    newData = localDateTime.toISOString();
   }
 
   if (newData && newData !== '') {

--- a/core/src/components/datetime/datetime-util.ts
+++ b/core/src/components/datetime/datetime-util.ts
@@ -248,7 +248,7 @@ export function parseDate(val: string | undefined | null): DatetimeData | undefi
  * such as "01:47"
  */
 export const getLocalDateTime = (dateString: any = ''): Date => {
-  let date = (typeof dateString === 'string' && dateString.length > 0) ? new Date(dateString) : new Date();
+  const date = (typeof dateString === 'string' && dateString.length > 0) ? new Date(dateString) : new Date();
 
   return new Date(
     Date.UTC(
@@ -266,7 +266,7 @@ export const getLocalDateTime = (dateString: any = ''): Date => {
 export function updateDate(existingData: DatetimeData, newData: any): boolean {
 
   if (!newData || typeof newData === 'string') {
-    let localDateTime = getLocalDateTime(newData);
+    const localDateTime = getLocalDateTime(newData);
     
     if (!Number.isNaN(localDateTime.getTime())) {
       newData = localDateTime.toISOString();

--- a/core/src/components/datetime/datetime-util.ts
+++ b/core/src/components/datetime/datetime-util.ts
@@ -250,10 +250,6 @@ export function parseDate(val: string | undefined | null): DatetimeData | undefi
 export const getLocalDateTime = (dateString: any = ''): Date => {
   let date = (typeof dateString === 'string' && dateString.length > 0) ? new Date(dateString) : new Date();
 
-  if (Number.isNaN(date.getTime())) {
-    date = new Date();
-  }
-
   return new Date(
     Date.UTC(
       date.getFullYear(),
@@ -270,8 +266,11 @@ export const getLocalDateTime = (dateString: any = ''): Date => {
 export function updateDate(existingData: DatetimeData, newData: any): boolean {
 
   if (!newData || typeof newData === 'string') {
-    const localDateTime = getLocalDateTime(newData);
-    newData = localDateTime.toISOString();
+    let localDateTime = getLocalDateTime(newData);
+    
+    if (!Number.isNaN(localDateTime.getTime())) {
+      newData = localDateTime.toISOString();
+    }
   }
 
   if (newData && newData !== '') {

--- a/core/src/components/datetime/datetime-util.ts
+++ b/core/src/components/datetime/datetime-util.ts
@@ -267,7 +267,7 @@ export function updateDate(existingData: DatetimeData, newData: any): boolean {
 
   if (!newData || typeof newData === 'string') {
     const localDateTime = getLocalDateTime(newData);
-    
+
     if (!Number.isNaN(localDateTime.getTime())) {
       newData = localDateTime.toISOString();
     }

--- a/core/src/components/datetime/test/datetime.spec.ts
+++ b/core/src/components/datetime/test/datetime.spec.ts
@@ -52,28 +52,6 @@ describe('Datetime', () => {
         expect(convertToLocal.toISOString()).toEqual(expectedDateString);
       });
     });
-    
-    it('should return default date time given an invalid value', () => {
-      
-      const dateStringTests = [
-        null,
-        undefined,
-        'abc123',
-        '!@#',
-        '',
-        '--2019-02-14T09:00:00.000Z--'
-      ];
-      
-      dateStringTests.forEach(test => {
-        const date = new Date();
-        
-        const convertToLocal = getLocalDateTime(test);
-        
-        expect(convertToLocal.getFullYear()).toEqual(date.getFullYear())
-        expect(convertToLocal.getMonth()).toEqual(date.getMonth())
-        expect(convertToLocal.getDate()).toEqual(date.getDate())
-      });
-    });
   });
 });
 

--- a/core/src/components/datetime/test/datetime.spec.ts
+++ b/core/src/components/datetime/test/datetime.spec.ts
@@ -40,7 +40,7 @@ describe('Datetime', () => {
         { expectedHourUTC: 12, input: `2019-11-02T12:08:06.601-00:00`, expectedOutput: `2019-11-02T%HOUR%:08:06.601Z` },
         { expectedHourUTC: 8, input: `1994-12-15T13:47:20.789+05:00`, expectedOutput: `1994-12-15T%HOUR%:47:20.789Z` },
         { expectedHourUTC: 18, input: `1994-12-15T13:47:20.789-05:00`, expectedOutput: `1994-12-15T%HOUR%:47:20.789Z` },
-        { expectedHourUTC: 9, input: `2019-02-14T09:00:00.000Z`, expectedOutput: `2019-02-14T%HOUR%:00:00.000Z` } 
+        { expectedHourUTC: 9, input: `2019-02-14T09:00:00.000Z`, expectedOutput: `2019-02-14T%HOUR%:00:00.000Z` }
       ];
       
       dateStringTests.forEach(test => {
@@ -50,6 +50,28 @@ describe('Datetime', () => {
         const expectedDateString = test.expectedOutput.replace('%HOUR%', padNumber(test.expectedHourUTC - timeZoneOffset));
         
         expect(convertToLocal.toISOString()).toEqual(expectedDateString);
+      });
+    });
+    
+    it('should return default date time given an invalid value', () => {
+      
+      const dateStringTests = [
+        null,
+        undefined,
+        'abc123',
+        '!@#',
+        '',
+        '--2019-02-14T09:00:00.000Z--'
+      ];
+      
+      dateStringTests.forEach(test => {
+        const date = new Date();
+        
+        const convertToLocal = getLocalDateTime(test);
+        
+        expect(convertToLocal.getFullYear()).toEqual(date.getFullYear())
+        expect(convertToLocal.getMonth()).toEqual(date.getMonth())
+        expect(convertToLocal.getDate()).toEqual(date.getDate())
       });
     });
   });


### PR DESCRIPTION
#### Short description of what this resolves:
This PR is a follow up to my previous datetime PR that adds better handling for invalid value edge cases

#### Changes proposed in this pull request:

- Explicitly detect if input dateString is of type `string`, otherwise default to current date
