### PR TITLE
fix(md): fix flicker when navigating back in MD mode on certain Android devices

### DIFF
--- a/core/src/utils/transition/md.transition.ts
+++ b/core/src/utils/transition/md.transition.ts
@@ -50,6 +50,7 @@ export const mdTransitionAnimation = (_: HTMLElement, opts: TransitionOptions): 
     const leavingPage = createAnimation();
     leavingPage
       .addElement(getIonPageElement(leavingEl))
+      .afterStyles({ 'display': 'none' })
       .fromTo('transform', `translateY(${CENTER})`, `translateY(${OFF_BOTTOM})`)
       .fromTo('opacity', 1, 0);
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic/issues/19491


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The leaving view, when navigating back, has `display: none` applied to it at the end of the transition, ensuring that there is no flicker between when the animation is destroyed and when the view is removed from the DOM.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
