### PR TITLE
fix(transition): enable ios transition shadow by default

### DIFF
--- a/core/scripts/testing/scripts.js
+++ b/core/scripts/testing/scripts.js
@@ -7,6 +7,5 @@
 
   window.Ionic = window.Ionic || {};
   window.Ionic.config = window.Ionic.config || {};
-  window.Ionic.config.experimentalTransitionShadow = true;
 
 })();

--- a/core/src/components/content/content.tsx
+++ b/core/src/components/content/content.tsx
@@ -302,7 +302,7 @@ export class Content implements ComponentInterface {
     const mode = getIonMode(this);
     const { scrollX, scrollY, forceOverscroll } = this;
 
-    const transitionShadow = (mode === 'ios' && config.getBoolean('experimentalTransitionShadow', false));
+    const transitionShadow = (mode === 'ios' && config.getBoolean('experimentalTransitionShadow', true));
 
     this.resize();
 


### PR DESCRIPTION
Still leaving in the `experimentalTransitionShadow` config for now, but defaulting it to true. We can remove the config in the next major release.