### PR TITLE
fix(nav): prevent completing transition from being interrupted

### DIFF
--- a/core/src/components/nav/nav.tsx
+++ b/core/src/components/nav/nav.tsx
@@ -18,6 +18,7 @@ export class Nav implements NavOutlet {
 
   private transInstr: TransitionInstruction[] = [];
   private sbAni?: Animation | IonicAnimation;
+  private enableAnimation = false;
   private useRouter = false;
   private isTransitioning = false;
   private destroyed = false;
@@ -953,13 +954,18 @@ export class Nav implements NavOutlet {
   }
 
   private onMove(stepValue: number) {
-    if (this.sbAni) {
+    if (this.sbAni && this.enableAnimation) {
       this.sbAni.progressStep(stepValue);
     }
   }
 
   private onEnd(shouldComplete: boolean, stepValue: number, dur: number) {
-    if (this.sbAni) {
+    if (this.sbAni && this.enableAnimation) {
+      this.enableAnimation = false;
+      this.sbAni.onFinish(() => {
+        this.enableAnimation = true;
+      }, { oneTimeCallback: true });
+
       this.sbAni.progressEnd(shouldComplete, stepValue, dur);
     }
   }

--- a/core/src/components/nav/nav.tsx
+++ b/core/src/components/nav/nav.tsx
@@ -18,7 +18,7 @@ export class Nav implements NavOutlet {
 
   private transInstr: TransitionInstruction[] = [];
   private sbAni?: Animation | IonicAnimation;
-  private enableAnimation = true;
+  private animationEnabled = true;
   private useRouter = false;
   private isTransitioning = false;
   private destroyed = false;
@@ -938,6 +938,7 @@ export class Nav implements NavOutlet {
       !!this.swipeGesture &&
       !this.isTransitioning &&
       this.transInstr.length === 0 &&
+      this.animationEnabled &&
       this.canGoBackSync()
     );
   }
@@ -954,16 +955,16 @@ export class Nav implements NavOutlet {
   }
 
   private onMove(stepValue: number) {
-    if (this.sbAni && this.enableAnimation) {
+    if (this.sbAni) {
       this.sbAni.progressStep(stepValue);
     }
   }
 
   private onEnd(shouldComplete: boolean, stepValue: number, dur: number) {
-    if (this.sbAni && this.enableAnimation) {
-      this.enableAnimation = false;
+    if (this.sbAni) {
+      this.animationEnabled = false;
       this.sbAni.onFinish(() => {
-        this.enableAnimation = true;
+        this.animationEnabled = true;
       }, { oneTimeCallback: true });
       this.sbAni.progressEnd(shouldComplete, stepValue, dur);
     }

--- a/core/src/components/nav/nav.tsx
+++ b/core/src/components/nav/nav.tsx
@@ -18,7 +18,7 @@ export class Nav implements NavOutlet {
 
   private transInstr: TransitionInstruction[] = [];
   private sbAni?: Animation | IonicAnimation;
-  private enableAnimation = false;
+  private enableAnimation = true;
   private useRouter = false;
   private isTransitioning = false;
   private destroyed = false;
@@ -965,7 +965,6 @@ export class Nav implements NavOutlet {
       this.sbAni.onFinish(() => {
         this.enableAnimation = true;
       }, { oneTimeCallback: true });
-
       this.sbAni.progressEnd(shouldComplete, stepValue, dur);
     }
   }

--- a/core/src/components/router-outlet/route-outlet.tsx
+++ b/core/src/components/router-outlet/route-outlet.tsx
@@ -18,7 +18,7 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
   private waitPromise?: Promise<void>;
   private gesture?: Gesture;
   private ani?: IonicAnimation | Animation;
-  private enableAnimation = false;
+  private enableAnimation = true;
 
   @Element() el!: HTMLElement;
 

--- a/core/src/components/router-outlet/route-outlet.tsx
+++ b/core/src/components/router-outlet/route-outlet.tsx
@@ -18,6 +18,7 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
   private waitPromise?: Promise<void>;
   private gesture?: Gesture;
   private ani?: IonicAnimation | Animation;
+  private enableAnimation = false;
 
   @Element() el!: HTMLElement;
 
@@ -67,10 +68,16 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
       this.el,
       () => !!this.swipeHandler && this.swipeHandler.canStart(),
       () => this.swipeHandler && this.swipeHandler.onStart(),
-      step => this.ani && this.ani.progressStep(step),
+      step => { if (this.ani && this.enableAnimation) { this.ani.progressStep(step); } },
       (shouldComplete, step, dur) => {
-        if (this.ani) {
+        if (this.ani && this.enableAnimation) {
+          this.enableAnimation = false;
+          this.ani.onFinish(() => {
+            this.enableAnimation = true;
+          }, { oneTimeCallback: true });
+
           this.ani.progressEnd(shouldComplete, step, dur);
+
         }
         if (this.swipeHandler) {
           this.swipeHandler.onEnd(shouldComplete);

--- a/core/src/components/router-outlet/route-outlet.tsx
+++ b/core/src/components/router-outlet/route-outlet.tsx
@@ -18,7 +18,7 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
   private waitPromise?: Promise<void>;
   private gesture?: Gesture;
   private ani?: IonicAnimation | Animation;
-  private enableAnimation = true;
+  private animationEnabled = true;
 
   @Element() el!: HTMLElement;
 
@@ -66,14 +66,14 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
   async componentDidLoad() {
     this.gesture = (await import('../../utils/gesture/swipe-back')).createSwipeBackGesture(
       this.el,
-      () => !!this.swipeHandler && this.swipeHandler.canStart(),
+      () => !!this.swipeHandler && this.swipeHandler.canStart() && this.animationEnabled,
       () => this.swipeHandler && this.swipeHandler.onStart(),
-      step => { if (this.ani && this.enableAnimation) { this.ani.progressStep(step); } },
+      step => this.ani && this.ani.progressStep(step),
       (shouldComplete, step, dur) => {
-        if (this.ani && this.enableAnimation) {
-          this.enableAnimation = false;
+        if (this.ani) {
+          this.animationEnabled = false;
           this.ani.onFinish(() => {
-            this.enableAnimation = true;
+            this.animationEnabled = true;
           }, { oneTimeCallback: true });
 
           this.ani.progressEnd(shouldComplete, step, dur);

--- a/core/src/utils/animation/animation.ts
+++ b/core/src/utils/animation/animation.ts
@@ -924,7 +924,6 @@ export const createAnimation = () => {
        cssAnimationsTimerFallback = setTimeout(onAnimationEndFallback, animationDelay + animationDuration + ANIMATION_END_FALLBACK_PADDING_MS);
 
        animationEnd(elements[0], () => {
-        pause(false);
         clearCSSAnimationsTimeout();
         clearCSSAnimationPlayState();
         animationFinish();

--- a/core/src/utils/animation/animation.ts
+++ b/core/src/utils/animation/animation.ts
@@ -604,7 +604,7 @@ export const createAnimation = () => {
     }
   };
 
-  const initializeCSSAnimation = () => {
+  const initializeCSSAnimation = (toggleAnimationName = true) => {
     cleanUpStyleSheets();
 
     elements.forEach(element => {
@@ -628,7 +628,10 @@ export const createAnimation = () => {
         setStyleProperty(element, 'animation-iteration-count', iterationsCount);
         setStyleProperty(element, 'animation-play-state', 'paused');
 
-        setStyleProperty(element, 'animation-name', `${stylesheet.id}-alt`);
+        if (toggleAnimationName) {
+          setStyleProperty(element, 'animation-name', `${stylesheet.id}-alt`);
+        }
+
         requestAnimationFrame(() => {
           setStyleProperty(element, 'animation-name', stylesheet.id || null);
         });
@@ -660,14 +663,14 @@ export const createAnimation = () => {
 
   };
 
-  const initializeAnimation = () => {
+  const initializeAnimation = (toggleAnimationName = true) => {
     beforeAnimation();
 
     if (_keyframes.length > 0) {
       if (supportsWebAnimations) {
         initializeWebAnimation();
       } else {
-        initializeCSSAnimation();
+        initializeCSSAnimation(toggleAnimationName);
       }
     }
 
@@ -920,6 +923,7 @@ export const createAnimation = () => {
        cssAnimationsTimerFallback = setTimeout(onAnimationEndFallback, animationDelay + animationDuration + ANIMATION_END_FALLBACK_PADDING_MS);
 
        animationEnd(elements[0], () => {
+        pause(false);
         clearCSSAnimationsTimeout();
         animationFinish();
       });
@@ -956,7 +960,7 @@ export const createAnimation = () => {
    */
   const play = () => {
     if (!initialized) {
-      initializeAnimation();
+      initializeAnimation(false);
     }
 
     if (finished) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

With both the old animations utility and the new animations utility, a new swipe animation could begin before the previous animation has fully finished, leading to visual glitches and occasionally breaking navigation.

It's a little hard to reproduce and really only happens if you are intentionally trying to break things 😉, but if you try and swipe back as a previous swipe back is finishing, the current view will "jump". Easiest to reproduce on a lower end iPhone with low battery mode enabled. Also helps to be on a larger/slower application.



## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Prevent a new swipe gesture from beginning until the previous one has fully resolved.
- This is consistent with the native iOS behavior as iOS does not let you "catch" a finishing swipe before it has finished.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build available at `4.8.0-dev.201908161302.b0dfb20`
