### PR TITLE
docs(): add iOS only note to translucent props

### DIFF
--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -1634,7 +1634,7 @@ export namespace Components {
     */
     'mode': Mode;
     /**
-    * If `true`, the footer will be translucent. Note: In order to scroll content behind the footer, the `fullscreen` attribute needs to be set on the content.
+    * If `true`, the footer will be translucent. This property only works on iOS. Note: In order to scroll content behind the footer, the `fullscreen` attribute needs to be set on the content.
     */
     'translucent': boolean;
   }
@@ -1644,7 +1644,7 @@ export namespace Components {
     */
     'mode'?: Mode;
     /**
-    * If `true`, the footer will be translucent. Note: In order to scroll content behind the footer, the `fullscreen` attribute needs to be set on the content.
+    * If `true`, the footer will be translucent. This property only works on iOS. Note: In order to scroll content behind the footer, the `fullscreen` attribute needs to be set on the content.
     */
     'translucent'?: boolean;
   }
@@ -1668,7 +1668,7 @@ export namespace Components {
     */
     'mode': Mode;
     /**
-    * If `true`, the header will be translucent. Note: In order to scroll content behind the header, the `fullscreen` attribute needs to be set on the content.
+    * If `true`, the header will be translucent. This property only works on iOS. Note: In order to scroll content behind the header, the `fullscreen` attribute needs to be set on the content.
     */
     'translucent': boolean;
   }
@@ -1678,7 +1678,7 @@ export namespace Components {
     */
     'mode'?: Mode;
     /**
-    * If `true`, the header will be translucent. Note: In order to scroll content behind the header, the `fullscreen` attribute needs to be set on the content.
+    * If `true`, the header will be translucent. This property only works on iOS. Note: In order to scroll content behind the header, the `fullscreen` attribute needs to be set on the content.
     */
     'translucent'?: boolean;
   }

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -1634,7 +1634,7 @@ export namespace Components {
     */
     'mode': Mode;
     /**
-    * If `true`, the footer will be translucent. This property only works in iOS mode. Note: In order to scroll content behind the footer, the `fullscreen` attribute needs to be set on the content.
+    * If `true`, the footer will be translucent. Only applies to `ios` mode. Note: In order to scroll content behind the footer, the `fullscreen` attribute needs to be set on the content.
     */
     'translucent': boolean;
   }
@@ -1644,7 +1644,7 @@ export namespace Components {
     */
     'mode'?: Mode;
     /**
-    * If `true`, the footer will be translucent. This property only works in iOS mode. Note: In order to scroll content behind the footer, the `fullscreen` attribute needs to be set on the content.
+    * If `true`, the footer will be translucent. Only applies to `ios` mode. Note: In order to scroll content behind the footer, the `fullscreen` attribute needs to be set on the content.
     */
     'translucent'?: boolean;
   }
@@ -1668,7 +1668,7 @@ export namespace Components {
     */
     'mode': Mode;
     /**
-    * If `true`, the header will be translucent. This property only works in iOS mode. Note: In order to scroll content behind the header, the `fullscreen` attribute needs to be set on the content.
+    * If `true`, the header will be translucent. Only applies to `ios` mode. Note: In order to scroll content behind the header, the `fullscreen` attribute needs to be set on the content.
     */
     'translucent': boolean;
   }
@@ -1678,7 +1678,7 @@ export namespace Components {
     */
     'mode'?: Mode;
     /**
-    * If `true`, the header will be translucent. This property only works in iOS mode. Note: In order to scroll content behind the header, the `fullscreen` attribute needs to be set on the content.
+    * If `true`, the header will be translucent. Only applies to `ios` mode. Note: In order to scroll content behind the header, the `fullscreen` attribute needs to be set on the content.
     */
     'translucent'?: boolean;
   }

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -1634,7 +1634,7 @@ export namespace Components {
     */
     'mode': Mode;
     /**
-    * If `true`, the footer will be translucent. This property only works on iOS. Note: In order to scroll content behind the footer, the `fullscreen` attribute needs to be set on the content.
+    * If `true`, the footer will be translucent. This property only works in iOS mode. Note: In order to scroll content behind the footer, the `fullscreen` attribute needs to be set on the content.
     */
     'translucent': boolean;
   }
