### PR TITLE
fix(angular): update ng-add schematic to use the project name

### DIFF
--- a/angular/src/schematics/add/index.ts
+++ b/angular/src/schematics/add/index.ts
@@ -69,29 +69,29 @@ function addIonicons(): Rule {
   };
 }
 
-function addIonicBuilder(): Rule {
+function addIonicBuilder(project: string): Rule {
   return (host: Tree) => {
     addArchitectBuilder(host, 'ionic-cordova-serve', {
       builder: '@ionic/angular-toolkit:cordova-serve',
       options: {
-        cordovaBuildTarget: 'app:ionic-cordova-build',
-        devServerTarget: 'app:serve'
+        cordovaBuildTarget: `${project}:ionic-cordova-build`,
+        devServerTarget: `${project}:serve`
       },
       configurations: {
         production: {
-          cordovaBuildTarget: 'app:ionic-cordova-build:production',
-          devServerTarget: 'app:serve:production'
+          cordovaBuildTarget: `${project}:ionic-cordova-build:production`,
+          devServerTarget: `${project}:serve:production`
         }
       }
     });
     addArchitectBuilder(host, 'ionic-cordova-build', {
       builder: '@ionic/angular-toolkit:cordova-build',
       options: {
-        browserTarget: 'app:build'
+        browserTarget: `${project}:build`
       },
       configurations: {
         production: {
-          browserTarget: 'app:build:production'
+          browserTarget: `${project}:build:production`
         }
       }
     });
@@ -128,7 +128,7 @@ export default function ngAdd(options: IonAddOptions): Rule {
       addIonicAngularToPackageJson(),
       addIonicAngularToolkitToPackageJson(),
       addIonicAngularModuleToAppModule(sourcePath),
-      addIonicBuilder(),
+      addIonicBuilder(options.project),
       addIonicStyles(),
       addIonicons(),
       mergeWith(rootTemplateSource),


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
The `ng add @ionic/angular` command generates an invalid `angular.json` file.

Issue Number: ionic-team/ionic-cli#4191


## What is the new behavior?

- The `ng add @ionic/angular` command generates a valid `angular.json` file.
- And with added `ionic.config.json`, `config.xml` and `resources`, you can actually build the application and run it inside an emulator:

![image](https://user-images.githubusercontent.com/2186426/67644701-8bbff080-f92c-11e9-9b4e-7d9f63b7b189.png)


## Does this introduce a breaking change?

- [ ] Yes
- [x] No
