### PR TITLE
handle asynchronous issues with loading indicator

### DIFF
--- a/packages/react/src/components/createControllerComponent.tsx
+++ b/packages/react/src/components/createControllerComponent.tsx
@@ -54,7 +54,7 @@ export const createControllerComponent = <OptionsType extends object, OverlayTyp
 
     async present(prevProps?: Props) {
       const { isOpen, onDidDismiss, ...cProps } = this.props;
-      let overlay = this.overlay
+      let overlay = this.overlay;
       if (!overlay) {
         overlay = this.overlay = await controller.create({
           ...cProps as any
@@ -63,7 +63,7 @@ export const createControllerComponent = <OptionsType extends object, OverlayTyp
       attachProps(overlay, {
         [dismissEventName]: onDidDismiss
       }, prevProps);
-      if (this.props.isOpen) {
+      if (this.props.isOpen === true) {
         await overlay.present();
       }
     }

--- a/packages/react/src/components/createControllerComponent.tsx
+++ b/packages/react/src/components/createControllerComponent.tsx
@@ -54,13 +54,18 @@ export const createControllerComponent = <OptionsType extends object, OverlayTyp
 
     async present(prevProps?: Props) {
       const { isOpen, onDidDismiss, ...cProps } = this.props;
-      const overlay = this.overlay = await controller.create({
-        ...cProps as any
-      });
+      let overlay = this.overlay
+      if (!overlay) {
+        overlay = this.overlay = await controller.create({
+          ...cProps as any
+        });
+      }
       attachProps(overlay, {
         [dismissEventName]: onDidDismiss
       }, prevProps);
-      await overlay.present();
+      if (this.props.isOpen) {
+        await overlay.present();
+      }
     }
 
     render(): null {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures

It doesn't seem like there are any relevant docs to address. I am struggling with how to test for this, and the existing tests seem fairly limited but they do still pass. If you have suggestions in this area I'm happy to work on it.

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #19755


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
-The overlay will now only be created if it doesn't already exist
- And it will only be shown if it hasn't already been dismissed

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