@@ -1644,7 +1644,7 @@ export namespace Components {
     */
     'mode'?: Mode;
     /**
-    * If `true`, the footer will be translucent. This property only works on iOS. Note: In order to scroll content behind the footer, the `fullscreen` attribute needs to be set on the content.
+    * If `true`, the footer will be translucent. This property only works in iOS mode. Note: In order to scroll content behind the footer, the `fullscreen` attribute needs to be set on the content.
     */
     'translucent'?: boolean;
   }
@@ -1668,7 +1668,7 @@ export namespace Components {
     */
     'mode': Mode;
     /**
-    * If `true`, the header will be translucent. This property only works on iOS. Note: In order to scroll content behind the header, the `fullscreen` attribute needs to be set on the content.
+    * If `true`, the header will be translucent. This property only works in iOS mode. Note: In order to scroll content behind the header, the `fullscreen` attribute needs to be set on the content.
     */
     'translucent': boolean;
   }
@@ -1678,7 +1678,7 @@ export namespace Components {
     */
     'mode'?: Mode;
     /**
-    * If `true`, the header will be translucent. This property only works on iOS. Note: In order to scroll content behind the header, the `fullscreen` attribute needs to be set on the content.
+    * If `true`, the header will be translucent. This property only works in iOS mode. Note: In order to scroll content behind the header, the `fullscreen` attribute needs to be set on the content.
     */
     'translucent'?: boolean;
   }

