### PR TITLE
perf(animation): remove display: none check

### DIFF
--- a/core/src/utils/animation/animation.ts
+++ b/core/src/utils/animation/animation.ts
@@ -923,22 +923,20 @@ export const createAnimation = () => {
       }
     });
 
-    const animationDelay = getDelay() || 0;
-    const animationDuration = getDuration() || 0;
-    const visibleElements = elements.filter(element => element.offsetParent !== null);
-    if (visibleElements.length === 0 || _keyframes.length === 0 || elements.length === 0) {
+    if (_keyframes.length === 0 || elements.length === 0) {
+       animationFinish();
+    } else {
       /**
+       * This is a catchall in the event that a CSS Animation did not finish.
+       * The Web Animations API has mechanisms in place for preventing this.
        * CSS Animations will not fire an `animationend` event
        * for elements with `display: none`. The Web Animations API
        * accounts for this, but using raw CSS Animations requires
        * this workaround.
        */
-       animationFinish();
-    } else if (_keyframes.length > 0 && elements.length > 0) {
-      /**
-       * This is a catchall in the event that a CSS Animation did not finish.
-       * The Web Animations API has mechanisms in place for preventing this.
-       */
+       const animationDelay = getDelay() || 0;
+       const animationDuration = getDuration() || 0;
+
        cssAnimationsTimerFallback = setTimeout(onAnimationEndFallback, animationDelay + animationDuration + ANIMATION_END_FALLBACK_PADDING_MS);
 
        animationEnd(elements[0], () => {

--- a/core/src/utils/animation/animation.ts
+++ b/core/src/utils/animation/animation.ts
@@ -925,35 +925,27 @@ export const createAnimation = () => {
 
     const animationDelay = getDelay() || 0;
     const animationDuration = getDuration() || 0;
+    const visibleElements = elements.filter(element => element.offsetParent !== null);
+    if (visibleElements.length === 0 || _keyframes.length === 0 || elements.length === 0) {
+      /**
+       * CSS Animations will not fire an `animationend` event
+       * for elements with `display: none`. The Web Animations API
+       * accounts for this, but using raw CSS Animations requires
+       * this workaround.
+       */
+       animationFinish();
+    } else if (_keyframes.length > 0 && elements.length > 0) {
+      /**
+       * This is a catchall in the event that a CSS Animation did not finish.
+       * The Web Animations API has mechanisms in place for preventing this.
+       */
+       cssAnimationsTimerFallback = setTimeout(onAnimationEndFallback, animationDelay + animationDuration + ANIMATION_END_FALLBACK_PADDING_MS);
 
-    /**
-     * offsetParent is going to cause a reflow
-     * So we need to wrap this in an raf otherwise
-     * performance will be slow
-     */
-    requestAnimationFrame(() => {
-      const visibleElements = elements.filter(element => element.offsetParent !== null);
-      if (visibleElements.length === 0 || _keyframes.length === 0 || elements.length === 0) {
-        /**
-         * CSS Animations will not fire an `animationend` event
-         * for elements with `display: none`. The Web Animations API
-         * accounts for this, but using raw CSS Animations requires
-         * this workaround.
-         */
-         animationFinish();
-      } else if (_keyframes.length > 0 && elements.length > 0) {
-        /**
-         * This is a catchall in the event that a CSS Animation did not finish.
-         * The Web Animations API has mechanisms in place for preventing this.
-         */
-         cssAnimationsTimerFallback = setTimeout(onAnimationEndFallback, animationDelay + animationDuration + ANIMATION_END_FALLBACK_PADDING_MS);
-
-         animationEnd(elements[0], () => {
-          clearCSSAnimationsTimeout();
-          animationFinish();
-        });
-      }
-    });
+       animationEnd(elements[0], () => {
+        clearCSSAnimationsTimeout();
+        animationFinish();
+      });
+    }
   };
 
   const playWebAnimations = () => {

--- a/core/src/utils/animation/animation.ts
+++ b/core/src/utils/animation/animation.ts
@@ -925,27 +925,35 @@ export const createAnimation = () => {
 
     const animationDelay = getDelay() || 0;
     const animationDuration = getDuration() || 0;
-    const visibleElements = elements.filter(element => element.offsetParent !== null);
-    if (visibleElements.length === 0 || _keyframes.length === 0 || elements.length === 0) {
-      /**
-       * CSS Animations will not fire an `animationend` event
-       * for elements with `display: none`. The Web Animations API
-       * accounts for this, but using raw CSS Animations requires
-       * this workaround.
-       */
-       animationFinish();
-    } else if (_keyframes.length > 0 && elements.length > 0) {
-      /**
-       * This is a catchall in the event that a CSS Animation did not finish.
-       * The Web Animations API has mechanisms in place for preventing this.
-       */
-       cssAnimationsTimerFallback = setTimeout(onAnimationEndFallback, animationDelay + animationDuration + ANIMATION_END_FALLBACK_PADDING_MS);
 
-       animationEnd(elements[0], () => {
-        clearCSSAnimationsTimeout();
-        animationFinish();
-      });
-    }
+    /**
+     * offsetParent is going to cause a reflow
+     * So we need to wrap this in an raf otherwise
+     * performance will be slow
+     */
+    requestAnimationFrame(() => {
+      const visibleElements = elements.filter(element => element.offsetParent !== null);
+      if (visibleElements.length === 0 || _keyframes.length === 0 || elements.length === 0) {
+        /**
+         * CSS Animations will not fire an `animationend` event
+         * for elements with `display: none`. The Web Animations API
+         * accounts for this, but using raw CSS Animations requires
+         * this workaround.
+         */
+         animationFinish();
+      } else if (_keyframes.length > 0 && elements.length > 0) {
+        /**
+         * This is a catchall in the event that a CSS Animation did not finish.
+         * The Web Animations API has mechanisms in place for preventing this.
+         */
+         cssAnimationsTimerFallback = setTimeout(onAnimationEndFallback, animationDelay + animationDuration + ANIMATION_END_FALLBACK_PADDING_MS);
+
+         animationEnd(elements[0], () => {
+          clearCSSAnimationsTimeout();
+          animationFinish();
+        });
+      }
+    });
   };
 
   const playWebAnimations = () => {

--- a/core/src/utils/animation/test/display/e2e.ts
+++ b/core/src/utils/animation/test/display/e2e.ts
@@ -4,6 +4,15 @@ import { listenForEvent, waitForFunctionTestContext } from '../../../test/utils'
 
 test(`animation:web: display`, async () => {
   const page = await newE2EPage({ url: '/src/utils/animation/test/display' });
+  await runTest(page);
+});
+
+test(`animation:css: display`, async () => {
+  const page = await newE2EPage({ url: '/src/utils/animation/test/display?ionic:_forceCSSAnimations=true' });
+  await runTest(page);
+});
+
+const runTest = async (page: any) => {
   const screenshotCompares = [];
 
   screenshotCompares.push(await page.compareScreenshot());
@@ -25,30 +34,4 @@ test(`animation:web: display`, async () => {
 
   }, { animationStatus });
   screenshotCompares.push(await page.compareScreenshot());
-});
-
-test(`animation:css: display`, async () => {
-  const page = await newE2EPage({ url: '/src/utils/animation/test/display?ionic:_forceCSSAnimations=true' });
-  const screenshotCompares = [];
-
-  screenshotCompares.push(await page.compareScreenshot());
-
-  const ANIMATION_FINISHED = 'onIonAnimationFinished';
-  const animationStatus = [];
-  await page.exposeFunction(ANIMATION_FINISHED, (ev: any) => {
-    animationStatus.push(ev.detail);
-  });
-
-  const squareA = await page.$('.square-a');
-  await listenForEvent(page, 'ionAnimationFinished', squareA, ANIMATION_FINISHED);
-
-  await page.click('.play');
-  await page.waitForSelector('.play');
-
-  await waitForFunctionTestContext((payload: any) => {
-    // CSS Animations do not account for elements with `display: none` very well, so we need to add a workaround for this.
-    return payload.animationStatus.join(', ') === ['AnimationAFinished', 'AnimationBFinished', 'AnimationRootFinished'].join(', ');
-
-  }, { animationStatus });
-  screenshotCompares.push(await page.compareScreenshot());
-});
+};


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): performance


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: css animations do not run on elements that are hidden (via display: none). We had a check for this, but it was very very slow and affected all devices that used the animations.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- We opted to remove this check and will document this behavior for users

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
