### PR TITLE
fix(item): use the correct highlight for an inset line input item

### DIFF
--- a/core/src/components/item/item.scss
+++ b/core/src/components/item/item.scss
@@ -181,6 +181,9 @@ button, a {
 
   display: flex;
 
+  /* This is required to work with an inset highlight */
+  position: relative;
+
   flex: 1;
   flex-direction: inherit;
   align-items: inherit;


### PR DESCRIPTION
The code to make inset highlight work was removed by this commit: https://github.com/ionic-team/ionic/commit/fd79b5774880e499933c19d658ccccac9b7899a5#diff-be35bd653745acb6d128c4ec32dd2e6fL172

This PR adds the code back which makes the highlight work again, but I'm not sure why it was removed in the first place.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
The inset highlight is taking up the full width

Issue Number: #18051


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The inset highlight has left padding to match the item border.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
