### PR TITLE
feat(item): improve border-width granularity

### DIFF
--- a/core/api.txt
+++ b/core/api.txt
@@ -489,7 +489,10 @@ ion-item,css-prop,--background-activated
 ion-item,css-prop,--border-color
 ion-item,css-prop,--border-radius
 ion-item,css-prop,--border-style
-ion-item,css-prop,--border-width
+ion-item,css-prop,--border-width-bottom
+ion-item,css-prop,--border-width-left
+ion-item,css-prop,--border-width-right
+ion-item,css-prop,--border-width-top
 ion-item,css-prop,--box-shadow
 ion-item,css-prop,--color
 ion-item,css-prop,--detail-icon-color
@@ -969,7 +972,7 @@ ion-select,prop,okText,string,'OK',false,false
 ion-select,prop,placeholder,null | string | undefined,undefined,false,false
 ion-select,prop,selectedText,null | string | undefined,undefined,false,false
 ion-select,prop,value,any,undefined,false,false
-ion-select,method,open,open(ev?: UIEvent | undefined) => Promise<HTMLIonActionSheetElement | HTMLIonAlertElement | HTMLIonPopoverElement | undefined>
+ion-select,method,open,open(ev?: UIEvent | undefined) => Promise<HTMLIonPopoverElement | HTMLIonActionSheetElement | HTMLIonAlertElement | undefined>
 ion-select,event,ionBlur,void,true
 ion-select,event,ionCancel,void,true
 ion-select,event,ionChange,SelectChangeEventDetail,true

--- a/core/src/components/item/item.scss
+++ b/core/src/components/item/item.scss
@@ -10,7 +10,12 @@
    * @prop --border-color: Color of the item border
    * @prop --border-radius: Radius of the item border
    * @prop --border-style: Style of the item border
-   * @prop --border-width: Width of the item border
+   *
+   * @prop --border-width-top: Top border width of the item
+   * @prop --border-width-right: Right border width of the item
+   * @prop --border-width-bottom: Bottom border width of the item
+   * @prop --border-width-left: Left border width of the item
+   *
    * @prop --box-shadow: Box shadow of the item
    * @prop --color: Color of the item
    *
@@ -39,7 +44,10 @@
    * @prop --highlight-color-invalid: The color of the highlight on the item when invalid
    */
   --border-radius: 0px;
-  --border-width: 0px;
+  --border-width-top: 0px;
+  --border-width-right: 0px;
+  --border-width-bottom: 0px;
+  --border-width-left: 0px;
   --border-style: solid;
   --padding-top: 0px;
   --padding-bottom: 0px;
@@ -142,7 +150,11 @@
 
   transition: var(--transition);
 
-  border-width: var(--border-width);
+  border-top-width: var(--border-width-top);
+  border-right-width: var(--border-width-right);
+  border-bottom-width: var(--border-width-bottom);
+  border-left-width: var(--border-width-left);
+
   border-style: var(--border-style);
   border-color: var(--border-color);
 

--- a/core/src/components/item/readme.md
+++ b/core/src/components/item/readme.md
@@ -1396,7 +1396,10 @@ Item Inputs
 | `--border-color`            | Color of the item border                            |
 | `--border-radius`           | Radius of the item border                           |
 | `--border-style`            | Style of the item border                            |
-| `--border-width`            | Width of the item border                            |
+| `--border-width-bottom`     | Bottom border width of the item                     |
+| `--border-width-left`       | Left border width of the item                       |
+| `--border-width-right`      | Right border width of the item                      |
+| `--border-width-top`        | Top border width of the item                        |
 | `--box-shadow`              | Box shadow of the item                              |
 | `--color`                   | Color of the item                                   |
 | `--detail-icon-color`       | Color of the item detail icon                       |


### PR DESCRIPTION
#### Short description of what this resolves:
Introduce 4 different CSS variables for the ion-item border-width instead of 1.

```css
--border-width-top
--border-width-right
--border-width-bottom
--border-width-left
```

#### Changes proposed in this pull request:

- Add the new variables to the item's css to support more granular control of the border width
- This will probably be a breaking change as border-width is no longer available. Not sure how you handle such changes to the API, but couldn't find an elegant CSS solution for supporting both.

**Ionic Version**: 4.2.0

**Fixes**: #17767
