### PR TITLE
fix(menu): Check if contentId's match

### DIFF
--- a/core/src/components/menu/menu.tsx
+++ b/core/src/components/menu/menu.tsx
@@ -215,8 +215,12 @@ AFTER:
 
   @Listen('ionSplitPaneVisible', { target: 'body' })
   onSplitPaneChanged(ev: CustomEvent) {
-    this.isPaneVisible = ev.detail.isPane(this.el);
-    this.updateState();
+    const eventElement: any = ev.target;
+    // Check if the contentId of the side-pane equals the contentId of this menu
+    if (eventElement.contentId === this.contentId) {
+      this.isPaneVisible = ev.detail.isPane(this.el);
+      this.updateState();
+    }
   }
 
   @Listen('click', { capture: true })


### PR DESCRIPTION
## Pull request

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes


## What is the current behavior?
When multiple split-panes/menus are in the DOM, the last loaded split-pane is dominant and will disable (the visible value) other menus.

Issue Number: #18974

## What is the new behavior?
When a split-pane changes its state the menu will verify if it has the same contentId.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
When loading a new page enable the menu: 
```javascript
ionViewWillEnter() {
    this.menuController.enable(true,'myMenuId');
  }
```