### PR TITLE
docs(item): wrap usage used directive instead of class

### DIFF
--- a/core/src/components/item/usage/angular.md
+++ b/core/src/components/item/usage/angular.md
@@ -68,14 +68,14 @@ List Items
   </ion-item>
 
   <ion-item>
-    <ion-label text-wrap>
+    <ion-label class="ion-text-wrap">
     Multiline text that should wrap when it is too long
     to fit on one line in the item.
     </ion-label>
   </ion-item>
 
   <ion-item>
-    <ion-label text-wrap>
+    <ion-label class="ion-text-wrap">
       <ion-text color="primary">
         <h3>H3 Primary Title</h3>
       </ion-text>

--- a/core/src/components/item/usage/javascript.md
+++ b/core/src/components/item/usage/javascript.md
@@ -68,14 +68,14 @@ List Items
   </ion-item>
 
   <ion-item>
-    <ion-label text-wrap>
+    <ion-label class="ion-text-wrap">
     Multiline text that should wrap when it is too long
     to fit on one line in the item.
     </ion-label>
   </ion-item>
 
   <ion-item>
-    <ion-label text-wrap>
+    <ion-label class="ion-text-wrap">
       <ion-text color="primary">
         <h3>H3 Primary Title</h3>
       </ion-text>

--- a/core/src/components/item/usage/react.md
+++ b/core/src/components/item/usage/react.md
@@ -67,14 +67,14 @@ const Example: React.FC<{}> = () => (
       </IonItem>
 
       <IonItem>
-        <IonLabel text-wrap>
+        <IonLabel class="ion-text-wrap">
         Multiline text that should wrap when it is too long
         to fit on one line in the item.
         </IonLabel>
       </IonItem>
 
       <IonItem>
-        <IonLabel text-wrap>
+        <IonLabel class="ion-text-wrap">
           <IonText color="primary">
             <h3>H3 Primary Title</h3>
           </IonText>

--- a/core/src/components/item/usage/vue.md
+++ b/core/src/components/item/usage/vue.md
@@ -73,14 +73,14 @@ List Items
     </ion-item>
 
     <ion-item>
-      <ion-label text-wrap>
+      <ion-label class="ion-text-wrap">
       Multiline text that should wrap when it is too long
       to fit on one line in the item.
       </ion-label>
     </ion-item>
 
     <ion-item>
-      <ion-label text-wrap>
+      <ion-label class="ion-text-wrap">
         <ion-text color="primary">
           <h3>H3 Primary Title</h3>
         </ion-text>


### PR DESCRIPTION
I'm not sure if this is correct but I have created the PR ready for merge if this is an issue. Please review before accepting.

I thought that the new approved way for Ionic 4 was to use `ion-text-wrap` over the `text-wrap` directive.

As I understand it this is a general policy as not all platforms support directives.

It seems the `text-wrap` directive was still lurking in the usage examples.