### PR TITLE
fix(angular): overlay.getTop can return undefined

### DIFF
--- a/angular/src/util/overlay.ts
+++ b/angular/src/util/overlay.ts
@@ -20,7 +20,7 @@ export class OverlayBaseController<Opts, Overlay> {
   /**
    * Returns the top overlay.
    */
-  getTop(): Promise<Overlay> {
+  getTop(): Promise<Overlay | undefined> {
     return proxyMethod(this.ctrl, this.doc, 'getTop');
   }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Add `undefined` to the return type of `getTop` method in `OverlayBaseController`

**Ionic Version**: 4.x

**Fixes**: #17801
