### PR TITLE
feat(react): Allow to use HashRouter in IonReactRouter component

### DIFF
--- a/packages/react-router/src/ReactRouter/Router.tsx
+++ b/packages/react-router/src/ReactRouter/Router.tsx
@@ -287,7 +287,7 @@ RouteManagerWithRouter.displayName = 'RouteManager';
 
 type IonReactRouterProps = BrowserRouterProps & HashRouterProps & {
   useHashRouter?: boolean;
-}
+};
 
 export class IonReactRouter extends React.Component<IonReactRouterProps> {
   render() {

--- a/packages/react-router/src/ReactRouter/Router.tsx
+++ b/packages/react-router/src/ReactRouter/Router.tsx
@@ -2,7 +2,7 @@ import { NavDirection } from '@ionic/core';
 import { RouterDirection } from '@ionic/react';
 import { Action as HistoryAction, Location as HistoryLocation, UnregisterCallback } from 'history';
 import React from 'react';
-import { BrowserRouter, BrowserRouterProps, RouteComponentProps, matchPath, withRouter } from 'react-router-dom';
+import { BrowserRouter, BrowserRouterProps, HashRouter, HashRouterProps, RouteComponentProps, matchPath, withRouter } from 'react-router-dom';
 
 import { generateId } from '../utils';
 
@@ -285,13 +285,26 @@ class RouteManager extends React.Component<RouteComponentProps, RouteManagerStat
 const RouteManagerWithRouter = withRouter(RouteManager);
 RouteManagerWithRouter.displayName = 'RouteManager';
 
-export class IonReactRouter extends React.Component<BrowserRouterProps> {
+type IonReactRouterProps = BrowserRouterProps & HashRouterProps & {
+  useHashRouter?: boolean;
+}
+
+export class IonReactRouter extends React.Component<IonReactRouterProps> {
   render() {
-    const { children, ...props } = this.props;
-    return (
-      <BrowserRouter {...props}>
-        <RouteManagerWithRouter>{children}</RouteManagerWithRouter>
-      </BrowserRouter>
-    );
+    const { useHashRouter, children, ...props } = this.props;
+
+    if (useHashRouter === true) {
+      return (
+        <HashRouter {...props}>
+          <RouteManagerWithRouter>{children}</RouteManagerWithRouter>
+        </HashRouter>
+      );
+    } else {
+      return (
+        <BrowserRouter {...props}>
+          <RouteManagerWithRouter>{children}</RouteManagerWithRouter>
+        </BrowserRouter>
+      );
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

By default the `IonReactRouter` uses the `BrowserRouter` component under the hood to route paths, but this can create some problems as described in this issue #19621.

## What is the new behavior?

This pull request adds a prop that lets you use `HashRouter` instead of `BrowserRouter`.

```tsx
const App: React.FC = () => (
  <IonApp>
    <IonReactRouter useHashRouter={true}>
      // ...
    </IonReactRouter>
  </IonApp>
);
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

What do you think of the name "useHashRouter"?