### PR TITLE
fix(modal): prevent double dismiss via gesture and backdrop tap on card-style modal

### DIFF
--- a/core/src/components/modal/gestures/swipe-to-close.ts
+++ b/core/src/components/modal/gestures/swipe-to-close.ts
@@ -70,13 +70,15 @@ export const createSwipeToCloseGesture = (
 
     animation
       .onFinish(() => {
-        if (shouldComplete) {
-          onDismiss();
-        } else {
+        if (!shouldComplete) {
           gesture.enable(true);
         }
       })
       .progressEnd((shouldComplete) ? 1 : 0, newStepValue, duration);
+
+    if (shouldComplete) {
+      onDismiss();
+    }
   };
 
   const gesture = createGesture({

--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -30,6 +30,8 @@ export class Modal implements ComponentInterface, OverlayInterface {
   // Reference to the user's provided modal content
   private usersElement?: HTMLElement;
 
+  // Whether or not modal is being dismissed via gesture
+  private gestureAnimationDismissing = false;
   presented = false;
   animation?: Animation;
   mode = getIonMode(this);
@@ -152,7 +154,23 @@ export class Modal implements ComponentInterface, OverlayInterface {
       this.gesture = createSwipeToCloseGesture(
         this.el,
         ani,
-        () => this.dismiss(undefined, 'gesture')
+        () => {
+          /**
+           * While the gesture animation is finishing
+           * it is possible for a user to tap the backdrop.
+           * This would result in the dismiss animation
+           * being played again. Typically this is avoided
+           * by setting `presented = false` on the overlay
+           * component; however, we cannot do that here as
+           * that would prevent the element from being
+           * removed from the DOM.
+           */
+          this.gestureAnimationDismissing = true;
+          this.animation!.onFinish(async () => {
+            await this.dismiss(undefined, 'gesture');
+            this.gestureAnimationDismissing = false;
+          });
+        },
       );
       this.gesture.enable(true);
     }
@@ -166,6 +184,10 @@ export class Modal implements ComponentInterface, OverlayInterface {
    */
   @Method()
   async dismiss(data?: any, role?: string): Promise<boolean> {
+    if (this.gestureAnimationDismissing && role !== 'gesture') {
+      return false;
+    }
+
     const iosAni = (this.animation === undefined || (role === BACKDROP || role === undefined)) ? iosLeaveAnimation : undefined;
     const enteringAnimation = activeAnimations.get(this) || [];
     const dismissed = await dismiss(this, data, role, 'modalLeave', iosAni, mdLeaveAnimation, this.presentingElement);
@@ -178,8 +200,6 @@ export class Modal implements ComponentInterface, OverlayInterface {
 
       enteringAnimation.forEach(ani => ani.destroy());
     }
-
-    this.animation = undefined;
 
     return dismissed;
   }

--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -200,6 +200,8 @@ export class Modal implements ComponentInterface, OverlayInterface {
 
       enteringAnimation.forEach(ani => ani.destroy());
     }
+    
+    this.animation = undefined;
 
     return dismissed;
   }

--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -200,7 +200,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
 
       enteringAnimation.forEach(ani => ani.destroy());
     }
-    
+
     this.animation = undefined;
 
     return dismissed;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When dismissing a card-style modal via a swipe, on older/slower iOS devices it is possible to quickly tap the backdrop and have the dismiss animation played again.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Add a flag when dismissing via a gesture which prevents the dismiss method from being called again.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
