### PR TITLE
fix(header): avoid flicker on collapsible header load

### DIFF
--- a/core/src/components/header/header.ios.scss
+++ b/core/src/components/header/header.ios.scss
@@ -51,8 +51,8 @@
   padding-bottom: 13px;
 }
 
-ion-toolbar.in-toolbar ion-title,
-ion-toolbar.in-toolbar ion-buttons {
+.header-collapse-main ion-toolbar.in-toolbar ion-title,
+.header-collapse-main ion-toolbar.in-toolbar ion-buttons {
   transition: all 0.2s ease-in-out;
 }
 

--- a/core/src/components/header/header.tsx
+++ b/core/src/components/header/header.tsx
@@ -2,7 +2,7 @@ import { Component, ComponentInterface, Element, Host, Prop, h, readTask, writeT
 
 import { getIonMode } from '../../global/ionic-global';
 
-import { cloneElement, createHeaderIndex, handleContentScroll, handleToolbarIntersection, setHeaderActive } from './header.utils';
+import { cloneElement, createHeaderIndex, handleContentScroll, handleToolbarIntersection, setHeaderActive, setToolbarBackgroundOpacity } from './header.utils';
 /**
  * @virtualProp {"ios" | "md"} mode - The mode determines which platform styles to use.
  */
@@ -19,6 +19,7 @@ export class Header implements ComponentInterface {
   private scrollEl?: HTMLElement;
   private contentScrollCallback?: any;
   private intersectionObserver?: any;
+  private collapsibleMainHeader?: HTMLElement;
 
   @Element() el!: HTMLElement;
 
@@ -77,6 +78,11 @@ export class Header implements ComponentInterface {
       this.scrollEl.removeEventListener('scroll', this.contentScrollCallback);
       this.contentScrollCallback = undefined;
     }
+
+    if (this.collapsibleMainHeader) {
+      this.collapsibleMainHeader.classList.remove('header-collapse-main');
+      this.collapsibleMainHeader = undefined;
+    }
   }
 
   private async setupCollapsibleHeader(contentEl: HTMLIonContentElement | null, pageEl: Element | null) {
@@ -84,20 +90,20 @@ export class Header implements ComponentInterface {
 
     this.scrollEl = await contentEl.getScrollElement();
 
+    const headers = pageEl.querySelectorAll('ion-header');
+    this.collapsibleMainHeader = Array.from(headers).find((header: any) => header.collapse !== 'condense') as HTMLElement | undefined;
+
+    if (!this.collapsibleMainHeader) { return; }
+
+    const mainHeaderIndex = createHeaderIndex(this.collapsibleMainHeader);
+    const scrollHeaderIndex = createHeaderIndex(this.el);
+
+    if (!mainHeaderIndex || !scrollHeaderIndex) { return; }
+
+    setHeaderActive(mainHeaderIndex, false);
+    setToolbarBackgroundOpacity(mainHeaderIndex.toolbars[0], 0);
+
     readTask(() => {
-      const headers = pageEl.querySelectorAll('ion-header');
-      const mainHeader = Array.from(headers).find((header: any) => header.collapse !== 'condense') as HTMLElement | undefined;
-
-      if (!mainHeader || !this.scrollEl) { return; }
-
-      const mainHeaderIndex = createHeaderIndex(mainHeader);
-      const scrollHeaderIndex = createHeaderIndex(this.el);
-
-      if (!mainHeaderIndex || !scrollHeaderIndex) { return; }
-
-      setHeaderActive(mainHeaderIndex, false);
-
-      readTask(() => {
         const mainHeaderHeight = mainHeaderIndex.el.clientHeight;
 
         /**
@@ -109,20 +115,21 @@ export class Header implements ComponentInterface {
         const toolbarIntersection = (ev: any) => { handleToolbarIntersection(ev, mainHeaderIndex, scrollHeaderIndex); };
         this.intersectionObserver = new IntersectionObserver(toolbarIntersection, { threshold: [0.25, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1], rootMargin: `-${mainHeaderHeight}px 0px 0px 0px` });
         this.intersectionObserver.observe(scrollHeaderIndex.toolbars[0].el);
-      });
 
       /**
        * Handle scaling of large iOS titles and
        * showing/hiding border on last toolbar
        * in primary header
        */
-      this.contentScrollCallback = () => { handleContentScroll(this.scrollEl!, scrollHeaderIndex); };
-      this.scrollEl.addEventListener('scroll', this.contentScrollCallback);
+        this.contentScrollCallback = () => { handleContentScroll(this.scrollEl!, scrollHeaderIndex); };
+        this.scrollEl!.addEventListener('scroll', this.contentScrollCallback);
     });
 
     writeTask(() => {
       cloneElement('ion-title');
       cloneElement('ion-back-button');
+
+      this.collapsibleMainHeader!.classList.add('header-collapse-main');
     });
 
     this.collapsibleHeaderInitialized = true;

--- a/core/src/components/header/header.utils.ts
+++ b/core/src/components/header/header.utils.ts
@@ -45,7 +45,7 @@ export const createHeaderIndex = (headerEl: HTMLElement | undefined): HeaderInde
         innerTitleEl: (ionTitleEl) ? ionTitleEl.shadowRoot!.querySelector('.toolbar-title') : null,
         ionButtonsEl: Array.from(toolbar.querySelectorAll('ion-buttons')) || []
       } as ToolbarIndex;
-    }) || [[]]
+    }) || []
   } as HeaderIndex;
 };
 
