### PR TITLE
chore(): change peer deps to support ng8

### DIFF
--- a/angular/package.json
+++ b/angular/package.json
@@ -49,18 +49,18 @@
     "tslib": "^1.9.3"
   },
   "peerDependencies": {
-    "@angular-devkit/core": "^7.2.1",
-    "@angular-devkit/schematics": "^7.2.1",
-    "@angular/core": "^7.2.1",
-    "@angular/common": "^7.2.1",
-    "@angular/forms": "^7.2.1",
-    "@angular/router": "^7.2.1",
-    "@angular/compiler": "^7.2.1",
-    "@angular/compiler-cli": "^7.2.1",
-    "@angular/platform-browser": "^7.2.1",
-    "@angular/platform-browser-dynamic": "^7.2.1",
+    "@angular-devkit/core": ">=7.2.1",
+    "@angular-devkit/schematics": ">=7.2.1",
+    "@angular/core": ">=7.2.1",
+    "@angular/common": ">=7.2.1",
+    "@angular/forms": ">=7.2.1",
+    "@angular/router": ">=7.2.1",
+    "@angular/compiler": ">=7.2.1",
+    "@angular/compiler-cli": ">=7.2.1",
+    "@angular/platform-browser": ">=7.2.1",
+    "@angular/platform-browser-dynamic": ">=7.2.1",
     "rxjs": ">=6.2.0",
-    "zone.js": "^0.8.26"
+    "zone.js": ">=0.8.26"
   },
   "devDependencies": {
     "@angular-devkit/core": "^7.2.1",


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):  Dependency updates 



## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
This PR brings support for Angular 8 while still supporting Angular 7 apps and not introducing a breaking change. While #18577 goes all in on Angular 8, it does introduce a breaking change that we'd like to avoid. After talking with the Angular team, they suggesting keeping things built with Angular 7, but allowing peer deps to use Angular 8

https://github.com/angular/angular/issues/30654#issuecomment-495642339


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

