### PR TITLE
fix(datetime): set picker to 0 instead of current time when value is 0

### DIFF
--- a/core/src/components/datetime/datetime-util.ts
+++ b/core/src/components/datetime/datetime-util.ts
@@ -6,7 +6,7 @@
 export function getDateValue(date: DatetimeData, format: string): number {
   const getValue = getValueFromFormat(date, format);
 
-  if (getValue) { return getValue; }
+  if (getValue !== undefined) { return getValue; }
 
   const defaultDate = parseDate(new Date().toISOString());
   return getValueFromFormat((defaultDate as DatetimeData), format);

--- a/core/src/components/datetime/test/basic/index.html
+++ b/core/src/components/datetime/test/basic/index.html
@@ -100,6 +100,11 @@
         </ion-item>
 
         <ion-item>
+          <ion-label>HH:mm (initial value 00:00)</ion-label>
+          <ion-datetime display-format="HH:mm" value="00:00"></ion-datetime>
+        </ion-item>
+
+        <ion-item>
           <ion-label>h:mm a</ion-label>
           <ion-datetime display-format="h:mm a" value="01:47"></ion-datetime>
         </ion-item>


### PR DESCRIPTION
#### Short description of what this resolves:
Set datetime picker to 0 instead of current time when value is 0

#### Changes proposed in this pull request:

-
-
-

**Ionic Version**:

**Fixes**: https://github.com/ionic-team/ionic/issues/17868
