### PR TITLE
FIX error "Cannot find name 'HTMLStencilElement'"

### DIFF
--- a/vue/src/interfaces.ts
+++ b/vue/src/interfaces.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import VueRouter from 'vue-router';
-import { RouterDirection } from '@ionic/core';
+import { RouterDirection, HTMLStencilElement } from '@ionic/core';
 import { RouterOptions } from 'vue-router/types/router';
 
 declare module 'vue-router/types/router' {

--- a/vue/src/util.ts
+++ b/vue/src/util.ts
@@ -1,3 +1,5 @@
+import { HTMLStencilElement } from "@ionic/core";
+
 export class OverlayBaseController<Opts, Overlay> {
   constructor(private ctrl: string) {}
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
(This fixes an issue)

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
When you are building a Typescript project in Vue it shows the following message: "Cannot find name 'HTMLStencilElement'"
This fixes the issue

Issue Number: N/A

## What is the new behavior?
Two imports has been added
-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X] No


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks 

![ISSUE](https://user-images.githubusercontent.com/27731047/60743403-ce0d8e00-9f47-11e9-85dc-2d4e9180b4a2.png)



