### PR TITLE
feat(ion-video): autoplay videos in viewport on scroll

### DIFF
--- a/angular/src/directives/proxies-list.txt
+++ b/angular/src/directives/proxies-list.txt
@@ -74,5 +74,6 @@ d.IonApp,
   d.IonThumbnail,
   d.IonTitle,
   d.IonToggle,
-  d.IonToolbar
+  d.IonToolbar,
+  d.IonVideo
 ];

--- a/angular/src/directives/proxies.ts
+++ b/angular/src/directives/proxies.ts
@@ -919,3 +919,14 @@ export class IonToolbar {
   }
 }
 proxyInputs(IonToolbar, ['color', 'mode']);
+
+export declare interface IonVideo extends Components.IonVideo {}
+@Component({ selector: 'ion-video', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['loop', 'src', 'threshold'] })
+export class IonVideo {
+  protected el: HTMLElement;
+  constructor(c: ChangeDetectorRef, r: ElementRef) {
+    c.detach();
+    this.el = r.nativeElement;
+  }
+}
+proxyInputs(IonVideo, ['loop', 'src', 'threshold']);

--- a/angular/src/directives/proxies.ts
+++ b/angular/src/directives/proxies.ts
@@ -921,7 +921,7 @@ export class IonToolbar {
 proxyInputs(IonToolbar, ['color', 'mode']);
 
 export declare interface IonVideo extends Components.IonVideo {}
-@Component({ selector: 'ion-video', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['loop', 'src', 'threshold'] })
+@Component({ selector: 'ion-video', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['loop', 'src'] })
 export class IonVideo {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef) {
@@ -929,4 +929,4 @@ export class IonVideo {
     this.el = r.nativeElement;
   }
 }
-proxyInputs(IonVideo, ['loop', 'src', 'threshold']);
+proxyInputs(IonVideo, ['loop', 'src']);

--- a/angular/src/directives/proxies.ts
+++ b/angular/src/directives/proxies.ts
@@ -921,7 +921,7 @@ export class IonToolbar {
 proxyInputs(IonToolbar, ['color', 'mode']);
 
 export declare interface IonVideo extends Components.IonVideo {}
-@Component({ selector: 'ion-video', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['loop', 'src'] })
+@Component({ selector: 'ion-video', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['loop', 'playThreshold', 'src'] })
 export class IonVideo {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef) {
@@ -929,4 +929,5 @@ export class IonVideo {
     this.el = r.nativeElement;
   }
 }
-proxyInputs(IonVideo, ['loop', 'src']);
+proxyMethods(IonVideo, ['play', 'pause']);
+proxyInputs(IonVideo, ['loop', 'playThreshold', 'src']);

--- a/core/api.txt
+++ b/core/api.txt
@@ -1260,6 +1260,11 @@ ion-toolbar,css-prop,--padding-end
 ion-toolbar,css-prop,--padding-start
 ion-toolbar,css-prop,--padding-top
 
+ion-video,shadow
+ion-video,prop,loop,boolean | undefined,true,false,false
+ion-video,prop,src,string | undefined,undefined,false,false
+ion-video,prop,threshold,number[] | undefined,[0, 0.65],false,false
+
 ion-virtual-scroll,none
 ion-virtual-scroll,prop,approxFooterHeight,number,30,false,false
 ion-virtual-scroll,prop,approxHeaderHeight,number,30,false,false

--- a/core/api.txt
+++ b/core/api.txt
@@ -1262,8 +1262,10 @@ ion-toolbar,css-prop,--padding-top
 
 ion-video,shadow
 ion-video,prop,loop,boolean | undefined,true,false,false
+ion-video,prop,playThreshold,number | undefined,undefined,false,false
 ion-video,prop,src,string | undefined,undefined,false,false
-ion-video,prop,threshold,number[] | undefined,[0, 0.65],false,false
+ion-video,method,pause,pause() => Promise<void>
+ion-video,method,play,play() => Promise<void>
 
 ion-virtual-scroll,none
 ion-virtual-scroll,prop,approxFooterHeight,number,30,false,false

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -2670,6 +2670,20 @@ export namespace Components {
     */
     'mode'?: "ios" | "md";
   }
+  interface IonVideo {
+    /**
+    * Determines if the video should loop endlessly. Defaults to true.
+    */
+    'loop'?: boolean | undefined;
+    /**
+    * The video URL. This attribute is mandatory for the <video> element.
+    */
+    'src'?: string;
+    /**
+    * intersection threshold triggers: >= 0.65 will play < 0.65 will pause.
+    */
+    'threshold'?: number[] | undefined;
+  }
   interface IonVirtualScroll {
     /**
     * The approximate width of each footer template's cell. This dimension is used to help determine how many cells should be created when initialized, and to help calculate the height of the scrollable area. This height value can only use `px` units. Note that the actual rendered size of each cell comes from the app's CSS, whereas this approximation is used to help calculate initial dimensions before the item has been rendered.
@@ -3310,6 +3324,12 @@ declare global {
     new (): HTMLIonToolbarElement;
   };
 
+  interface HTMLIonVideoElement extends Components.IonVideo, HTMLStencilElement {}
+  var HTMLIonVideoElement: {
+    prototype: HTMLIonVideoElement;
+    new (): HTMLIonVideoElement;
+  };
+
   interface HTMLIonVirtualScrollElement extends Components.IonVirtualScroll, HTMLStencilElement {}
   var HTMLIonVirtualScrollElement: {
     prototype: HTMLIonVirtualScrollElement;
@@ -3412,6 +3432,7 @@ declare global {
     'ion-toast-controller': HTMLIonToastControllerElement;
     'ion-toggle': HTMLIonToggleElement;
     'ion-toolbar': HTMLIonToolbarElement;
+    'ion-video': HTMLIonVideoElement;
     'ion-virtual-scroll': HTMLIonVirtualScrollElement;
   }
 }
@@ -5917,6 +5938,20 @@ declare namespace LocalJSX {
     */
     'mode'?: "ios" | "md";
   }
+  interface IonVideo extends JSXBase.HTMLAttributes<HTMLIonVideoElement> {
+    /**
+    * Determines if the video should loop endlessly. Defaults to true.
+    */
+    'loop'?: boolean | undefined;
+    /**
+    * The video URL. This attribute is mandatory for the <video> element.
+    */
+    'src'?: string;
+    /**
+    * intersection threshold triggers: >= 0.65 will play < 0.65 will pause.
+    */
+    'threshold'?: number[] | undefined;
+  }
   interface IonVirtualScroll extends JSXBase.HTMLAttributes<HTMLIonVirtualScrollElement> {
     /**
     * The approximate width of each footer template's cell. This dimension is used to help determine how many cells should be created when initialized, and to help calculate the height of the scrollable area. This height value can only use `px` units. Note that the actual rendered size of each cell comes from the app's CSS, whereas this approximation is used to help calculate initial dimensions before the item has been rendered.
@@ -6061,6 +6096,7 @@ declare namespace LocalJSX {
     'ion-toast-controller': IonToastController;
     'ion-toggle': IonToggle;
     'ion-toolbar': IonToolbar;
+    'ion-video': IonVideo;
     'ion-virtual-scroll': IonVirtualScroll;
   }
 }

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -2679,10 +2679,6 @@ export namespace Components {
     * The video URL. This attribute is mandatory for the <video> element.
     */
     'src'?: string;
-    /**
-    * intersection threshold triggers: >= 0.65 will play < 0.65 will pause.
-    */
-    'threshold'?: number[] | undefined;
   }
   interface IonVirtualScroll {
     /**
@@ -5947,10 +5943,6 @@ declare namespace LocalJSX {
     * The video URL. This attribute is mandatory for the <video> element.
     */
     'src'?: string;
-    /**
-    * intersection threshold triggers: >= 0.65 will play < 0.65 will pause.
-    */
-    'threshold'?: number[] | undefined;
   }
   interface IonVirtualScroll extends JSXBase.HTMLAttributes<HTMLIonVirtualScrollElement> {
     /**

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -2676,6 +2676,18 @@ export namespace Components {
     */
     'loop'?: boolean | undefined;
     /**
+    * Pauses the video
+    */
+    'pause': () => Promise<void>;
+    /**
+    * Plays the video
+    */
+    'play': () => Promise<void>;
+    /**
+    * Determines at what percent the video should be in the view before playing.
+    */
+    'playThreshold'?: number;
+    /**
     * The video URL. This attribute is mandatory for the <video> element.
     */
     'src'?: string;
@@ -5939,6 +5951,10 @@ declare namespace LocalJSX {
     * Determines if the video should loop endlessly. Defaults to true.
     */
     'loop'?: boolean | undefined;
+    /**
+    * Determines at what percent the video should be in the view before playing.
+    */
+    'playThreshold'?: number;
     /**
     * The video URL. This attribute is mandatory for the <video> element.
     */

--- a/core/src/components/video/readme.md
+++ b/core/src/components/video/readme.md
@@ -64,11 +64,11 @@ export const VideoExample: React.FunctionComponent = () => (
 
 ## Properties
 
-| Property    | Attribute | Description                                                           | Type                    | Default     |
-| ----------- | --------- | --------------------------------------------------------------------- | ----------------------- | ----------- |
-| `loop`      | `loop`    | Determines if the video should loop endlessly. Defaults to true.      | `boolean \| undefined`  | `true`      |
-| `src`       | `src`     | The video URL. This attribute is mandatory for the <video> element.   | `string \| undefined`   | `undefined` |
-| `threshold` | --        | intersection threshold triggers: >= 0.65 will play < 0.65 will pause. | `number[] \| undefined` | `[0, 0.65]` |
+| Property    | Attribute | Description                                                                                 | Type                    | Default     |
+| ----------- | --------- | ------------------------------------------------------------------------------------------- | ----------------------- | ----------- |
+| `loop`      | `loop`    | Determines if the video should loop endlessly. Defaults to true.                            | `boolean \| undefined`  | `true`      |
+| `src`       | `src`     | The video URL. This attribute is mandatory for the <video> element.                         | `string \| undefined`   | `undefined` |
+| `threshold` | --        | An array that determines the threshold trigger values: >= 0.65 will play < 0.65 will pause. | `number[] \| undefined` | `[0, 0.65]` |
 
 
 ----------------------------------------------

--- a/core/src/components/video/readme.md
+++ b/core/src/components/video/readme.md
@@ -1,0 +1,76 @@
+# ion-video
+
+Video is a tag that will play/pause the video as it hits the desired threshold. The component uses [Intersection Observer](https://caniuse.com/#feat=intersectionobserver) internally, which is supported in most modern browsers.
+
+<!-- Auto Generated Below -->
+
+
+## Usage
+
+### Angular
+
+```html
+<ion-list>
+  <ion-item *ngFor="let item of items">
+    <ion-video src="item.src"></ion-video>
+  </ion-item>
+</ion-list>
+```
+
+
+### Javascript
+
+```html
+  <ion-video src="https://www.w3schools.com/html/mov_bbb.mp4"></ion-video>
+```
+
+
+### React
+
+```tsx
+import React from 'react';
+import { IonList, IonItem, IonVideo IonContent } from '@ionic/react';
+
+type Item = {
+  src: string;
+};
+const items: Item[] = [{ src: 'https://www.w3schools.com/html/mov_bbb.mp4' }];
+
+export const VideoExample: React.FunctionComponent = () => (
+  <IonContent>
+    <IonList>
+      {items.map((video, i) => (
+        <IonVideo key={i} src={video.src}></IonVideo>
+      ))}
+    </IonList>
+  </IonContent>
+);
+```
+
+
+### Vue
+
+```html
+<template>
+  <ion-list>
+    <ion-item v-for="item in items" :key="item.src">
+      <ion-video :src="item.src"></ion-video>
+    </ion-item>
+  </ion-list>
+</template>
+```
+
+
+
+## Properties
+
+| Property    | Attribute | Description                                                           | Type                    | Default     |
+| ----------- | --------- | --------------------------------------------------------------------- | ----------------------- | ----------- |
+| `loop`      | `loop`    | Determines if the video should loop endlessly. Defaults to true.      | `boolean \| undefined`  | `true`      |
+| `src`       | `src`     | The video URL. This attribute is mandatory for the <video> element.   | `string \| undefined`   | `undefined` |
+| `threshold` | --        | intersection threshold triggers: >= 0.65 will play < 0.65 will pause. | `number[] \| undefined` | `[0, 0.65]` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/video/readme.md
+++ b/core/src/components/video/readme.md
@@ -2,6 +2,10 @@
 
 Video is a tag that will play/pause the video as it hits the desired threshold. The component uses [Intersection Observer](https://caniuse.com/#feat=intersectionobserver) internally, which is supported in most modern browsers.
 
+Requires the following `config.xml` preference
+
+`<preference name=”AllowInlineMediaPlayback” value=”true” />` 
+
 <!-- Auto Generated Below -->
 
 

--- a/core/src/components/video/readme.md
+++ b/core/src/components/video/readme.md
@@ -64,11 +64,34 @@ export const VideoExample: React.FunctionComponent = () => (
 
 ## Properties
 
-| Property    | Attribute | Description                                                                                 | Type                    | Default     |
-| ----------- | --------- | ------------------------------------------------------------------------------------------- | ----------------------- | ----------- |
-| `loop`      | `loop`    | Determines if the video should loop endlessly. Defaults to true.                            | `boolean \| undefined`  | `true`      |
-| `src`       | `src`     | The video URL. This attribute is mandatory for the <video> element.                         | `string \| undefined`   | `undefined` |
-| `threshold` | --        | An array that determines the threshold trigger values: >= 0.65 will play < 0.65 will pause. | `number[] \| undefined` | `[0, 0.65]` |
+| Property        | Attribute        | Description                                                                | Type                   | Default     |
+| --------------- | ---------------- | -------------------------------------------------------------------------- | ---------------------- | ----------- |
+| `loop`          | `loop`           | Determines if the video should loop endlessly. Defaults to true.           | `boolean \| undefined` | `true`      |
+| `playThreshold` | `play-threshold` | Determines at what percent the video should be in the view before playing. | `number \| undefined`  | `undefined` |
+| `src`           | `src`            | The video URL. This attribute is mandatory for the <video> element.        | `string \| undefined`  | `undefined` |
+
+
+## Methods
+
+### `pause() => Promise<void>`
+
+Pauses the video
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+### `play() => Promise<void>`
+
+Plays the video
+
+#### Returns
+
+Type: `Promise<void>`
+
+
 
 
 ----------------------------------------------

--- a/core/src/components/video/test/basic/e2e.ts
+++ b/core/src/components/video/test/basic/e2e.ts
@@ -1,0 +1,12 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+test('video: basic', async () => {
+  const page = await newE2EPage({
+    url: '/src/components/video/test/basic?ionic:_testing=true'
+  });
+
+  await page.waitFor(250);
+
+  const compare = await page.compareScreenshot();
+  expect(compare).toMatchScreenshot();
+});

--- a/core/src/components/video/test/basic/index.html
+++ b/core/src/components/video/test/basic/index.html
@@ -23,7 +23,7 @@
     <ion-content class="ion-padding">
       <f></f>
       <f></f>
-      <ion-video #hidden
+      <ion-video #hidden playThreshold="0.65"
         src="https://www.w3schools.com/html/mov_bbb.mp4"></ion-video>
       <f></f>
       <f></f>
@@ -31,7 +31,7 @@
       <f></f>
       <f></f>
       <f></f>
-      <ion-video #hidden
+      <ion-video #hidden playThreshold="0.65"
         src="https://www.w3schools.com/html/mov_bbb.mp4"></ion-video>
       <f></f>
       <f></f>
@@ -39,7 +39,7 @@
       <f></f>
       <f></f>
       <f></f>
-      <ion-video #hidden
+      <ion-video #hidden playThreshold="0.65"
         src="https://www.w3schools.com/html/mov_bbb.mp4"></ion-video>
 
     </ion-content>

--- a/core/src/components/video/test/basic/index.html
+++ b/core/src/components/video/test/basic/index.html
@@ -24,7 +24,7 @@
       <f></f>
       <f></f>
       <ion-video #hidden
-        src="https://ia800501.us.archive.org/10/items/BigBuckBunny_310/big_buck_bunny_640_512kb.mp4"></ion-video>
+        src="https://www.w3schools.com/html/mov_bbb.mp4"></ion-video>
       <f></f>
       <f></f>
       <f></f>
@@ -32,7 +32,7 @@
       <f></f>
       <f></f>
       <ion-video #hidden
-        src="https://ia800501.us.archive.org/10/items/BigBuckBunny_310/big_buck_bunny_640_512kb.mp4"></ion-video>
+        src="https://www.w3schools.com/html/mov_bbb.mp4"></ion-video>
       <f></f>
       <f></f>
       <f></f>
@@ -40,7 +40,7 @@
       <f></f>
       <f></f>
       <ion-video #hidden
-        src="https://ia800501.us.archive.org/10/items/BigBuckBunny_310/big_buck_bunny_640_512kb.mp4"></ion-video>
+        src="https://www.w3schools.com/html/mov_bbb.mp4"></ion-video>
 
     </ion-content>
 
@@ -68,6 +68,12 @@
       }
 
     </style>
+
+    <script>
+      document.body.addEventListener('ionVideoWillLoad', (event) => {
+        console.log('video will load', event.target);
+      });
+    </script>
   </ion-app>
 </body>
 

--- a/core/src/components/video/test/basic/index.html
+++ b/core/src/components/video/test/basic/index.html
@@ -23,7 +23,7 @@
     <ion-content class="ion-padding">
       <f></f>
       <f></f>
-      <ion-video #hidden playThreshold="0.65"
+      <ion-video #hidden play-threshold="0.65"
         src="https://www.w3schools.com/html/mov_bbb.mp4"></ion-video>
       <f></f>
       <f></f>
@@ -31,7 +31,7 @@
       <f></f>
       <f></f>
       <f></f>
-      <ion-video #hidden playThreshold="0.65"
+      <ion-video #hidden play-threshold="0.65"
         src="https://www.w3schools.com/html/mov_bbb.mp4"></ion-video>
       <f></f>
       <f></f>
@@ -39,7 +39,7 @@
       <f></f>
       <f></f>
       <f></f>
-      <ion-video #hidden playThreshold="0.65"
+      <ion-video #hidden play-threshold="0.65"
         src="https://www.w3schools.com/html/mov_bbb.mp4"></ion-video>
 
     </ion-content>

--- a/core/src/components/video/test/basic/index.html
+++ b/core/src/components/video/test/basic/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html dir="ltr">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Img - Basic</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+  <link href="../../../../../css/ionic.bundle.css" rel="stylesheet">
+  <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
+  <script src="../../../../../scripts/testing/scripts.js"></script>
+  <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
+  <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script></head>
+
+<body>
+  <ion-app>
+
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Video - Basic</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content class="ion-padding">
+      <f></f>
+      <f></f>
+      <ion-video #hidden
+        src="https://ia800501.us.archive.org/10/items/BigBuckBunny_310/big_buck_bunny_640_512kb.mp4"></ion-video>
+      <f></f>
+      <f></f>
+      <f></f>
+      <f></f>
+      <f></f>
+      <f></f>
+      <ion-video #hidden
+        src="https://ia800501.us.archive.org/10/items/BigBuckBunny_310/big_buck_bunny_640_512kb.mp4"></ion-video>
+      <f></f>
+      <f></f>
+      <f></f>
+      <f></f>
+      <f></f>
+      <f></f>
+      <ion-video #hidden
+        src="https://ia800501.us.archive.org/10/items/BigBuckBunny_310/big_buck_bunny_640_512kb.mp4"></ion-video>
+
+    </ion-content>
+
+    <ion-footer>
+      <ion-toolbar>
+        <ion-title>Footer</ion-title>
+      </ion-toolbar>
+    </ion-footer>
+
+    <style>
+      f {
+        display: block;
+        margin: 15px auto;
+        max-width: 150px;
+        height: 150px;
+        background: blue;
+      }
+
+      #hidden {
+        width: 300px;
+      }
+
+      f:last-of-type {
+        background: yellow;
+      }
+
+    </style>
+  </ion-app>
+</body>
+
+</html>

--- a/core/src/components/video/test/standalone/e2e.ts
+++ b/core/src/components/video/test/standalone/e2e.ts
@@ -1,0 +1,12 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+test('img: standalone', async () => {
+  const page = await newE2EPage({
+    url: '/src/components/video/test/standalone?ionic:_testing=true'
+  });
+
+  await page.waitFor(250);
+
+  const compare = await page.compareScreenshot();
+  expect(compare).toMatchScreenshot();
+});

--- a/core/src/components/video/test/standalone/index.html
+++ b/core/src/components/video/test/standalone/index.html
@@ -14,7 +14,7 @@
 <body class="ion-padding" onLoad="render()">
   <h2>Default</h2>
   <ion-video
-    src="https://ia800501.us.archive.org/10/items/BigBuckBunny_310/big_buck_bunny_640_512kb.mp4"></ion-video>
+    src="https://www.w3schools.com/html/mov_bbb.mp4"></ion-video>
 
   <style>
 

--- a/core/src/components/video/test/standalone/index.html
+++ b/core/src/components/video/test/standalone/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html dir="ltr">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Img - Standalone</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+  <link href="../../../../../css/core.css" rel="stylesheet">
+  <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
+  <script src="../../../../../scripts/testing/scripts.js"></script>
+  <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
+  <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script></head>
+
+<body class="ion-padding" onLoad="render()">
+  <h2>Default</h2>
+  <ion-video
+    src="https://ia800501.us.archive.org/10/items/BigBuckBunny_310/big_buck_bunny_640_512kb.mp4"></ion-video>
+
+  <style>
+
+    #hidden {
+      width: 300px;
+    }
+
+  </style>
+</body>
+
+</html>

--- a/core/src/components/video/usage/angular.md
+++ b/core/src/components/video/usage/angular.md
@@ -1,0 +1,7 @@
+```html
+<ion-list>
+  <ion-item *ngFor="let item of items">
+    <ion-video src="item.src"></ion-video>
+  </ion-item>
+</ion-list>
+```

--- a/core/src/components/video/usage/javascript.md
+++ b/core/src/components/video/usage/javascript.md
@@ -1,4 +1,3 @@
 ```html
-  <ion-video
-    src="..."></ion-video>
+  <ion-video src="https://www.w3schools.com/html/mov_bbb.mp4"></ion-video>
 ```

--- a/core/src/components/video/usage/javascript.md
+++ b/core/src/components/video/usage/javascript.md
@@ -1,0 +1,4 @@
+```html
+  <ion-video
+    src="..."></ion-video>
+```

--- a/core/src/components/video/usage/react.md
+++ b/core/src/components/video/usage/react.md
@@ -1,0 +1,19 @@
+```tsx
+import React from 'react';
+import { IonList, IonItem, IonVideo IonContent } from '@ionic/react';
+
+type Item = {
+  src: string;
+};
+const items: Item[] = [{ src: 'https://www.w3schools.com/html/mov_bbb.mp4' }];
+
+export const VideoExample: React.FunctionComponent = () => (
+  <IonContent>
+    <IonList>
+      {items.map((video, i) => (
+        <IonVideo key={i} src={video.src}></IonVideo>
+      ))}
+    </IonList>
+  </IonContent>
+);
+```

--- a/core/src/components/video/usage/vue.md
+++ b/core/src/components/video/usage/vue.md
@@ -1,0 +1,9 @@
+```html
+<template>
+  <ion-list>
+    <ion-item v-for="item in items" :key="item.src">
+      <ion-video :src="item.src"></ion-video>
+    </ion-item>
+  </ion-list>
+</template>
+```

--- a/core/src/components/video/video.scss
+++ b/core/src/components/video/video.scss
@@ -1,0 +1,15 @@
+:host {
+  display: block;
+
+  object-fit: fill;
+}
+
+video {
+  display: block;
+
+  width: 100%;
+  height: 100%;
+
+  object-fit: inherit;
+  object-position: inherit;
+}

--- a/core/src/components/video/video.tsx
+++ b/core/src/components/video/video.tsx
@@ -1,0 +1,104 @@
+import { Component, ComponentInterface, Element, Prop, State, Watch, h } from '@stencil/core';
+
+@Component({
+  tag: 'ion-video',
+  styleUrl: 'video.scss',
+  shadow: true,
+})
+export class Video implements ComponentInterface {
+
+  private io?: IntersectionObserver;
+
+  @Element() el!: HTMLElement;
+
+  /**
+   * Determines if the video should be muted or unmuted. Muted by default.
+   */
+  @State() muted ? = true;
+
+  /**
+   * Determines if the video is playing to minimize calls.
+   */
+  @State() playing?: boolean;
+
+  /**
+   * The video URL. This attribute is mandatory for the <video> element.
+   */
+  @Prop() src?: string;
+
+  /**
+   * Determines if the video should loop endlessly. Defaults to true.
+   */
+  @Prop() loop ? = true;
+
+  /**
+   * intersection threshold triggers:
+   * >= 0.65 will play
+   * < 0.65 will pause.
+   */
+  @Prop() threshold ? = [0, 0.65];
+
+  @Watch('src')
+  srcChanged() {
+    this.addIO();
+  }
+
+  componentDidLoad() {
+    this.addIO();
+  }
+
+  private addIO() {
+    if (this.src === undefined) {
+      return;
+    }
+    if ('IntersectionObserver' in window) {
+      this.removeIO();
+      this.io = new IntersectionObserver((data: any) => {
+        // because there will only ever be one instance
+        // of the element we are observing
+        // we can just use data[0]
+
+        // Check if we should play the video.
+        const shouldPlay = data[0].intersectionRatio > 0.65;
+
+        // Determine if the video state has changed to avoid useless operations.
+        if (shouldPlay !== this.playing) {
+
+          // Grab the shadowRoot video element.
+          const video = data[0].target.shadowRoot.lastChild;
+
+          // Play or Pause if necessary.
+          shouldPlay ? video.play() : video.pause();
+
+          // Update video state.
+          this.playing = shouldPlay;
+        }
+      }, { threshold: this.threshold });
+
+      this.io.observe(this.el);
+    }
+  }
+
+  private removeIO() {
+    if (this.io) {
+      this.io.disconnect();
+      this.io = undefined;
+    }
+  }
+
+  render() {
+    return (
+      <video
+        playsInline
+        preload="auto"
+        muted={this.muted}
+        loop={this.loop}
+      >
+        <source
+          src={this.src}
+          type="video/mp4"
+        />
+      </video>
+    );
+  }
+}

--- a/core/src/components/video/video.tsx
+++ b/core/src/components/video/video.tsx
@@ -32,11 +32,11 @@ export class Video implements ComponentInterface {
   @Prop() loop ? = true;
 
   /**
-   * intersection threshold triggers:
+   * An array that determines the threshold trigger values:
    * >= 0.65 will play
    * < 0.65 will pause.
    */
-  @Prop() threshold ? = [0, 0.65];
+  private threshold?: number[] = [0, 0.65];
 
   @Watch('src')
   srcChanged() {
@@ -58,8 +58,13 @@ export class Video implements ComponentInterface {
         // of the element we are observing
         // we can just use data[0]
 
+        // Suppress possible null check for threshold.
+        if (this.threshold === undefined || this.threshold.length === 0) {
+          return console.error('IonVideo: Threshold must contain array of values between 0 and 1.0');
+        }
+
         // Check if we should play the video.
-        const shouldPlay = data[0].intersectionRatio > 0.65;
+        const shouldPlay = data[0].intersectionRatio >= this.threshold[this.threshold.length - 1];
 
         // Determine if the video state has changed to avoid useless operations.
         if (shouldPlay !== this.playing) {
@@ -67,7 +72,7 @@ export class Video implements ComponentInterface {
           // Grab the shadowRoot video element.
           const video = data[0].target.shadowRoot.lastChild;
 
-          // Play or Pause if necessary.
+          // Play or Pause as necessary.
           shouldPlay ? video.play() : video.pause();
 
           // Update video state.


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [x] Feature

## What is the current behavior?
There is no component currently to auto play or pause videos in Ionic, and the desired functionality has to be manually added in apps requiring it. This should solve that.

Issue Number: #18603 


## What is the new behavior?
When a user utilizes the `ion-video` tag, their videos will automatically be paused until the video is within the viewport, at the desired threshold. If a threshold is not provided, the component will default to playing when 65% of the video is in the view.

Example code:
```
<ion-video play-threshold="0.65" src="https://www.w3schools.com/html/mov_bbb.mp4"></ion-video>
```

## Does this introduce a breaking change?
- [x] No
