### PR TITLE
fix(angular): preserve queryParams and fragment when going back

### DIFF
--- a/angular/src/directives/navigation/ion-router-outlet.ts
+++ b/angular/src/directives/navigation/ion-router-outlet.ts
@@ -141,6 +141,20 @@ export class IonRouterOutlet implements OnDestroy, OnInit {
     if (this.activated) {
       if (this.activatedView) {
         this.activatedView.savedData = new Map(this.getContext()!.children['contexts']);
+
+        /**
+         * Ensure we are saving the NavigationExtras
+         * data otherwise it will be lost
+         */
+        this.activatedView.savedExtras = {};
+        const context = this.getContext()!;
+
+        if (context.route) {
+          const contextSnapshot = context.route.snapshot;
+
+          this.activatedView.savedExtras.queryParams = contextSnapshot.queryParams;
+          this.activatedView.savedExtras.queryParams = contextSnapshot.fragment;
+        }
       }
       const c = this.component;
       this.activatedView = null;

--- a/angular/src/directives/navigation/ion-router-outlet.ts
+++ b/angular/src/directives/navigation/ion-router-outlet.ts
@@ -153,7 +153,7 @@ export class IonRouterOutlet implements OnDestroy, OnInit {
           const contextSnapshot = context.route.snapshot;
 
           this.activatedView.savedExtras.queryParams = contextSnapshot.queryParams;
-          this.activatedView.savedExtras.queryParams = contextSnapshot.fragment;
+          this.activatedView.savedExtras.fragment = contextSnapshot.fragment;
         }
       }
       const c = this.component;

--- a/angular/src/directives/navigation/stack-controller.ts
+++ b/angular/src/directives/navigation/stack-controller.ts
@@ -132,7 +132,7 @@ export class StackController {
         }
       }
 
-      return this.navCtrl.navigateBack(url).then(() => true);
+      return this.navCtrl.navigateBack(url, view.savedExtras).then(() => true);
     });
   }
 

--- a/angular/src/directives/navigation/stack-utils.ts
+++ b/angular/src/directives/navigation/stack-utils.ts
@@ -94,5 +94,6 @@ export interface RouteView {
   element: HTMLElement;
   ref: ComponentRef<any>;
   savedData?: any;
+  savedExtras?: any;
   unlistenEvents: () => void;
 }

--- a/angular/src/directives/navigation/stack-utils.ts
+++ b/angular/src/directives/navigation/stack-utils.ts
@@ -1,5 +1,5 @@
 import { ComponentRef } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, NavigationExtras, Router } from '@angular/router';
 import { NavDirection, RouterDirection } from '@ionic/core';
 
 export function insertView(views: RouteView[], view: RouteView, direction: RouterDirection) {
@@ -94,6 +94,6 @@ export interface RouteView {
   element: HTMLElement;
   ref: ComponentRef<any>;
   savedData?: any;
-  savedExtras?: any;
+  savedExtras?: NavigationExtras;
   unlistenEvents: () => void;
 }

--- a/angular/src/providers/nav-controller.ts
+++ b/angular/src/providers/nav-controller.ts
@@ -184,7 +184,16 @@ export class NavController {
     if (Array.isArray(url)) {
       return this.router!.navigate(url, options);
     } else {
-      return this.router!.navigateByUrl(url, options);
+
+      /**
+       * navigateByUrl ignores any properties that
+       * would change the url, so things like queryParams
+       * would be ignored unless we create a url tree
+       * More Info: https://github.com/angular/angular/issues/18798
+       */
+      return this.router!.navigateByUrl(
+        this.router!.createUrlTree([url], options)
+      );
     }
   }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic/issues/16744

Going from` /page1?query=Hello` to `/page2`, and then back would return you to `/page1` instead of `/page1?query=Hello`

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

`queryParams` and `fragment` options are now preserved when going back in navigation. I originally had only intended to fix `queryParams` but it was easy to also preserve `fragment` too, so I added that in as well. Now, going from `/page1?query=Hello#MyDiv` to `/page2` and then back, will return you to `/page1?query=Hello#MyDiv`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
