### PR TITLE
fix(card) Fixes the ion-card color issue #19197

### DIFF
--- a/core/src/components/card/card.scss
+++ b/core/src/components/card/card.scss
@@ -35,6 +35,7 @@
 :host(.ion-color)::slotted(*) ion-card-header,
 :host(.ion-color)::slotted(*) ion-card-title,
 :host(.ion-color)::slotted(*) ion-card-subtitle {
+  background: current-color(base);
   color: current-color(contrast);
 }
 

--- a/core/src/components/card/test/item-color/e2e.ts
+++ b/core/src/components/card/test/item-color/e2e.ts
@@ -1,0 +1,10 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+test('card: item-color', async () => {
+  const page = await newE2EPage({
+    url: '/src/components/card/test/item-color?ionic:_testing=true'
+  });
+
+  const compare = await page.compareScreenshot();
+  expect(compare).toMatchScreenshot();
+});

--- a/core/src/components/card/test/item-color/index.html
+++ b/core/src/components/card/test/item-color/index.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html dir="ltr">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Card - Item-Color</title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
+    <link href="../../../../../css/ionic.bundle.css" rel="stylesheet" />
+    <link href="../../../../../scripts/testing/styles.css" rel="stylesheet" />
+    <script src="../../../../../scripts/testing/scripts.js"></script>
+    <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
+    <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+  </head>
+
+  <body>
+    <ion-app class="dark">
+      <ion-header>
+        <ion-toolbar color="primary">
+          <ion-title>Card - Item-Color</ion-title>
+        </ion-toolbar>
+      </ion-header>
+
+      <ion-content class="ion-padding">
+        <ion-card color="danger">
+          <ion-card-header>
+            <ion-card-subtitle>Subtitle</ion-card-subtitle>
+            <ion-card-title>Title</ion-card-title>
+          </ion-card-header>
+
+          <ion-card-content>
+            This is content, without any paragraph or header tags, within an
+            ion-card-content element.
+          </ion-card-content>
+        </ion-card>
+      </ion-content>
+    </ion-app>
+    <style>
+      .dark {
+        --ion-background-color: #121212;
+        --ion-background-color-rgb: 18, 18, 18;
+
+        --ion-text-color: #ffffff;
+        --ion-text-color-rgb: 255, 255, 255;
+
+        --ion-border-color: #222222;
+
+        --ion-color-step-50: #1e1e1e;
+        --ion-color-step-100: #2a2a2a;
+        --ion-color-step-150: #363636;
+        --ion-color-step-200: #414141;
+        --ion-color-step-250: #4d4d4d;
+        --ion-color-step-300: #595959;
+        --ion-color-step-350: #656565;
+        --ion-color-step-400: #717171;
+        --ion-color-step-450: #7d7d7d;
+        --ion-color-step-500: #898989;
+        --ion-color-step-550: #949494;
+        --ion-color-step-600: #a0a0a0;
+        --ion-color-step-650: #acacac;
+        --ion-color-step-700: #b8b8b8;
+        --ion-color-step-750: #c4c4c4;
+        --ion-color-step-800: #d0d0d0;
+        --ion-color-step-850: #dbdbdb;
+        --ion-color-step-900: #e7e7e7;
+        --ion-color-step-950: #f3f3f3;
+
+        --ion-item-background: #1a1b1e;
+      }
+    </style>
+  </body>
+</html>

--- a/core/src/components/card/test/item-color/index.html
+++ b/core/src/components/card/test/item-color/index.html
@@ -30,8 +30,32 @@
           </ion-card-header>
 
           <ion-card-content>
-            This is content, without any paragraph or header tags, within an
-            ion-card-content element.
+            This card has set the color attribute to the color danger. The whole
+            card should be red.
+          </ion-card-content>
+        </ion-card>
+
+        <ion-card>
+          <ion-card-header color="danger">
+            <ion-card-subtitle>Subtitle</ion-card-subtitle>
+            <ion-card-title>Title</ion-card-title>
+          </ion-card-header>
+
+          <ion-card-content>
+            This card has set the color attribute for the header. Only the
+            header should be red (danger color).
+          </ion-card-content>
+        </ion-card>
+
+        <ion-card color="light">
+          <ion-card-header color="primary">
+            <ion-card-subtitle>Subtitle</ion-card-subtitle>
+            <ion-card-title>Title</ion-card-title>
+          </ion-card-header>
+
+          <ion-card-content>
+            The card and the header has different colors. The card should be
+            light and the header blue. It looks like the content is light.
           </ion-card-content>
         </ion-card>
       </ion-content>


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix

## What is the current behavior?
The `ion-card-header` does not take the color of the `ion-card`.
It's because the `ion-card-header` has a background and uses the variable `ion-item-background`.
Please see the issue for detailed description and demonstrations.

Issue Number: #19197


## What is the new behavior?
Now the `ion-card-header (and other card elements) takes the background color.`
See `ion-card-header.scss` and `ion-card.scss` and the test demo `item-color`.
In this demo the css variable `--ion-item-background` is set and important for this issue.

## Does this introduce a breaking change?

- [x] No

