### PR TITLE
Fix back button event handling

### DIFF
--- a/vue/src/components/ion-vue-router.ts
+++ b/vue/src/components/ion-vue-router.ts
@@ -56,6 +56,9 @@ export default {
 };
 
 function catchIonicGoBack(parent: Vue, event: Event): void {
+  // In case of nested ion-vue-routers run only once
+  event.stopImmediatePropagation();
+
   if (!event.target) return;
 
   // We only care for the event coming from Ionic's back button


### PR DESCRIPTION
Given nested `ion-vue-router` elements, each is adding a click handler listening to `ion-back-button` events, without stopping propagation user is navigated back as many steps as there are `ion-vue-router` elements.