### PR TITLE
feat(textarea): add max-height css variable

### DIFF
--- a/core/api.txt
+++ b/core/api.txt
@@ -1192,6 +1192,7 @@ ion-textarea,event,ionInput,KeyboardEvent,true
 ion-textarea,css-prop,--background
 ion-textarea,css-prop,--border-radius
 ion-textarea,css-prop,--color
+ion-textarea,css-prop,--max-height
 ion-textarea,css-prop,--padding-bottom
 ion-textarea,css-prop,--padding-end
 ion-textarea,css-prop,--padding-start

--- a/core/src/components/textarea/readme.md
+++ b/core/src/components/textarea/readme.md
@@ -253,6 +253,7 @@ Type: `Promise<void>`
 | `--background`              | Background of the textarea                                                                                  |
 | `--border-radius`           | Border radius of the textarea                                                                               |
 | `--color`                   | Color of the text                                                                                           |
+| `--max-height`              | Maximum height of the textarea                                                                              |
 | `--padding-bottom`          | Bottom padding of the textarea                                                                              |
 | `--padding-end`             | Right padding if direction is left-to-right, and left padding if direction is right-to-left of the textarea |
 | `--padding-start`           | Left padding if direction is left-to-right, and right padding if direction is right-to-left of the textarea |

--- a/core/src/components/textarea/textarea.scss
+++ b/core/src/components/textarea/textarea.scss
@@ -20,6 +20,7 @@
    * @prop --padding-end: Right padding if direction is left-to-right, and left padding if direction is right-to-left of the textarea
    * @prop --padding-bottom: Bottom padding of the textarea
    * @prop --padding-start: Left padding if direction is left-to-right, and right padding if direction is right-to-left of the textarea
+   * @prop --max-height: Maximum height of the textarea
    */
   --background: initial;
   --color: initial;
@@ -32,6 +33,7 @@
   --padding-bottom: 0;
   --padding-start: 0;
   --border-radius: 0;
+  --max-height: 100%;
 
   display: block;
   position: relative;
@@ -84,7 +86,7 @@
 
   width: 100%;
   max-width: 100%;
-  max-height: 100%;
+  max-height: var(--max-height);
 
   border: 0;
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When autoGrow is true, you cannot limit correctly the height of the `ion-textarea`. It grows forever as you type.

Issue Number: can relate to #18543


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Setting `--max-height` css variable on a `ion-textarea` stops growing on the desired height.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
