### PR TITLE
fix(angular): preserve special characters encoding when going back

### DIFF
--- a/angular/src/providers/nav-controller.ts
+++ b/angular/src/providers/nav-controller.ts
@@ -190,9 +190,12 @@ export class NavController {
        * would change the url, so things like queryParams
        * would be ignored unless we create a url tree
        * More Info: https://github.com/angular/angular/issues/18798
+       *
+       * Additionally, the router does some encoding under the hood,
+       * so make sure we are not encoding special characters more than once
        */
       return this.router!.navigateByUrl(
-        this.router!.createUrlTree([url], options)
+        this.router!.createUrlTree([decodeURIComponent(url.toString())], options)
       );
     }
   }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: patch for https://github.com/ionic-team/ionic/pull/18298
Special chars were being encoded via the router and then re-encoded when creating a UrlTree

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Since we can't prevent the router from encoding the url, decode the url before passing it in to be re-encoded 
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