--- a/core/src/components/footer/footer.tsx
+++ b/core/src/components/footer/footer.tsx
@@ -17,7 +17,7 @@ export class Footer implements ComponentInterface {
   @Prop() mode!: Mode;
 
   /**
-   * If `true`, the footer will be translucent.
+   * If `true`, the footer will be translucent. This property only works on iOS.
    * Note: In order to scroll content behind the footer, the `fullscreen`
    * attribute needs to be set on the content.
    */

--- a/core/src/components/footer/footer.tsx
+++ b/core/src/components/footer/footer.tsx
@@ -17,7 +17,7 @@ export class Footer implements ComponentInterface {
   @Prop() mode!: Mode;
 
   /**
-   * If `true`, the footer will be translucent. This property only works in iOS mode.
+   * If `true`, the footer will be translucent. Only applies to `ios` mode.
    * Note: In order to scroll content behind the footer, the `fullscreen`
    * attribute needs to be set on the content.
    */

--- a/core/src/components/footer/footer.tsx
+++ b/core/src/components/footer/footer.tsx
@@ -17,7 +17,7 @@ export class Footer implements ComponentInterface {
   @Prop() mode!: Mode;
 
   /**
-   * If `true`, the footer will be translucent. This property only works on iOS.
+   * If `true`, the footer will be translucent. This property only works in iOS mode.
    * Note: In order to scroll content behind the footer, the `fullscreen`
    * attribute needs to be set on the content.
    */

--- a/core/src/components/footer/readme.md
+++ b/core/src/components/footer/readme.md
@@ -47,10 +47,10 @@ export default Example;
 
 ## Properties
 
-| Property      | Attribute     | Description                                                                                                                                                                                     | Type            | Default     |
-| ------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ----------- |
-| `mode`        | `mode`        | The mode determines which platform styles to use.                                                                                                                                               | `"ios" \| "md"` | `undefined` |
-| `translucent` | `translucent` | If `true`, the footer will be translucent. This property only works in iOS mode. Note: In order to scroll content behind the footer, the `fullscreen` attribute needs to be set on the content. | `boolean`       | `false`     |
+| Property      | Attribute     | Description                                                                                                                                                                           | Type            | Default     |
+| ------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ----------- |
+| `mode`        | `mode`        | The mode determines which platform styles to use.                                                                                                                                     | `"ios" \| "md"` | `undefined` |
+| `translucent` | `translucent` | If `true`, the footer will be translucent. Only applies to `ios` mode. Note: In order to scroll content behind the footer, the `fullscreen` attribute needs to be set on the content. | `boolean`       | `false`     |
 
 
 ----------------------------------------------

--- a/core/src/components/footer/readme.md
+++ b/core/src/components/footer/readme.md
@@ -47,10 +47,10 @@ export default Example;
 
 ## Properties
 
-| Property      | Attribute     | Description                                                                                                                                                                                | Type            | Default     |
-| ------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ----------- |
-| `mode`        | `mode`        | The mode determines which platform styles to use.                                                                                                                                          | `"ios" \| "md"` | `undefined` |
-| `translucent` | `translucent` | If `true`, the footer will be translucent. This property only works on iOS. Note: In order to scroll content behind the footer, the `fullscreen` attribute needs to be set on the content. | `boolean`       | `false`     |
+| Property      | Attribute     | Description                                                                                                                                                                                     | Type            | Default     |
+| ------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ----------- |
+| `mode`        | `mode`        | The mode determines which platform styles to use.                                                                                                                                               | `"ios" \| "md"` | `undefined` |
+| `translucent` | `translucent` | If `true`, the footer will be translucent. This property only works in iOS mode. Note: In order to scroll content behind the footer, the `fullscreen` attribute needs to be set on the content. | `boolean`       | `false`     |
 
 
 ----------------------------------------------

--- a/core/src/components/footer/readme.md
+++ b/core/src/components/footer/readme.md
@@ -47,10 +47,10 @@ export default Example;
 
 ## Properties
 
-| Property      | Attribute     | Description                                                                                                                                               | Type            | Default     |
-| ------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ----------- |
-| `mode`        | `mode`        | The mode determines which platform styles to use.                                                                                                         | `"ios" \| "md"` | `undefined` |
-| `translucent` | `translucent` | If `true`, the footer will be translucent. Note: In order to scroll content behind the footer, the `fullscreen` attribute needs to be set on the content. | `boolean`       | `false`     |
+| Property      | Attribute     | Description                                                                                                                                                                                | Type            | Default     |
+| ------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ----------- |
+| `mode`        | `mode`        | The mode determines which platform styles to use.                                                                                                                                          | `"ios" \| "md"` | `undefined` |
+| `translucent` | `translucent` | If `true`, the footer will be translucent. This property only works on iOS. Note: In order to scroll content behind the footer, the `fullscreen` attribute needs to be set on the content. | `boolean`       | `false`     |
 
 
 ----------------------------------------------

--- a/core/src/components/header/header.tsx
+++ b/core/src/components/header/header.tsx
@@ -17,7 +17,7 @@ export class Header implements ComponentInterface {
   @Prop() mode!: Mode;
 
   /**
-   * If `true`, the header will be translucent. This property only works in iOS mode.
+   * If `true`, the header will be translucent. Only applies to `ios` mode.
    * Note: In order to scroll content behind the header, the `fullscreen`
    * attribute needs to be set on the content.
    */

--- a/core/src/components/header/header.tsx
+++ b/core/src/components/header/header.tsx
@@ -17,7 +17,7 @@ export class Header implements ComponentInterface {
   @Prop() mode!: Mode;
 
   /**
-   * If `true`, the header will be translucent. This property only works on iOS.
+   * If `true`, the header will be translucent. This property only works in iOS mode.
    * Note: In order to scroll content behind the header, the `fullscreen`
    * attribute needs to be set on the content.
    */

--- a/core/src/components/header/header.tsx
+++ b/core/src/components/header/header.tsx
@@ -17,7 +17,7 @@ export class Header implements ComponentInterface {
   @Prop() mode!: Mode;
 
   /**
-   * If `true`, the header will be translucent.
+   * If `true`, the header will be translucent. This property only works on iOS.
    * Note: In order to scroll content behind the header, the `fullscreen`
    * attribute needs to be set on the content.
    */

--- a/core/src/components/header/readme.md
+++ b/core/src/components/header/readme.md
@@ -62,10 +62,10 @@ export default Example
 
 ## Properties
 
-| Property      | Attribute     | Description                                                                                                                                                                                | Type            | Default     |
-| ------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ----------- |
-| `mode`        | `mode`        | The mode determines which platform styles to use.                                                                                                                                          | `"ios" \| "md"` | `undefined` |
-| `translucent` | `translucent` | If `true`, the header will be translucent. This property only works on iOS. Note: In order to scroll content behind the header, the `fullscreen` attribute needs to be set on the content. | `boolean`       | `false`     |
+| Property      | Attribute     | Description                                                                                                                                                                                     | Type            | Default     |
+| ------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ----------- |
+| `mode`        | `mode`        | The mode determines which platform styles to use.                                                                                                                                               | `"ios" \| "md"` | `undefined` |
+| `translucent` | `translucent` | If `true`, the header will be translucent. This property only works in iOS mode. Note: In order to scroll content behind the header, the `fullscreen` attribute needs to be set on the content. | `boolean`       | `false`     |
 
 
 ----------------------------------------------

--- a/core/src/components/header/readme.md
+++ b/core/src/components/header/readme.md
@@ -62,10 +62,10 @@ export default Example
 
 ## Properties
 
-| Property      | Attribute     | Description                                                                                                                                                                                     | Type            | Default     |
-| ------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ----------- |
-| `mode`        | `mode`        | The mode determines which platform styles to use.                                                                                                                                               | `"ios" \| "md"` | `undefined` |
-| `translucent` | `translucent` | If `true`, the header will be translucent. This property only works in iOS mode. Note: In order to scroll content behind the header, the `fullscreen` attribute needs to be set on the content. | `boolean`       | `false`     |
+| Property      | Attribute     | Description                                                                                                                                                                           | Type            | Default     |
+| ------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ----------- |
+| `mode`        | `mode`        | The mode determines which platform styles to use.                                                                                                                                     | `"ios" \| "md"` | `undefined` |
+| `translucent` | `translucent` | If `true`, the header will be translucent. Only applies to `ios` mode. Note: In order to scroll content behind the header, the `fullscreen` attribute needs to be set on the content. | `boolean`       | `false`     |
 
 
 ----------------------------------------------

--- a/core/src/components/header/readme.md
+++ b/core/src/components/header/readme.md
@@ -62,10 +62,10 @@ export default Example
 
 ## Properties
 
-| Property      | Attribute     | Description                                                                                                                                               | Type            | Default     |
-| ------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ----------- |
-| `mode`        | `mode`        | The mode determines which platform styles to use.                                                                                                         | `"ios" \| "md"` | `undefined` |
-| `translucent` | `translucent` | If `true`, the header will be translucent. Note: In order to scroll content behind the header, the `fullscreen` attribute needs to be set on the content. | `boolean`       | `false`     |
+| Property      | Attribute     | Description                                                                                                                                                                                | Type            | Default     |
+| ------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ----------- |
+| `mode`        | `mode`        | The mode determines which platform styles to use.                                                                                                                                          | `"ios" \| "md"` | `undefined` |
+| `translucent` | `translucent` | If `true`, the header will be translucent. This property only works on iOS. Note: In order to scroll content behind the header, the `fullscreen` attribute needs to be set on the content. | `boolean`       | `false`     |
 
 
 ----------------------------------------------


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic/issues/18510#issuecomment-501404919


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added a note to the `translucent` props on `ion-header` and `ion-footer` that translucency only works in iOS mode.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
