### PR TITLE
fix(animation): set defaults to avoid inconsistencies

### DIFF
--- a/core/src/utils/animation/animation.ts
+++ b/core/src/utils/animation/animation.ts
@@ -292,7 +292,7 @@ export const createAnimation = () => {
     if (_fill !== undefined) { return _fill; }
     if (parentAnimation) { return parentAnimation.getFill(); }
 
-    return undefined;
+    return 'both';
   };
 
   /**
@@ -303,7 +303,7 @@ export const createAnimation = () => {
     if (_direction !== undefined) { return _direction; }
     if (parentAnimation) { return parentAnimation.getDirection(); }
 
-    return undefined;
+    return 'normal';
 
   };
 
@@ -315,7 +315,7 @@ export const createAnimation = () => {
     if (_easing !== undefined) { return _easing; }
     if (parentAnimation) { return parentAnimation.getEasing(); }
 
-    return undefined;
+    return 'linear';
   };
 
   /**
@@ -327,7 +327,7 @@ export const createAnimation = () => {
     if (_duration !== undefined) { return _duration; }
     if (parentAnimation) { return parentAnimation.getDuration(); }
 
-    return undefined;
+    return 0;
   };
 
   /**
@@ -337,7 +337,7 @@ export const createAnimation = () => {
     if (_iterations !== undefined) { return _iterations; }
     if (parentAnimation) { return parentAnimation.getIterations(); }
 
-    return undefined;
+    return 1;
   };
 
   /**
@@ -348,7 +348,7 @@ export const createAnimation = () => {
     if (_delay !== undefined) { return _delay; }
     if (parentAnimation) { return parentAnimation.getDelay(); }
 
-    return undefined;
+    return 0;
   };
 
   /**

--- a/core/src/utils/animation/test/animation.spec.ts
+++ b/core/src/utils/animation/test/animation.spec.ts
@@ -151,17 +151,17 @@ describe('Animation Class', () => {
       animation = createAnimation();
     });
     
-    it('should get undefined when easing not set', () => {
-      expect(animation.getEasing()).toEqual(undefined);
+    it('should get "linear" when easing not set', () => {
+      expect(animation.getEasing()).toEqual("linear");
     });
     
     it('should get parent easing when child easing is not set', () => {
       const childAnimation = createAnimation();
       animation
         .addAnimation(childAnimation)
-        .easing('linear');
+        .easing('ease-in-out');
       
-      expect(childAnimation.getEasing()).toEqual('linear');
+      expect(childAnimation.getEasing()).toEqual('ease-in-out');
     });
     
     it('should get prefer child easing over parent easing', () => {
@@ -185,8 +185,8 @@ describe('Animation Class', () => {
       expect(animation.getEasing()).toEqual('ease-in-out');
     });
     
-    it('should get undefined when duration not set', () => {
-      expect(animation.getDuration()).toEqual(undefined);
+    it('should get 0 when duration not set', () => {
+      expect(animation.getDuration()).toEqual(0);
     });
     
     it('should get parent duration when child duration is not set', () => {
@@ -209,8 +209,8 @@ describe('Animation Class', () => {
       expect(childAnimation.getDuration()).toEqual(500);
     });
     
-    it('should get undefined when delay not set', () => {
-      expect(animation.getDelay()).toEqual(undefined);
+    it('should get 0 when delay not set', () => {
+      expect(animation.getDelay()).toEqual(0);
     });
     
     it('should get parent delay when child delay is not set', () => {
@@ -233,8 +233,8 @@ describe('Animation Class', () => {
       expect(childAnimation.getDelay()).toEqual(500);
     });
     
-    it('should get undefined when iterations not set', () => {
-      expect(animation.getIterations()).toEqual(undefined);
+    it('should get 1 when iterations not set', () => {
+      expect(animation.getIterations()).toEqual(1);
     });
     
     it('should get parent iterations when child iterations is not set', () => {
@@ -257,17 +257,17 @@ describe('Animation Class', () => {
       expect(childAnimation.getIterations()).toEqual(2);
     });    
     
-    it('should get undefined when fill not set', () => {
-      expect(animation.getFill()).toEqual(undefined);
+    it('should get "both" when fill not set', () => {
+      expect(animation.getFill()).toEqual("both");
     });
     
     it('should get parent fill when child fill is not set', () => {
       const childAnimation = createAnimation();
       animation
         .addAnimation(childAnimation)
-        .fill('both');
+        .fill('forwards');
       
-      expect(childAnimation.getFill()).toEqual('both');
+      expect(childAnimation.getFill()).toEqual('forwards');
     });
     
     it('should get prefer child fill over parent fill', () => {
@@ -281,8 +281,8 @@ describe('Animation Class', () => {
       expect(childAnimation.getFill()).toEqual('none');
     });
     
-    it('should get undefined when direction not set', () => {
-      expect(animation.getDirection()).toEqual(undefined);
+    it('should get "normal" when direction not set', () => {
+      expect(animation.getDirection()).toEqual('normal');
     });
     
     it('should get parent direction when child direction is not set', () => {

--- a/core/src/utils/animation/test/multiple/index.html
+++ b/core/src/utils/animation/test/multiple/index.html
@@ -123,6 +123,7 @@
     
     rootAnimation
       .addAnimation([animationA, animationB, animationC])
+      .fill('none')
       .onFinish(() => {
         const ev = new CustomEvent('ionAnimationFinished', { detail: 'AnimationRootFinished' });
         squareA.dispatchEvent(ev);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There are a few inconsistencies between Web and CSS Animations. For example, the default easing in css animations is `ease`, but in web animations the default easing is `linear`


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Set defaults to avoid any inconsistencies between web and css anims

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
