### PR TITLE
Extend JSX namespace

### DIFF
--- a/core/src/interface.d.ts
+++ b/core/src/interface.d.ts
@@ -1,5 +1,5 @@
 // Components interfaces
-import {Components as IoniconsComponents} from 'ionicons';
+import {JSX as IoniconsJSX, Components as IoniconsComponents} from 'ionicons';
 export * from './components';
 export * from './index';
 export * from './components/alert/alert-interface';
@@ -64,5 +64,8 @@ export interface StyleEventDetail {
 declare module "./components" {
   export namespace Components {
     export interface IonIcon extends IoniconsComponents.IonIcon{}
+  }
+  export namespace JSX {
+    export interface IntrinsicElements extends IoniconsJSX.IntrinsicElements{}
   }
 }


### PR DESCRIPTION
Added IntrinsicElements from IonIcons to JSX namespace

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
When importing Ionic ion-icons can't be used even if proper typing are bound.

Issue Number: #18883


## What is the new behavior?

- If Ionic core is imported in another project using JSX with proper bindings also ion-icons can be used

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
