### PR TITLE
perf(animation): avoid ngzone with requestAnimationFrame

### DIFF
--- a/core/src/components/menu/test/basic/index.html
+++ b/core/src/components/menu/test/basic/index.html
@@ -102,7 +102,7 @@
     }
 
     async  function openEnd() {
-      awaitmenuCtrl.open('end');
+      await menuCtrl.open('end');
     }
 
     async function openCustom() {

--- a/core/src/utils/animation/animation.ts
+++ b/core/src/utils/animation/animation.ts
@@ -968,10 +968,8 @@ export const createAnimation = () => {
          */
         raf(() => {
           clearCSSAnimationPlayState();
-          raf(() => {
-              animationFinish();
-            });
-          });
+          raf(animationFinish);
+        });
       });
     }
   };

--- a/core/src/utils/animation/animation.ts
+++ b/core/src/utils/animation/animation.ts
@@ -1,5 +1,7 @@
 // TODO: Add more tests. until then, be sure to manually test menu and swipe to go back/routing transitions
 
+import { raf } from '../helpers';
+
 import { Animation, AnimationDirection, AnimationFill, AnimationOnFinishCallback, AnimationOnFinishOptions } from './animation-interface';
 import { addClassToArray, animationEnd, createKeyframeStylesheet, generateKeyframeName, generateKeyframeRules, removeStyleProperty, setStyleProperty } from './animation-utils';
 
@@ -125,7 +127,7 @@ export const createAnimation = () => {
       webAnimations.length = 0;
     } else {
       elements.forEach(element => {
-        requestAnimationFrame(() => {
+        raf(() => {
           removeStyleProperty(element, 'animation-name');
           removeStyleProperty(element, 'animation-duration');
           removeStyleProperty(element, 'animation-timing-function');
@@ -653,7 +655,7 @@ export const createAnimation = () => {
           setStyleProperty(element, 'animation-name', `${stylesheet.id}-alt`);
         }
 
-        requestAnimationFrame(() => {
+        raf(() => {
           setStyleProperty(element, 'animation-name', stylesheet.id || null);
         });
       }
@@ -734,7 +736,7 @@ export const createAnimation = () => {
 
   const updateCSSAnimation = (toggleAnimationName = true) => {
     elements.forEach(element => {
-      requestAnimationFrame(() => {
+      raf(() => {
         setStyleProperty(element, 'animation-name', keyframeName || null);
         setStyleProperty(element, 'animation-duration', (getDuration() !== undefined) ? `${getDuration()}ms` : null);
         setStyleProperty(element, 'animation-timing-function', getEasing() || null);
@@ -753,7 +755,7 @@ export const createAnimation = () => {
           setStyleProperty(element, 'animation-name', `${keyframeName}-alt`);
         }
 
-        requestAnimationFrame(() => {
+        raf(() => {
           setStyleProperty(element, 'animation-name', keyframeName || null);
         });
       });
@@ -928,7 +930,7 @@ export const createAnimation = () => {
 
     elements.forEach(element => {
       if (_keyframes.length > 0) {
-        requestAnimationFrame(() => {
+        raf(() => {
           setStyleProperty(element, 'animation-play-state', 'running');
         });
       }
@@ -964,9 +966,9 @@ export const createAnimation = () => {
          *
          * TODO: Is there a cleaner way to do this?
          */
-        requestAnimationFrame(() => {
+        raf(() => {
           clearCSSAnimationPlayState();
-          requestAnimationFrame(() => {
+          raf(() => {
               animationFinish();
             });
           });

--- a/core/src/utils/helpers.ts
+++ b/core/src/utils/helpers.ts
@@ -2,6 +2,23 @@ import { EventEmitter } from '@stencil/core';
 
 import { Side } from '../interface';
 
+declare const __zone_symbol__requestAnimationFrame: any;
+declare const requestAnimationFrame: any;
+
+/**
+ * Patched version of requestAnimationFrame that avoids ngzone
+ * Use only when you know ngzone should not run
+ */
+export const raf = (h: any) => {
+  if (typeof __zone_symbol__requestAnimationFrame === 'function') {
+    return __zone_symbol__requestAnimationFrame(h);
+  }
+  if (typeof requestAnimationFrame === 'function') {
+    return requestAnimationFrame(h);
+  }
+  return setTimeout(h);
+};
+
 export const rIC = (callback: () => void) => {
   if ('requestIdleCallback' in window) {
     (window as any).requestIdleCallback(callback);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Our raf calls did were not using the patched version of raf, so ngzone would have run during animations causing a lot of jank


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- updated animations to use a patched version of raf that prevents ngzone from being called

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
