### PR TITLE
Update BREAKING.md

### DIFF
--- a/angular/BREAKING.md
+++ b/angular/BREAKING.md
@@ -1092,7 +1092,7 @@ openLoading() {
 ```javascript
 async openLoading() {
   let loading = this.loadingCtrl.create({
-    content: 'Loading...'
+    message: 'Loading...'
   });
 
   await loading.present();


### PR DESCRIPTION
Just corrected the `LoadingOptions` usage. Nothing critical.
`content` does not exist in `LoadingOptions`. It's now called `message`.