### PR TITLE
fix(card): remove top padding of content in iOS if under header

### DIFF
--- a/core/src/components/card-content/card-content.ios.scss
+++ b/core/src/components/card-content/card-content.ios.scss
@@ -41,3 +41,7 @@
     font-size: 14px;
   }
 }
+
+ion-card-header + .card-content-ios {
+  padding-top: 0;
+}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

| master | branch |
| ---| ---|
|![localhost_3333_src_components_card_test_translucent_ionic_mode=ios(Galaxy S5) (1)](https://user-images.githubusercontent.com/6577830/72628345-1efd3680-391c-11ea-9617-b6942561636a.png) | ![localhost_3333_src_components_card_test_translucent_ionic_mode=ios(Galaxy S5)](https://user-images.githubusercontent.com/6577830/72628337-1ad11900-391c-11ea-9f7a-c26c94f91de5.png) |



