### PR TITLE
fix(textarea): properly adjust auto-grow textarea height on scrolled content

### DIFF
--- a/core/src/components/textarea/textarea.tsx
+++ b/core/src/components/textarea/textarea.tsx
@@ -21,6 +21,7 @@ export class Textarea implements ComponentInterface {
   private nativeInput?: HTMLTextAreaElement;
   private inputId = `ion-input-${textareaIds++}`;
   private didBlurAfterEdit = false;
+  private textareaWrapper?: HTMLElement;
 
   @Element() el!: HTMLElement;
 
@@ -191,13 +192,15 @@ export class Textarea implements ComponentInterface {
     this.runAutoGrow();
   }
 
-  // TODO: performance hit, this cause layout thrashing
   private runAutoGrow() {
     const nativeInput = this.nativeInput;
     if (nativeInput && this.autoGrow) {
       readTask(() => {
-        nativeInput.style.height = 'inherit';
+        nativeInput.style.height = 'auto';
         nativeInput.style.height = nativeInput.scrollHeight + 'px';
+        if (this.textareaWrapper) {
+          this.textareaWrapper.style.height = nativeInput.scrollHeight + 'px';
+        }
       });
     }
   }
@@ -310,29 +313,34 @@ export class Textarea implements ComponentInterface {
           [mode]: true,
         }}
       >
-        <textarea
-          class="native-textarea"
-          ref={el => this.nativeInput = el}
-          autoCapitalize={this.autocapitalize}
-          autoFocus={this.autofocus}
-          disabled={this.disabled}
-          maxLength={this.maxlength}
-          minLength={this.minlength}
-          name={this.name}
-          placeholder={this.placeholder || ''}
-          readOnly={this.readonly}
-          required={this.required}
-          spellCheck={this.spellcheck}
-          cols={this.cols}
-          rows={this.rows}
-          wrap={this.wrap}
-          onInput={this.onInput}
-          onBlur={this.onBlur}
-          onFocus={this.onFocus}
-          onKeyDown={this.onKeyDown}
+        <div
+          class="textarea-wrapper"
+          ref={el => this.textareaWrapper = el}
         >
-          {value}
-        </textarea>
+          <textarea
+            class="native-textarea"
+            ref={el => this.nativeInput = el}
+            autoCapitalize={this.autocapitalize}
+            autoFocus={this.autofocus}
+            disabled={this.disabled}
+            maxLength={this.maxlength}
+            minLength={this.minlength}
+            name={this.name}
+            placeholder={this.placeholder || ''}
+            readOnly={this.readonly}
+            required={this.required}
+            spellCheck={this.spellcheck}
+            cols={this.cols}
+            rows={this.rows}
+            wrap={this.wrap}
+            onInput={this.onInput}
+            onBlur={this.onBlur}
+            onFocus={this.onFocus}
+            onKeyDown={this.onKeyDown}
+          >
+            {value}
+          </textarea>
+        </div>
       </Host>
     );
   }


### PR DESCRIPTION
Remove setting the nativeInput height to 'initial' before resetting it to scrollHeight in Textarea.runAutoGrow

closes #19193

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?

Issue Number: #19193

## What is the new behavior?

When adding text into an autoGrow textarea, the browser window (or scroll element) is no longer automatically scrolled to the top of the textarea

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

As far as I know, this doesn't introduce any breaking change. I wasn't sure how to add automated tests for this, but I'd be happy to take care of it if someone were able to point me in the right direction.

The function that I changed had the following comment above it: `// TODO: performance hit, this cause layout thrashing` so apparently this is a known issue, at least to someone.

Debugging locally, removing the single line `nativeInput.style.height = 'inherit'` before updating the element height to the scroll height fixed the problem. This seems to easy though, so maybe Im missing something? I wasn't sure why the height was being set to `'inherit'` in the first place.

# Update

This PR has since been updated with a proper fix, which is reflected in the current state of the commit for this PR. See [this comment](https://github.com/ionic-team/ionic/pull/19776#issuecomment-559210927) below.

I ran a git blame and this was the output:
```
3cdab10aa0 core/src/components/textarea/textarea.tsx          (Brandy Carney      2019-04-24 12:33:22 -0400 193)
26e6d6f115 core/src/components/textarea/textarea.tsx          (Manu MA            2019-07-17 19:23:13 +0200 194)   // TODO: performance hit, this cause layout thrashing
cc8678ad58 core/src/components/textarea/textarea.tsx          (Adam LaCombe       2019-05-07 16:52:24 -0400 195)   private runAutoGrow() {
34dfc3ce98 core/src/components/textarea/textarea.tsx          (Manu MA            2019-06-23 11:26:42 +0200 196)     const nativeInput = this.nativeInput;
34dfc3ce98 core/src/components/textarea/textarea.tsx          (Manu MA            2019-06-23 11:26:42 +0200 197)     if (nativeInput && this.autoGrow) {
34dfc3ce98 core/src/components/textarea/textarea.tsx          (Manu MA            2019-06-23 11:26:42 +0200 198)       readTask(() => {
26e6d6f115 core/src/components/textarea/textarea.tsx          (Manu MA            2019-07-17 19:23:13 +0200 199)         nativeInput.style.height = 'inherit';
34dfc3ce98 core/src/components/textarea/textarea.tsx          (Manu MA            2019-06-23 11:26:42 +0200 200)         nativeInput.style.height = nativeInput.scrollHeight + 'px';
34dfc3ce98 core/src/components/textarea/textarea.tsx          (Manu MA            2019-06-23 11:26:42 +0200 201)       });
cc8678ad58 core/src/components/textarea/textarea.tsx          (Adam LaCombe       2019-05-07 16:52:24 -0400 202)     }
cc8678ad58 core/src/components/textarea/textarea.tsx          (Adam LaCombe       2019-05-07 16:52:24 -0400 203)   }
```
