### PR TITLE
fix(react-router): clone ViewItem when a location change returns a ViewItem already in the history (#19891)

### DIFF
--- a/packages/react-router/src/ReactRouter/Router.tsx
+++ b/packages/react-router/src/ReactRouter/Router.tsx
@@ -97,19 +97,25 @@ class RouteManager extends React.Component<RouteComponentProps, RouteManagerStat
     const viewStackKeys = viewStacks.getKeys();
 
     viewStackKeys.forEach(key => {
-      const { view: _enteringView, viewStack: enteringViewStack, match } = viewStacks.findViewInfoByLocation(location, key);
-      if (!_enteringView || !enteringViewStack) {
+      const { view: stackEnteringView, viewStack: enteringViewStack, match } = viewStacks.findViewInfoByLocation(location, key);
+      if (!stackEnteringView || !enteringViewStack) {
         return;
       }
 
-      const enteringView = (!_enteringView.location) || (_enteringView.location && _enteringView.location === location.pathname)
-        ? _enteringView
+      /**
+       * if stackEnteringView already has a location and it is different from the current location,
+       * make a fresh clone of the view and add it to the stack. This ensures that if the same view
+       * is selected because the match rule has some wildcards, a separate view is created for
+       * each different location matching the same view
+       */
+      const enteringView = (!stackEnteringView.location) || (stackEnteringView.location && stackEnteringView.location === location.pathname)
+        ? stackEnteringView
         : {
           id: generateId(),
           key: generateId(),
-          route: _enteringView.route,
+          route: stackEnteringView.route,
           routeData: {
-            ..._enteringView.routeData,
+            ...stackEnteringView.routeData,
             match
           },
           mount: true,
@@ -117,7 +123,7 @@ class RouteManager extends React.Component<RouteComponentProps, RouteManagerStat
           isIonRoute: false
         } as ViewItem<IonRouteData>;
 
-      if (_enteringView !== enteringView) {
+      if (stackEnteringView !== enteringView) {
         enteringViewStack.views.push(enteringView);
       }
       enteringView.location = location.pathname;

--- a/packages/react-router/src/ReactRouter/Router.tsx
+++ b/packages/react-router/src/ReactRouter/Router.tsx
@@ -115,13 +115,12 @@ class RouteManager extends React.Component<RouteComponentProps, RouteManagerStat
           mount: true,
           show: false,
           isIonRoute: false
-        } as ViewItem<IonRouteData>
+        } as ViewItem<IonRouteData>;
 
       if (_enteringView !== enteringView) {
         enteringViewStack.views.push(enteringView);
       }
-      enteringView.location = location.pathname
-
+      enteringView.location = location.pathname;
 
       leavingView = viewStacks.findViewInfoById(this.activeIonPageId).view;
 

--- a/packages/react-router/src/ReactRouter/Router.tsx
+++ b/packages/react-router/src/ReactRouter/Router.tsx
@@ -97,10 +97,32 @@ class RouteManager extends React.Component<RouteComponentProps, RouteManagerStat
     const viewStackKeys = viewStacks.getKeys();
 
     viewStackKeys.forEach(key => {
-      const { view: enteringView, viewStack: enteringViewStack, match } = viewStacks.findViewInfoByLocation(location, key);
-      if (!enteringView || !enteringViewStack) {
+      const { view: _enteringView, viewStack: enteringViewStack, match } = viewStacks.findViewInfoByLocation(location, key);
+      if (!_enteringView || !enteringViewStack) {
         return;
       }
+
+      const enteringView = (!_enteringView.location) || (_enteringView.location && _enteringView.location === location.pathname)
+        ? _enteringView
+        : {
+          id: generateId(),
+          key: generateId(),
+          route: _enteringView.route,
+          routeData: {
+            ..._enteringView.routeData,
+            match
+          },
+          mount: true,
+          show: false,
+          isIonRoute: false
+        } as ViewItem<IonRouteData>
+
+      if (_enteringView !== enteringView) {
+        enteringViewStack.views.push(enteringView);
+      }
+      enteringView.location = location.pathname
+
+
       leavingView = viewStacks.findViewInfoById(this.activeIonPageId).view;
 
       if (enteringView.isIonRoute) {

--- a/packages/react-router/src/ReactRouter/ViewItem.ts
+++ b/packages/react-router/src/ReactRouter/ViewItem.ts
@@ -27,5 +27,5 @@ export interface ViewItem<RouteData = any> {
   /**
    * location of the view
    */
-  location?: string
+  location?: string;
 }

--- a/packages/react-router/src/ReactRouter/ViewItem.ts
+++ b/packages/react-router/src/ReactRouter/ViewItem.ts
@@ -23,4 +23,9 @@ export interface ViewItem<RouteData = any> {
    * An IonRoute is a Route that contains an IonPage. Only IonPages participate in transition and lifecycle events.
    */
   isIonRoute: boolean;
+
+  /**
+   * location of the view
+   */
+  location?: string
 }

--- a/packages/react-router/src/ReactRouter/ViewStacks.ts
+++ b/packages/react-router/src/ReactRouter/ViewStacks.ts
@@ -58,7 +58,7 @@ export class ViewStacks {
         path: v.routeData.childProps.path || v.routeData.childProps.from,
         component: v.routeData.childProps.component
       };
-      const myMatch : IonRouteData['match'] | null | undefined = matchPath(location.pathname, matchProps);
+      const myMatch: IonRouteData['match'] | null | undefined = matchPath(location.pathname, matchProps);
       if (myMatch) {
         view = v;
         match = myMatch;

--- a/packages/react-router/src/ReactRouter/ViewStacks.ts
+++ b/packages/react-router/src/ReactRouter/ViewStacks.ts
@@ -58,10 +58,11 @@ export class ViewStacks {
         path: v.routeData.childProps.path || v.routeData.childProps.from,
         component: v.routeData.childProps.component
       };
-      match = matchPath(location.pathname, matchProps);
-      if (match) {
+      const myMatch : IonRouteData['match'] | null | undefined = matchPath(location.pathname, matchProps);
+      if (myMatch) {
         view = v;
-        return true;
+        match = myMatch;
+        return view.location === location.pathname;
       }
       return false;
     }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X ] Build (`npm run build`) was run locally and any changes were pushed
- [X ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<IonRouterOutlet> does not manage routes where the match contains wildcards. the page would not be added to the navigation stack if a page matching the same route already exists.

Issue Number: 19891


## What is the new behavior?

See issue description, changes are described in comment 3

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


