### PR TITLE
check for component unmount

### DIFF
--- a/packages/react/src/components/createControllerComponent.tsx
+++ b/packages/react/src/components/createControllerComponent.tsx
@@ -23,6 +23,7 @@ export const createControllerComponent = <OptionsType extends object, OverlayTyp
 
   return class extends React.Component<Props> {
     overlay?: OverlayType;
+    isUnmounted = false;
 
     constructor(props: Props) {
       super(props);
@@ -40,6 +41,7 @@ export const createControllerComponent = <OptionsType extends object, OverlayTyp
     }
 
     componentWillUnmount() {
+      this.isUnmounted = true;
       if (this.overlay) { this.overlay.dismiss(); }
     }
 
@@ -63,8 +65,9 @@ export const createControllerComponent = <OptionsType extends object, OverlayTyp
       attachProps(overlay, {
         [dismissEventName]: onDidDismiss
       }, prevProps);
-      // Check isOpen again since the value could of changed during the async call to controller.create
-      if (this.props.isOpen === true) {
+      // Check isOpen again since the value could have changed during the async call to controller.create
+      // It's also possible for the component to have become unmounted.
+      if (this.props.isOpen === true && this.isUnmounted === false) {
         await overlay.present();
       }
     }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
IonLoading fails to disappear under some special circumstances where it is unmounted during the creation of its overlay.
https://github.com/ionic-team/ionic/issues/19859

Issue Number: 19859


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
The controller component will now check to see if it has been unmounted before displaying itself.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Based on [this stackoverflow thread](https://stackoverflow.com/questions/39767482/is-there-a-way-to-check-if-the-react-component-is-unmounted) I wasn't entirely sure what was the best way to track the state of whether the component is mounted. This way seems straightforward enough, but if you want to suggest another way then I'm happy to make a change here.

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
