### PR TITLE
[Vue] Fixed popover controller

### DIFF
--- a/vue/src/controllers/popover-controller.ts
+++ b/vue/src/controllers/popover-controller.ts
@@ -2,7 +2,7 @@ import { PopoverOptions } from '@ionic/core';
 import { OverlayBaseController } from '../util';
 import { VueDelegate } from './vue-delegate';
 
-export const CTRL = 'ion-modal-controller';
+export const CTRL = 'ion-popover-controller';
 export class PopoverController extends OverlayBaseController<PopoverOptions, HTMLIonPopoverElement> {
 
   constructor(


### PR DESCRIPTION
#### Short description of what this resolves:
This PR fixed a typo in the popover controller, https://github.com/ionic-team/ionic/blob/master/vue/src/controllers/popover-controller.ts#L5.

before:
```typescript
export const CTRL = 'ion-modal-controller';
```

#### Changes proposed in this pull request:

- Change the typo line to be:
```typescript
export const CTRL = 'ion-popover-controller'
```


**Ionic Version**: 4.1.2

**Fixes**: #17864