@@ -60,7 +60,7 @@ export const handleContentScroll = (scrollEl: HTMLElement, scrollHeaderIndex: He
   });
 };
 
-const setToolbarBackgroundOpacity = (toolbar: ToolbarIndex, opacity: number | undefined) => {
+export const setToolbarBackgroundOpacity = (toolbar: ToolbarIndex, opacity: number | undefined) => {
   if (opacity === undefined) {
     toolbar.background.style.removeProperty('--opacity');
   } else {
@@ -124,13 +124,11 @@ export const handleToolbarIntersection = (ev: any, mainHeaderIndex: HeaderIndex,
 };
 
 export const setHeaderActive = (headerIndex: HeaderIndex, active = true) => {
-  writeTask(() => {
-    if (active) {
-      headerIndex.el.classList.remove('header-collapse-condense-inactive');
-    } else {
-      headerIndex.el.classList.add('header-collapse-condense-inactive');
-    }
-  });
+  if (active) {
+    headerIndex.el.classList.remove('header-collapse-condense-inactive');
+  } else {
+    headerIndex.el.classList.add('header-collapse-condense-inactive');
+  }
 };
 
 export const scaleLargeTitles = (toolbars: ToolbarIndex[] = [], scale = 1, transition = false) => {

--- a/core/src/components/tabs/test/basic/index.html
+++ b/core/src/components/tabs/test/basic/index.html
@@ -28,24 +28,8 @@
             <ion-title>Tab One</ion-title>
           </ion-toolbar>
         </ion-header>
-        <ion-content>
-          <ion-header collapse="condense">
-            <ion-toolbar>
-              <ion-title size="large">
-                Tab One
-              </ion-title>
-            </ion-toolbar>
-          </ion-header>
-          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
-          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
-          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
-          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
-          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
-          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
-          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
-          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
-          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
-          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
+        <ion-content class="ion-padding">
+          <h1>Tab One</h1>
           <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
           <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
         </ion-content>
@@ -57,26 +41,8 @@
             <ion-title>Tab Two</ion-title>
           </ion-toolbar>
         </ion-header>
-        <ion-content>
-          <ion-header collapse="condense">
-            <ion-toolbar>
-              <ion-title size="large">
-                Tab Two
-              </ion-title>
-            </ion-toolbar>
-          </ion-header>
-          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
-          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
-          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
-          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
-          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
-          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
-          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
-          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
-          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
-          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
-          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
-          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
+        <ion-content class="ion-padding">
+          <h1>Tab Two</h1>
         </ion-content>
       </ion-tab>
 

--- a/core/src/components/tabs/test/basic/index.html
+++ b/core/src/components/tabs/test/basic/index.html
@@ -28,8 +28,24 @@
             <ion-title>Tab One</ion-title>
           </ion-toolbar>
         </ion-header>
-        <ion-content class="ion-padding">
-          <h1>Tab One</h1>
+        <ion-content>
+          <ion-header collapse="condense">
+            <ion-toolbar>
+              <ion-title size="large">
+                Tab One
+              </ion-title>
+            </ion-toolbar>
+          </ion-header>
+          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
+          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
+          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
+          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
+          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
+          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
+          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
+          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
+          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
+          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
           <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
           <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
         </ion-content>
@@ -41,8 +57,26 @@
             <ion-title>Tab Two</ion-title>
           </ion-toolbar>
         </ion-header>
-        <ion-content class="ion-padding">
-          <h1>Tab Two</h1>
+        <ion-content>
+          <ion-header collapse="condense">
+            <ion-toolbar>
+              <ion-title size="large">
+                Tab Two
+              </ion-title>
+            </ion-toolbar>
+          </ion-header>
+          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
+          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
+          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
+          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
+          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
+          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
+          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
+          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
+          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
+          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
+          <ion-button expand="block" onclick="updateBadgeCount()">Update Badge Count</ion-button>
+          <ion-button color="secondary" expand="block" onclick="updateBadgeColor()">Update Badge Color</ion-button>
         </ion-content>
       </ion-tab>
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The main header had a transition always applied (even if not using collapsible header). For collapsible headers, this caused the main title/buttons to appear briefly before fading out which was a bit jarring.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

I made it so that the transition is only applied a) for the collapsible header and b) after the buttons/title have already been hidden

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
