### PR TITLE
docs: publish Stencil JsonDocs types with @ionic/docs

### DIFF
--- a/core/stencil.config.ts
+++ b/core/stencil.config.ts
@@ -94,6 +94,16 @@ export const config: Config = {
       file: '../docs/core.json'
     },
     {
+      type: 'copy',
+      dir: '../docs',
+      copy: [
+        {
+          src: '../node_modules/@stencil/core/dist/declarations/docs.d.ts',
+          dest: 'types.d.ts'
+        }
+      ]
+    },
+    {
       type: 'dist-hydrate-script'
     },
     apiSpecGenerator({

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,2 @@
 core.json
+types.d.ts

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,8 @@
   "description": "Pre-packaged API documentation for the Ionic docs.",
   "main": "core.json",
   "files": [
-    "core.json"
+    "core.json",
+    "types.d.ts"
   ],
   "author": "Ionic Team",
   "license": "MIT",


### PR DESCRIPTION
This adds a copy task to the Stencil config that copies Stencil's `JsonDocs` types to the docs package directory as `types.d.ts` and adds that to the files array in `package.json` so it can be published.

```js
{
  type: 'copy',
  dir: '../docs',
  copy: [
    {
      src: '../node_modules/@stencil/core/dist/declarations/docs.d.ts',
      dest: 'types.d.ts'
    }
  ]
}
```

The idea is to bundle the types as they were when the package was published so they can be used alongside the JSON data.