### PR TITLE
fix(animation): prevent animation re-run when toggling element visibility

### DIFF
--- a/core/src/components/menu/menu.tsx
+++ b/core/src/components/menu/menu.tsx
@@ -420,7 +420,7 @@ export class Menu implements ComponentInterface, MenuI {
     this.lastOnEnd = detail.timeStamp;
     this.animation
       .onFinish(() => this.afterAnimation(shouldOpen), {
-        oneTime: true
+        oneTimeCallback: true
       })
       .progressEnd(shouldComplete, stepValue, realDur);
   }

--- a/core/src/utils/animation/animation-interface.ts
+++ b/core/src/utils/animation/animation-interface.ts
@@ -64,7 +64,7 @@ export interface AnimationOnFinishCallback {
 }
 
 export interface AnimationOnFinishOptions {
-  oneTime: boolean;
+  oneTimeCallback: boolean;
 }
 
 export type AnimationDirection = 'normal' | 'reverse' | 'alternate' | 'alternate-reverse';

--- a/core/src/utils/animation/animation.ts
+++ b/core/src/utils/animation/animation.ts
@@ -92,7 +92,7 @@ export const createAnimation = () => {
    * upon the animation ending
    */
   const onFinish = (callback: any, opts?: AnimationOnFinishOptions) => {
-    const callbacks = (opts && opts.oneTime) ? onFinishOneTimeCallbacks : onFinishCallbacks;
+    const callbacks = (opts && opts.oneTimeCallback) ? onFinishOneTimeCallbacks : onFinishCallbacks;
     callbacks.push({ callback, opts } as AnimationOnFinishCallback);
 
     return ani;
@@ -758,7 +758,7 @@ export const createAnimation = () => {
       animation.progressStart(forceLinearEasing);
     });
 
-    pause(false);
+    pauseAnimation();
     shouldForceLinearEasing = forceLinearEasing;
 
     if (!initialized) {
@@ -783,7 +783,6 @@ export const createAnimation = () => {
     return ani;
   };
 
-  // TODO: Need to clean this up
   const progressEnd = (shouldComplete: boolean, step: number, dur: number | undefined) => {
     childAnimations.forEach(animation => {
       animation.progressEnd(shouldComplete, step, dur);
@@ -820,7 +819,7 @@ export const createAnimation = () => {
       forceDirectionValue = undefined;
       forceDelayValue = undefined;
     }, {
-      oneTime: true
+      oneTimeCallback: true
     });
 
     if (!parentAnimation) {
@@ -829,17 +828,8 @@ export const createAnimation = () => {
 
     return ani;
   };
-
-  /**
-   * Pause the animation.
-   */
-  const pause = (deep = true) => {
-    if (deep) {
-      childAnimations.forEach(animation => {
-        animation.pause();
-      });
-    }
-
+  
+  const pauseAnimation = () => {
     if (initialized) {
       if (supportsWebAnimations) {
         getWebAnimations().forEach(animation => {
@@ -851,6 +841,17 @@ export const createAnimation = () => {
         });
       }
     }
+  }
+
+  /**
+   * Pause the animation.
+   */
+  const pause = () => {
+    childAnimations.forEach(animation => {
+      animation.pause();
+    });
+
+    pauseAnimation();
 
     return ani;
   };
@@ -862,7 +863,7 @@ export const createAnimation = () => {
    */
   const playAsync = () => {
     return new Promise(resolve => {
-      onFinish(resolve, { oneTime: true });
+      onFinish(resolve, { oneTimeCallback: true });
       play();
 
       return ani;
@@ -877,7 +878,7 @@ export const createAnimation = () => {
   const playSync = () => {
     shouldForceSyncPlayback = true;
 
-    onFinish(() => shouldForceSyncPlayback = false, { oneTime: true });
+    onFinish(() => shouldForceSyncPlayback = false, { oneTimeCallback: true });
     play();
 
     return ani;

--- a/core/src/utils/animation/animation.ts
+++ b/core/src/utils/animation/animation.ts
@@ -828,7 +828,7 @@ export const createAnimation = () => {
 
     return ani;
   };
-  
+
   const pauseAnimation = () => {
     if (initialized) {
       if (supportsWebAnimations) {
@@ -841,7 +841,7 @@ export const createAnimation = () => {
         });
       }
     }
-  }
+  };
 
   /**
    * Pause the animation.
@@ -922,9 +922,20 @@ export const createAnimation = () => {
 
        animationEnd(elements[0], () => {
         clearCSSAnimationsTimeout();
+        clearCSSAnimationPlayState();
         animationFinish();
       });
     }
+  };
+
+  const clearCSSAnimationPlayState = () => {
+    elements.forEach(element => {
+      requestAnimationFrame(() => {
+        removeStyleProperty(element, 'animation-duration');
+        removeStyleProperty(element, 'animation-delay');
+        removeStyleProperty(element, 'animation-play-state');
+      });
+    });
   };
 
   const playWebAnimations = () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

when using css animations, toggling an element's display state causes the animation re-run

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- on animation finish, remove the `animation-play-state`, `animation-duration`, `animation-delay` from all animated elements to prevent them from "replaying" once they are done. Animations can be actually replayed via the usual `.play()`, method in IonicAnimations

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
