### PR TITLE
fix(content) set overscroll-behavior based on the scroll direction of…

### DIFF
--- a/core/src/components/content/content.scss
+++ b/core/src/components/content/content.scss
@@ -77,17 +77,18 @@
 .scroll-x {
   -webkit-overflow-scrolling: touch;
   will-change: scroll-position;
-  overscroll-behavior: contain;
 }
 
 .scroll-y {
   touch-action: pan-y;
   overflow-y: var(--overflow);
+  overscroll-behavior-y: contain;
 }
 
 .scroll-x {
   touch-action: pan-x;
   overflow-x: var(--overflow);
+  overscroll-behavior-x: contain;
 }
 
 .scroll-x.scroll-y {


### PR DESCRIPTION
This is kind of a placeholder PR for #20010. I went ahead and just split out `overscroll-behavior` into `overscroll-behavior-x` and `overscroll-behavior-y`. I can change this based on feedback.

fix(content) set overscroll-behavior based on the scroll direction of ion-content

By setting overscroll-behavior-y and overscroll-behavior-x based on the scroll direction of ion-content  instead of overscroll-behavior for both x and y scrolling, we prevent unwanted side effects that may prevent parent elements from scrolling in some edge cases.

closes #20010

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
`overscroll-behavior` is set for both x and y directions

Issue Number: #20010

## What is the new behavior?

only sets `overscroll-behavior` for the direction that the ion-content is scrolling.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No (as far as I know. I could be wrong)