### PR TITLE
fix(animations): convert hyphenated properties to camel case when using Web Animations

### DIFF
--- a/core/src/utils/animation/animation-utils.ts
+++ b/core/src/utils/animation/animation-utils.ts
@@ -11,7 +11,7 @@ export const processKeyframes = (keyframes: AnimationKeyFrames) => {
         const value = keyframe[key];
         const newKey = convertHyphenToCamelCase(key);
 
-        keyframe[newKey] = keyframe[key];
+        keyframe[newKey] = value;
         delete keyframe[key];
       }
     }

--- a/core/src/utils/animation/animation-utils.ts
+++ b/core/src/utils/animation/animation-utils.ts
@@ -1,3 +1,28 @@
+import { AnimationKeyFrames } from './animation-interface';
+
+/**
+ * Web Animations requires hyphenated CSS properties
+ * to be written in camelCase when animating
+ */
+export const processKeyframes = (keyframes: AnimationKeyFrames) => {
+  keyframes.forEach(keyframe => {
+    for (const key in keyframe) {
+      if (keyframe.hasOwnProperty(key) && key.includes('-')) {
+        const value = keyframe[key];
+        const newKey = convertHyphenToCamelCase(key);
+
+        keyframe[newKey] = keyframe[key];
+        delete keyframe[key];
+      }
+    }
+  });
+
+  return keyframes;
+};
+
+const convertHyphenToCamelCase = (str: string) => {
+  return str.replace(/-([a-z])/ig, g => g[1].toUpperCase());
+};
 
 export const setStyleProperty = (element: HTMLElement, propertyName: string, value: string | null) => {
   element.style.setProperty(propertyName, value);

--- a/core/src/utils/animation/animation.ts
+++ b/core/src/utils/animation/animation.ts
@@ -3,7 +3,7 @@
 import { raf } from '../helpers';
 
 import { Animation, AnimationCallbackOptions, AnimationDirection, AnimationFill, AnimationKeyFrame, AnimationKeyFrameEdge, AnimationKeyFrames, AnimationLifecycle, AnimationPlayOptions } from './animation-interface';
-import { addClassToArray, animationEnd, createKeyframeStylesheet, generateKeyframeName, generateKeyframeRules, removeStyleProperty, setStyleProperty } from './animation-utils';
+import { addClassToArray, animationEnd, createKeyframeStylesheet, generateKeyframeName, generateKeyframeRules, processKeyframes, removeStyleProperty, setStyleProperty } from './animation-utils';
 
 interface AnimationOnFinishCallback {
   c: AnimationLifecycle;
@@ -526,8 +526,10 @@ export const createAnimation = (animationId?: string): Animation => {
   };
 
   const initializeWebAnimation = () => {
+    const processedKeyframes = processKeyframes(_keyframes);
+
     elements.forEach(element => {
-      const animation = element.animate(_keyframes, {
+      const animation = element.animate(processedKeyframes, {
         id,
         delay: getDelay(),
         duration: getDuration(),

--- a/core/src/utils/animation/test/basic/index.html
+++ b/core/src/utils/animation/test/basic/index.html
@@ -29,10 +29,10 @@
       .iterations(2)
       .easing('linear')
       .keyframes([
-        { background: 'rgba(255, 0, 0, 0.5)', offset: 0 },
-        { background: 'rgba(0, 255, 0, 0.5)', offset: 0.33 },
-        { background: 'rgba(0, 0, 255, 0.5)', offset: 0.66 },
-        { background: 'rgba(255, 0, 0, 0.5)', offset: 1 }
+        { background: 'rgba(255, 0, 0, 0.5)', offset: 0, 'border-radius': '0px' },
+        { background: 'rgba(0, 255, 0, 0.5)', offset: 0.33, 'border-radius': '10px' },
+        { background: 'rgba(0, 0, 255, 0.5)', offset: 0.66, 'border-radius': '20px' },
+        { background: 'rgba(255, 0, 0, 0.5)', offset: 1, 'border-radius': '30px' }
       ])
       .onFinish(() => {
         const ev = new CustomEvent('ionAnimationFinished');

--- a/core/src/utils/animation/test/gesture/index.html
+++ b/core/src/utils/animation/test/gesture/index.html
@@ -63,7 +63,7 @@
       }
     });
     
-    gesture.setDisabled(false);
+    gesture.enable(true);
     
     animationA
       .addElement(squareA)


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic/issues/20058


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- For Web Animations only, we convert all hyphenated animated properties (`border-radius`) to camel case variants (`borderRadius`). This is a required change in order to allow devs to animate hyphenated CSS properties.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
