### PR TITLE
fix(note): fix ion-note on ion-item with multiple lines

### DIFF
--- a/core/src/components/item/item.md.scss
+++ b/core/src/components/item/item.md.scss
@@ -156,7 +156,7 @@
 ::slotted(ion-note) {
   @include margin(0);
 
-  align-self: flex-start;
+  align-self: center;
 
   font-size: $item-md-note-slot-font-size;
 }

--- a/core/src/components/item/item.md.vars.scss
+++ b/core/src/components/item/item.md.vars.scss
@@ -162,7 +162,7 @@ $item-md-label-slot-end-margin-start:       $item-md-label-slot-end-margin-end !
 $item-md-note-slot-font-size:               11px !default;
 
 /// @prop - Padding top for a note in the start/end slot
-$item-md-note-slot-padding-top:             18px !default;
+$item-md-note-slot-padding-top:             10px !default;
 
 /// @prop - Padding end for a note in the start/end slot
 $item-md-note-slot-padding-end:             0 !default;

--- a/core/src/components/note/test/basic/index.html
+++ b/core/src/components/note/test/basic/index.html
@@ -73,6 +73,15 @@
           <ion-note slot="end" color="dark">99</ion-note>
         </ion-item>
 
+        <ion-item >
+          <ion-label>
+            Multiple lines
+            <p>Line 1</p>
+            <p>Line 2</p>
+          </ion-label>
+          <ion-note slot="end">Note</ion-note>
+        </ion-item>
+
         <ion-item onclick="toggleColor()">
           <ion-note id="toggleColor" slot="end" color="primary">primary</ion-note>
           <ion-label>Dynamic Note Color (toggle)</ion-label>


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

When ion-label and ion-note coexist, if ion-label is displayed in multiple lines, the ion-note display will be offset.

Issue Number: #19689 


## What is the new behavior?

- Now de ion-note is vertical alignment.
- Regardless of the number of lines or the size of the ion-label.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

