### PR TITLE
fix(modal): account for safe area on devices with a notch

### DIFF
--- a/core/src/components/modal/animations/ios.enter.ts
+++ b/core/src/components/modal/animations/ios.enter.ts
@@ -17,7 +17,7 @@ export const iosEnterAnimation = (
   const wrapperAnimation = createAnimation()
     .addElement(baseEl.querySelector('.modal-wrapper')!)
     .beforeStyles({ 'opacity': 1 })
-    .fromTo('transform', 'translateY(100%)', 'translateY(0%)');
+    .fromTo('transform', 'translateY(100%)', 'translateY(var(--ion-safe-area-top))');
 
   const baseAnimation = createAnimation()
     .addElement(baseEl)
@@ -27,10 +27,10 @@ export const iosEnterAnimation = (
     .addAnimation([backdropAnimation, wrapperAnimation]);
 
   if (presentingEl) {
-    const modalTransform = (presentingEl.tagName === 'ION-MODAL' && (presentingEl as HTMLIonModalElement).presentingElement !== undefined) ? 40 : 0;
+    const modalTransform = (presentingEl.tagName === 'ION-MODAL' && (presentingEl as HTMLIonModalElement).presentingElement !== undefined) ? '-40px' : 'var(--ion-safe-area-top)';
     const bodyEl = document.body;
     const toPresentingScale = SwipeToCloseDefaults.MIN_PRESENTING_SCALE;
-    const finalTransform = `translateY(${-modalTransform}px) scale(${toPresentingScale})`;
+    const finalTransform = `translateY(${modalTransform}) scale(${toPresentingScale})`;
 
     const presentingAnimation = createAnimation()
       .beforeStyles({

--- a/core/src/components/modal/animations/ios.enter.ts
+++ b/core/src/components/modal/animations/ios.enter.ts
@@ -17,7 +17,7 @@ export const iosEnterAnimation = (
   const wrapperAnimation = createAnimation()
     .addElement(baseEl.querySelector('.modal-wrapper')!)
     .beforeStyles({ 'opacity': 1 })
-    .fromTo('transform', 'translateY(100%)', 'translateY(var(--ion-safe-area-top))');
+    .fromTo('transform', 'translateY(100%)', `translateY(${(presentingEl) ? 'var(--ion-safe-area-top)' : '0%'})`);
 
   const baseAnimation = createAnimation()
     .addElement(baseEl)

--- a/core/src/components/modal/animations/ios.enter.ts
+++ b/core/src/components/modal/animations/ios.enter.ts
@@ -17,7 +17,7 @@ export const iosEnterAnimation = (
   const wrapperAnimation = createAnimation()
     .addElement(baseEl.querySelector('.modal-wrapper')!)
     .beforeStyles({ 'opacity': 1 })
-    .fromTo('transform', 'translateY(100%)', `translateY(${(presentingEl) ? 'var(--ion-safe-area-top)' : '0%'})`);
+    .fromTo('transform', 'translateY(100%)', 'translateY(0%)');
 
   const baseAnimation = createAnimation()
     .addElement(baseEl)

--- a/core/src/components/modal/animations/ios.enter.ts
+++ b/core/src/components/modal/animations/ios.enter.ts
@@ -27,14 +27,15 @@ export const iosEnterAnimation = (
     .addAnimation([backdropAnimation, wrapperAnimation]);
 
   if (presentingEl) {
-    const modalTransform = (presentingEl.tagName === 'ION-MODAL' && (presentingEl as HTMLIonModalElement).presentingElement !== undefined) ? '-40px' : 'var(--ion-safe-area-top)';
+    const modalTransform = (presentingEl.tagName === 'ION-MODAL' && (presentingEl as HTMLIonModalElement).presentingElement !== undefined) ? '-10px' : 'calc(var(--ion-safe-area-top) + 10px)';
     const bodyEl = document.body;
     const toPresentingScale = SwipeToCloseDefaults.MIN_PRESENTING_SCALE;
     const finalTransform = `translateY(${modalTransform}) scale(${toPresentingScale})`;
 
     const presentingAnimation = createAnimation()
       .beforeStyles({
-        'transform': 'translateY(0)'
+        'transform': 'translateY(0)',
+        'transform-origin': 'top center'
       })
       .afterStyles({
         'transform': finalTransform

--- a/core/src/components/modal/animations/ios.leave.ts
+++ b/core/src/components/modal/animations/ios.leave.ts
@@ -18,7 +18,7 @@ export const iosLeaveAnimation = (
   const wrapperAnimation = createAnimation()
     .addElement(baseEl.querySelector('.modal-wrapper')!)
     .beforeStyles({ 'opacity': 1 })
-    .fromTo('transform', `translateY(0%)`, 'translateY(100%)');
+    .fromTo('transform', `translateY(var(--ion-safe-area-top))`, 'translateY(100%)');
 
   const baseAnimation = createAnimation()
     .addElement(baseEl)
@@ -27,7 +27,7 @@ export const iosLeaveAnimation = (
     .addAnimation([backdropAnimation, wrapperAnimation]);
 
   if (presentingEl) {
-    const modalTransform = (presentingEl.tagName === 'ION-MODAL' && (presentingEl as HTMLIonModalElement).presentingElement !== undefined) ? 40 : 0;
+    const modalTransform = (presentingEl.tagName === 'ION-MODAL' && (presentingEl as HTMLIonModalElement).presentingElement !== undefined) ? '-40px' : 'var(--ion-safe-area-top)';
     const bodyEl = document.body;
     const currentPresentingScale = SwipeToCloseDefaults.MIN_PRESENTING_SCALE;
     const presentingAnimation = createAnimation()
@@ -44,7 +44,7 @@ export const iosLeaveAnimation = (
         }
       })
       .keyframes([
-        { offset: 0, transform: `translateY(${-modalTransform}px) scale(${currentPresentingScale})`, 'border-radius': '10px 10px 0 0' },
+        { offset: 0, transform: `translateY(${modalTransform}) scale(${currentPresentingScale})`, 'border-radius': '10px 10px 0 0' },
         { offset: 1, transform: 'translateY(0px) scale(1)', 'border-radius': '0px' }
       ]);
 

--- a/core/src/components/modal/animations/ios.leave.ts
+++ b/core/src/components/modal/animations/ios.leave.ts
@@ -27,7 +27,7 @@ export const iosLeaveAnimation = (
     .addAnimation([backdropAnimation, wrapperAnimation]);
 
   if (presentingEl) {
-    const modalTransform = (presentingEl.tagName === 'ION-MODAL' && (presentingEl as HTMLIonModalElement).presentingElement !== undefined) ? '-40px' : 'var(--ion-safe-area-top)';
+    const modalTransform = (presentingEl.tagName === 'ION-MODAL' && (presentingEl as HTMLIonModalElement).presentingElement !== undefined) ? '-10px' : 'calc(var(--ion-safe-area-top) + 10px)';
     const bodyEl = document.body;
     const currentPresentingScale = SwipeToCloseDefaults.MIN_PRESENTING_SCALE;
     const presentingAnimation = createAnimation()

--- a/core/src/components/modal/animations/ios.leave.ts
+++ b/core/src/components/modal/animations/ios.leave.ts
@@ -18,7 +18,7 @@ export const iosLeaveAnimation = (
   const wrapperAnimation = createAnimation()
     .addElement(baseEl.querySelector('.modal-wrapper')!)
     .beforeStyles({ 'opacity': 1 })
-    .fromTo('transform', `translateY(var(--ion-safe-area-top))`, 'translateY(100%)');
+    .fromTo('transform', `translateY(${(presentingEl) ? 'var(--ion-safe-area-top)' : '0%'})`, 'translateY(100%)');
 
   const baseAnimation = createAnimation()
     .addElement(baseEl)

--- a/core/src/components/modal/animations/ios.leave.ts
+++ b/core/src/components/modal/animations/ios.leave.ts
@@ -18,7 +18,7 @@ export const iosLeaveAnimation = (
   const wrapperAnimation = createAnimation()
     .addElement(baseEl.querySelector('.modal-wrapper')!)
     .beforeStyles({ 'opacity': 1 })
-    .fromTo('transform', `translateY(${(presentingEl) ? 'var(--ion-safe-area-top)' : '0%'})`, 'translateY(100%)');
+    .fromTo('transform', 'translateY(0%)', 'translateY(100%)');
 
   const baseAnimation = createAnimation()
     .addElement(baseEl)

--- a/core/src/components/modal/gestures/swipe-to-close.ts
+++ b/core/src/components/modal/gestures/swipe-to-close.ts
@@ -5,11 +5,7 @@ import { clamp } from '../../../utils/helpers';
 
 // Defaults for the card swipe animation
 export const SwipeToCloseDefaults = {
-  MIN_BACKDROP_OPACITY: 0.4,
-  MIN_PRESENTING_SCALE: 0.95,
-  MIN_Y_CARD: 44,
-  MIN_Y_FULLSCREEN: 0,
-  MIN_PRESENTING_Y: 0
+  MIN_PRESENTING_SCALE: 0.92,
 };
 
 export const createSwipeToCloseGesture = (
@@ -70,16 +66,20 @@ export const createSwipeToCloseGesture = (
     const duration = (shouldComplete) ? computeDuration(step * height, velocity) : computeDuration((1 - step) * height, velocity);
     isOpen = shouldComplete;
 
+    gesture.enable(false);
+
     animation
       .onFinish(() => {
         if (shouldComplete) {
           onDismiss();
+        } else {
+          gesture.enable(true);
         }
       })
       .progressEnd((shouldComplete) ? 1 : 0, newStepValue, duration);
   };
 
-  return createGesture({
+  const gesture = createGesture({
     el,
     gestureName: 'modalSwipeToClose',
     gesturePriority: 40,
@@ -90,8 +90,9 @@ export const createSwipeToCloseGesture = (
     onMove,
     onEnd
   });
+  return gesture;
 };
 
 const computeDuration = (remaining: number, velocity: number) => {
-  return clamp(100, remaining / Math.abs(velocity * 1.1), 400);
+  return clamp(400, remaining / Math.abs(velocity * 1.1), 500);
 };

--- a/core/src/components/modal/gestures/swipe-to-close.ts
+++ b/core/src/components/modal/gestures/swipe-to-close.ts
@@ -5,7 +5,7 @@ import { clamp } from '../../../utils/helpers';
 
 // Defaults for the card swipe animation
 export const SwipeToCloseDefaults = {
-  MIN_PRESENTING_SCALE: 0.92,
+  MIN_PRESENTING_SCALE: 0.93,
 };
 
 export const createSwipeToCloseGesture = (

--- a/core/src/components/modal/modal.ios.scss
+++ b/core/src/components/modal/modal.ios.scss
@@ -27,5 +27,5 @@
 
 :host(.modal-card) .modal-wrapper {
   @include border-radius($modal-ios-border-radius, $modal-ios-border-radius, 0, 0);
-  height: calc(100% - var(--ion-safe-area-top) - 40px);
+  height: calc(100% - var(--ion-safe-area-top) - 20px);
 }

--- a/core/src/components/modal/modal.ios.scss
+++ b/core/src/components/modal/modal.ios.scss
@@ -20,10 +20,12 @@
 }
 
 :host(.modal-card) {
+  --backdrop-opacity: 0.15;
+  
   align-items: flex-end;
 }
 
 :host(.modal-card) .modal-wrapper {
   @include border-radius($modal-ios-border-radius, $modal-ios-border-radius, 0, 0);
-  height: calc(100% - 40px);
+  height: calc(100% - var(--ion-safe-area-top) - 40px);
 }

--- a/core/src/components/modal/test/spec/index.html
+++ b/core/src/components/modal/test/spec/index.html
@@ -4,6 +4,8 @@
 <head>
   <meta charset="UTF-8">
   <title>Modal - Spec</title>
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <link href="../../../../../css/ionic.bundle.css" rel="stylesheet">
   <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">

--- a/core/src/css/core.scss
+++ b/core/src/css/core.scss
@@ -30,6 +30,14 @@ body.backdrop-no-scroll {
 //   --overflow: hidden;
 // }
 
+// Modal - Card Style
+// --------------------------------------------------
+// The card style does not reach all the way to
+// the top of the screen, so there does not need
+// to be any safe area padding added
+ion-modal.modal-card .ion-page > ion-header > ion-toolbar:first-child {
+  padding-top: 0px;
+}
 
 // Ionic Colors
 // --------------------------------------------------


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

On devices with a notch, the card style modal would not account for the safe area, pushing the presenting element underneath the status bar.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Apply `var(--ion-safe-area-top)` where needed to ensure modal/presenting el do not appear under statusbar

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
