### PR TITLE
fix(menu): menu is positioned currently on resize

### DIFF
--- a/core/src/components/menu/menu.tsx
+++ b/core/src/components/menu/menu.tsx
@@ -379,9 +379,7 @@ export class Menu implements ComponentInterface, MenuI {
     const delta = computeDelta(detail.deltaX, this._isOpen, this.isEndSide);
     const stepValue = delta / this.width;
 
-    this.animation
-
-      .progressStep(stepValue);
+    this.animation.progressStep(stepValue);
   }
 
   private onEnd(detail: GestureDetail) {
@@ -489,6 +487,10 @@ export class Menu implements ComponentInterface, MenuI {
       }
       if (this.backdropEl) {
         this.backdropEl.classList.remove(SHOW_BACKDROP);
+      }
+
+      if (this.animation) {
+        this.animation.stop();
       }
 
       // emit close event

--- a/core/src/utils/animation/animation.ts
+++ b/core/src/utils/animation/animation.ts
@@ -1031,7 +1031,7 @@ export const createAnimation = () => {
     });
 
     if (initialized) {
-      cleanUp();
+      cleanUpElements();
       initialized = false;
     }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic/issues/19203
With the old animation system, doing `transform: none` was fine, but doesn't work for Web Animations


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- explicitly stop the web animation when the animation is done and when the menu is closed
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
