### PR TITLE
chore(ionicons): update ionicons to 5.0.0-13

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -30,7 +30,7 @@
     "loader/"
   ],
   "dependencies": {
-    "ionicons": "^5.0.0-12",
+    "ionicons": "^5.0.0-13",
     "tslib": "^1.10.0"
   },
   "devDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "@ionic/core": "5.0.0-beta.1",
-    "ionicons": "^5.0.0-11",
+    "ionicons": "^5.0.0-13",
     "tslib": "*"
   },
   "peerDependencies": {

--- a/vue/package-lock.json
+++ b/vue/package-lock.json
@@ -571,9 +571,9 @@
       "dev": true
     },
     "ionicons": {
-      "version": "5.0.0-11",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-5.0.0-11.tgz",
-      "integrity": "sha512-daYkcBiNNfWKXZInkDmZuNFFkcTOUQtC9Itjr7/zV2qK0ORyrcITjYbYecoMkrJtkH7RU3d6B8o2FqRBASC7UA=="
+      "version": "5.0.0-13",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-5.0.0-13.tgz",
+      "integrity": "sha512-CG9tZRWm4S3abz8ie7JsoO4ZvY5JeNYG6UEIHjCNNns0m/XVNhEK50CTVSAkc+ybPmSnbMh3r0ELVRyordshpg=="
     },
     "is-buffer": {
       "version": "1.1.6",

--- a/vue/package.json
+++ b/vue/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@ionic/core": "^4.6.0",
-    "ionicons": "^5.0.0-11"
+    "ionicons": "^5.0.0-13"
   },
   "devDependencies": {
     "rollup": "^0.62.0",


### PR DESCRIPTION
The `ionicons/icons` package is now using data urls.