### PR TITLE
fix(datetime): fix placeholder not being respected

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -542,6 +542,8 @@ export class Datetime implements ComponentInterface {
     // create the text of the formatted data
     const template = this.displayFormat || this.pickerFormat || DEFAULT_FORMAT;
 
+    if (this.value === undefined || this.value === null) { return; }
+
     return renderDatetime(template, this.datetimeValue, this.locale);
   }
 


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes scenario where value is not set and so current date was rendered. As a result, placeholder is never used. This PR does not render the current date if there is no value. Current date is still shown in the picker though

#### Changes proposed in this pull request:

- Return early from `getText` if no value set
