### PR TITLE
ion-button outline or clear MD hover colors were overly muted

### DIFF
--- a/core/src/components/button/button.md.scss
+++ b/core/src/components/button/button.md.scss
@@ -122,18 +122,18 @@
 
 @media (any-hover: hover) {
   :host(.button-outline:hover) .button-native {
-    background: ion-color(primary, base, .04);
+    background: ion-color(primary, base, .4);
   }
 
   :host(.button-outline.ion-color:hover) .button-native {
-    background: current-color(base, .04);
+    background: current-color(base, .4);
   }
 
   :host(.button-clear:hover) .button-native {
-    background: ion-color(primary, base, .04);
+    background: ion-color(primary, base, .4);
   }
 
   :host(.button-clear.ion-color:hover) .button-native {
-    background: current-color(base, .04);
+    background: current-color(base, .4);
   }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Button hover styles were accidentally put in as .04 (4%) instead of .4 (40%). This basically made all colors look like light grey.

#### Changes proposed in this pull request:

- Change the `.04`s to `.4`s.

**Ionic Version**: 4.2.1

**Fixes**: #17974