### PR TITLE
fix(content): scroll-content div now takes up full height of container

### DIFF
--- a/core/src/components/content/content.scss
+++ b/core/src/components/content/content.scss
@@ -59,7 +59,7 @@
   --background: #{$background-color-step-50};
 }
 
-.scroll-content {
+#scroll-content {
   height: 100%;
 }
 

--- a/core/src/components/content/content.scss
+++ b/core/src/components/content/content.scss
@@ -59,6 +59,10 @@
   --background: #{$background-color-step-50};
 }
 
+.scroll-content {
+  height: 100%;
+}
+
 .inner-scroll {
   @include position(calc(var(--offset-top) * -1), 0px,calc(var(--offset-bottom) * -1), 0px);
   @include padding(calc(var(--padding-top) + var(--offset-top)), var(--padding-end), calc(var(--padding-bottom) + var(--keyboard-offset) + var(--offset-bottom)), var(--padding-start));


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic/issues/20185


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `.scroll-content` now takes up 100% of the container height

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
