### PR TITLE
feat(menu): default overlay for all platforms

### DIFF
--- a/core/src/components/menu/menu.tsx
+++ b/core/src/components/menu/menu.tsx
@@ -144,7 +144,7 @@ export class Menu implements ComponentInterface, MenuI {
 
   async componentWillLoad() {
     if (this.type === undefined) {
-      this.type = this.config.get('menuType', this.mode === 'ios' ? 'reveal' : 'overlay');
+      this.type = this.config.get('menuType', 'overlay');
     }
 
     if (this.isServer) {


### PR DESCRIPTION
This PR changes the default for menu to be `overlay` on all platforms.

I've been working with Ben and we both agree that the overlay style is much more prevalent these days for apps on Android *and* iOS, and looks quite a bit more sophisticated than the reveal type which we'd like to phase out.

I suppose this would be a breaking change, need to think about the details there. Since we're going to update the starters to set the type explicitly to `overlay`, perhaps we can come up with a plan to introduce the changes in this PR at a specific later date? Perhaps in line with our upcoming title/menu/etc. changes for iOS 13 and Ionic 5?