### PR TITLE
feat(fab-button): add close icon size css variable

### DIFF
--- a/core/api.txt
+++ b/core/api.txt
@@ -359,6 +359,7 @@ ion-fab-button,css-prop,--border-radius
 ion-fab-button,css-prop,--border-style
 ion-fab-button,css-prop,--border-width
 ion-fab-button,css-prop,--box-shadow
+ion-fab-button,css-prop,--close-icon-font-size
 ion-fab-button,css-prop,--color
 ion-fab-button,css-prop,--color-activated
 ion-fab-button,css-prop,--color-focused

--- a/core/src/components/fab-button/fab-button.ios.scss
+++ b/core/src/components/fab-button/fab-button.ios.scss
@@ -13,6 +13,7 @@
   --color-focused: var(--color-activated);
   --box-shadow: #{$fab-ios-box-shadow};
   --transition: #{$fab-ios-transition};
+  --close-icon-font-size: #{$fab-ios-icon-font-size};
 }
 
 :host(.activated) {
@@ -21,9 +22,12 @@
   --transition: #{$fab-ios-transition-activated};
 }
 
-::slotted(ion-icon),
-.close-icon {
+::slotted(ion-icon) {
   font-size: $fab-ios-icon-font-size;
+}
+
+.close-icon {
+  font-size: var(--close-icon-font-size);
 }
 
 // FAB buttons in a list

--- a/core/src/components/fab-button/fab-button.md.scss
+++ b/core/src/components/fab-button/fab-button.md.scss
@@ -19,15 +19,19 @@
     opacity 15ms linear 30ms,
     transform 270ms cubic-bezier(0, 0, .2, 1) 0ms
   };
+  --close-icon-font-size: #{$fab-md-icon-font-size};
 }
 
 :host(.activated) {
   --box-shadow: #{$fab-md-box-shadow-activated};
 }
 
-::slotted(ion-icon),
-.close-icon {
+::slotted(ion-icon) {
   font-size: $fab-md-icon-font-size;
+}
+
+.close-icon {
+  font-size: var(--close-icon-font-size);
 }
 
 

--- a/core/src/components/fab-button/fab-button.scss
+++ b/core/src/components/fab-button/fab-button.scss
@@ -17,6 +17,8 @@
    *
    * @prop --transition: Transition of the button
    *
+   * @prop --close-icon-font-size: Font size of the close button icon
+   *
    * @prop --border-radius: Border radius of the button
    * @prop --border-width: Border width of the button
    * @prop --border-style: Border style of the button

--- a/core/src/components/fab-button/readme.md
+++ b/core/src/components/fab-button/readme.md
@@ -136,6 +136,7 @@ export const FabButtonExample: React.FC = () => (
 | `--border-style`         | Border style of the button                                                                                |
 | `--border-width`         | Border width of the button                                                                                |
 | `--box-shadow`           | Box shadow of the button                                                                                  |
+| `--close-icon-font-size` | Font size of the close button icon                                                                        |
 | `--color`                | Text color of the button                                                                                  |
 | `--color-activated`      | Text color of the button when pressed                                                                     |
 | `--color-focused`        | Text color of the button when focused with the tab key                                                    |


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The close icon on a fab button gets a default font-size and cannot be targeted (because of shadow DOM) to change it.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
This PR introduces a new css variable (`--close-icon-font-size`) which targets the close icon size, and defaults to the previous md and ios values.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


