### PR TITLE
feat(react): add Ionic Animations wrapper (experimental)

### DIFF
--- a/core/src/interface.d.ts
+++ b/core/src/interface.d.ts
@@ -31,7 +31,7 @@ export * from './components/toggle/toggle-interface';
 export * from './components/virtual-scroll/virtual-scroll-interface';
 
 // Types from utils
-export { Animation, AnimationBuilder } from './utils/animation/animation-interface';
+export { Animation, AnimationBuilder, AnimationCallbackOptions, AnimationDirection, AnimationFill, AnimationKeyFrames, AnimationLifecycle } from './utils/animation/animation-interface';
 export * from './utils/overlays-interface';
 export * from './global/config';
 export { Gesture, GestureConfig, GestureDetail } from './utils/gesture';

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ionic/react",
-  "version": "5.0.0-beta.5",
+  "version": "5.0.0-dev.202001221957.f1aca7a",
   "description": "React specific wrapper for @ionic/core",
   "keywords": [
     "ionic",
@@ -39,7 +39,7 @@
     "css/"
   ],
   "dependencies": {
-    "@ionic/core": "5.0.0-beta.5",
+    "@ionic/core": "5.0.0-dev.202001221957.f1aca7a",
     "ionicons": "^5.0.0-13",
     "tslib": "*"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ionic/react",
-  "version": "5.0.0-dev.202001221957.f1aca7a",
+  "version": "5.0.0-beta.5",
   "description": "React specific wrapper for @ionic/core",
   "keywords": [
     "ionic",
@@ -39,7 +39,7 @@
     "css/"
   ],
   "dependencies": {
-    "@ionic/core": "5.0.0-dev.202001221957.f1aca7a",
+    "@ionic/core": "5.0.0-beta.5",
     "ionicons": "^5.0.0-13",
     "tslib": "*"
   },

--- a/packages/react/src/components/CreateAnimation.tsx
+++ b/packages/react/src/components/CreateAnimation.tsx
@@ -53,8 +53,6 @@ export interface CreateAnimationProps {
  /**
   * QUESTIONS
   * How do I update props on the fly? (i.e. toggle play/pause)
-  * Is there a better way to setup the animation
-  * other than individually checking each prop?
   * Should the before/after hooks accept arrays of
   * callback in the core method?
   * How do I accept multiples elements even if they aren't immediately nested?

--- a/packages/react/src/components/CreateAnimation.tsx
+++ b/packages/react/src/components/CreateAnimation.tsx
@@ -35,7 +35,10 @@ export interface CreateAnimationProps {
   to?: PartialPropertyValue;
   fromTo?: PropertyValue;
 
-  play: boolean;
+  play?: boolean;
+  pause?: boolean;
+  stop?: boolean;
+  destroy?: boolean;
 
   progressStart?: { forceLinearEasing: boolean, step?: number };
   progressStep?: { step: number };
@@ -44,10 +47,6 @@ export interface CreateAnimationProps {
 
 /**
  * TODO
- * play
- * pause
- * stop
- * destroy
  * progressStart
  * progressStep
  * progressEnd
@@ -78,6 +77,7 @@ export class CreateAnimation extends React.Component<CreateAnimationProps> {
 
     const props = this.props;
     for (const key in props) {
+      // TODO
       if (props.hasOwnProperty(key) && !['children', 'progressStart', 'progressStep', 'progressEnd', 'play', 'from', 'to', 'fromTo', 'onFinish'].includes(key)) {
         console.log(key as any, animation as any, props as any);
         (animation as any)[key]((props as any)[key]);
@@ -107,10 +107,8 @@ export class CreateAnimation extends React.Component<CreateAnimationProps> {
       const values = (Array.isArray(onFinishValues)) ? onFinishValues : [onFinishValues];
       values.forEach(val => animation.onFinish(val.callback, val.opts));
     }
-
-    if (this.props.play) {
-      animation.play();
-    }
+    
+    checkPlayback(animation, props);    
   }
 
   componentDidMount() {
@@ -120,22 +118,24 @@ export class CreateAnimation extends React.Component<CreateAnimationProps> {
 
   componentDidUpdate(prevProps: any) {
     const animation = this.animation;
-
     if (animation === undefined) { return; }
 
-    const { progressStart, progressStep, progressEnd } = this.props;
-    console.log(this.props, prevProps);
-    if (prevProps.progressStart?.forceLinearEasing !== progressStart?.forceLinearEasing || prevProps.progressStart?.step !== progressStart?.step) {
+    const props = this.props;
+    const { progressStart, progressStep, progressEnd } = props;
+
+    if (progressStart && (prevProps.progressStart?.forceLinearEasing !== progressStart?.forceLinearEasing || prevProps.progressStart?.step !== progressStart?.step)) {
       animation.progressStart(progressStart.forceLinearEasing, progressStart.step);
     }
 
-    if (prevProps.progressStep?.step !== progressStep?.step) {
+    if (progressStep && prevProps.progressStep?.step !== progressStep?.step) {
       animation.progressStep(progressStep.step);
     }
 
-    if (prevProps.progressEnd?.playTo !== progressEnd?.playTo || prevProps.progressEnd?.step !== progressEnd?.step || prevProps?.dur !== progressEnd?.dur) {
+    if (progressEnd && (prevProps.progressEnd?.playTo !== progressEnd?.playTo || prevProps.progressEnd?.step !== progressEnd?.step || prevProps?.dur !== progressEnd?.dur)) {
       animation.progressEnd(progressEnd.playTo, progressEnd.step, progressEnd.dur);
     }
+    
+    checkPlayback(animation, props, prevProps);
   }
 
   render() {
@@ -147,4 +147,22 @@ export class CreateAnimation extends React.Component<CreateAnimationProps> {
     );
   }
 
+}
+
+const checkPlayback = (animation: Animation, currentProps: any = {}, prevProps: any = {}, ) => {
+  if (!prevProps.play && currentProps.play) {
+    animation.play();
+  }
+  
+  if (!prevProps.pause && currentProps.pause) {
+    animation.pause();
+  }
+  
+  if (!prevProps.stop && currentProps.stop) {
+    animation.stop();
+  }
+  
+  if (!prevProps.destroy && currentProps.destroy) {
+    animation.destroy();
+  }
 }

--- a/packages/react/src/components/CreateAnimation.tsx
+++ b/packages/react/src/components/CreateAnimation.tsx
@@ -36,6 +36,10 @@ export interface CreateAnimationProps {
   fromTo?: PropertyValue;
 
   play: boolean;
+
+  progressStart?: { forceLinearEasing: boolean, step?: number };
+  progressStep?: { step: number };
+  progressEnd?: { playTo: 0 | 1 | undefined, step: number, dur?: number };
 }
 
 /**
@@ -63,7 +67,7 @@ export class CreateAnimation extends React.Component<CreateAnimationProps> {
   animation?: Animation;
 
   updateAnimation() {
-    if (!this.animation) { return; }
+    if (this.animation === undefined) { return; }
 
     console.log(this);
     const animation = this.animation!;
@@ -74,7 +78,7 @@ export class CreateAnimation extends React.Component<CreateAnimationProps> {
 
     const props = this.props;
     for (const key in props) {
-      if (props.hasOwnProperty(key) && !['children', 'play', 'from', 'to', 'fromTo', 'onFinish'].includes(key)) {
+      if (props.hasOwnProperty(key) && !['children', 'progressStart', 'progressStep', 'progressEnd', 'play', 'from', 'to', 'fromTo', 'onFinish'].includes(key)) {
         console.log(key as any, animation as any, props as any);
         (animation as any)[key]((props as any)[key]);
       }
@@ -112,6 +116,26 @@ export class CreateAnimation extends React.Component<CreateAnimationProps> {
   componentDidMount() {
     this.animation = createAnimation();
     this.updateAnimation();
+  }
+
+  componentDidUpdate(prevProps: any) {
+    const animation = this.animation;
+
+    if (animation === undefined) { return; }
+
+    const { progressStart, progressStep, progressEnd } = this.props;
+    console.log(this.props, prevProps);
+    if (prevProps.progressStart?.forceLinearEasing !== progressStart?.forceLinearEasing || prevProps.progressStart?.step !== progressStart?.step) {
+      animation.progressStart(progressStart.forceLinearEasing, progressStart.step);
+    }
+
+    if (prevProps.progressStep?.step !== progressStep?.step) {
+      animation.progressStep(progressStep.step);
+    }
+
+    if (prevProps.progressEnd?.playTo !== progressEnd?.playTo || prevProps.progressEnd?.step !== progressEnd?.step || prevProps?.dur !== progressEnd?.dur) {
+      animation.progressEnd(progressEnd.playTo, progressEnd.step, progressEnd.dur);
+    }
   }
 
   render() {

--- a/packages/react/src/components/CreateAnimation.tsx
+++ b/packages/react/src/components/CreateAnimation.tsx
@@ -65,37 +65,7 @@ export class CreateAnimation extends React.Component<CreateAnimationProps> {
       animation.addElement(Array.from(this.nodes.values()));
     }
 
-    for (const key in props) {
-      // TODO
-      if (props.hasOwnProperty(key) && !['children', 'progressStart', 'progressStep', 'progressEnd', 'play', 'from', 'to', 'fromTo', 'onFinish'].includes(key)) {
-        (animation as any)[key]((props as any)[key]);
-      }
-    }
-
-    const fromValues = props.from;
-    if (fromValues) {
-      const values = (Array.isArray(fromValues)) ? fromValues : [fromValues];
-      values.forEach(val => animation.from(val.property, val.value));
-    }
-
-    const toValues = props.to;
-    if (toValues) {
-      const values = (Array.isArray(toValues)) ? toValues : [toValues];
-      values.forEach(val => animation.to(val.property, val.value));
-    }
-
-    const fromToValues = props.fromTo;
-    if (fromToValues) {
-      const values = (Array.isArray(fromToValues)) ? fromToValues : [fromToValues];
-      values.forEach(val => animation.fromTo(val.property, val.fromValue, val.toValue));
-    }
-
-    const onFinishValues = props.onFinish;
-    if (onFinishValues) {
-      const values = (Array.isArray(onFinishValues)) ? onFinishValues : [onFinishValues];
-      values.forEach(val => animation.onFinish(val.callback, val.opts));
-    }
-
+    checkConfig(animation, props);
     checkPlayback(animation, props);
   }
 
@@ -111,6 +81,7 @@ export class CreateAnimation extends React.Component<CreateAnimationProps> {
 
     const props = this.props;
 
+    checkConfig(animation, props, prevProps);
     checkProgress(animation, props, prevProps);
     checkPlayback(animation, props, prevProps);
   }
@@ -124,6 +95,43 @@ export class CreateAnimation extends React.Component<CreateAnimationProps> {
     );
   }
 }
+
+const checkConfig = (animation: Animation, currentProps: any = {}, prevProps: any = {}) => {
+  for (const key in currentProps) {
+    // TODO
+    if (
+      currentProps.hasOwnProperty(key) &&
+      !['children', 'progressStart', 'progressStep', 'progressEnd', 'play', 'from', 'to', 'fromTo', 'onFinish'].includes(key) &&
+      currentProps[key] !== prevProps[key]
+    ) {
+      (animation as any)[key]((currentProps as any)[key]);
+    }
+  }
+
+  const fromValues = currentProps.from;
+  if (fromValues && fromValues.length !== (prevProps.from || [])) {
+    const values = (Array.isArray(fromValues)) ? fromValues : [fromValues];
+    values.forEach(val => animation.from(val.property, val.value));
+  }
+
+  const toValues = currentProps.to;
+  if (toValues && toValues.length !== (prevProps.to || [])) {
+    const values = (Array.isArray(toValues)) ? toValues : [toValues];
+    values.forEach(val => animation.to(val.property, val.value));
+  }
+
+  const fromToValues = currentProps.fromTo;
+  if (fromToValues && fromToValues.length !== (prevProps.fromTo || [])) {
+    const values = (Array.isArray(fromToValues)) ? fromToValues : [fromToValues];
+    values.forEach(val => animation.fromTo(val.property, val.fromValue, val.toValue));
+  }
+
+  const onFinishValues = currentProps.onFinish;
+  if (onFinishValues && onFinishValues.length !== (prevProps.onFinish || [])) {
+    const values = (Array.isArray(onFinishValues)) ? onFinishValues : [onFinishValues];
+    values.forEach(val => animation.onFinish(val.callback, val.opts));
+  }
+};
 
 const checkProgress = (animation: Animation, currentProps: any = {}, prevProps: any = {}) => {
   const { progressStart, progressStep, progressEnd } = currentProps;

--- a/packages/react/src/components/CreateAnimation.tsx
+++ b/packages/react/src/components/CreateAnimation.tsx
@@ -44,12 +44,6 @@ export interface CreateAnimationProps {
   progressEnd?: { playTo: 0 | 1 | undefined, step: number, dur?: number };
 }
 
-/**
- * TODO
- * make sure destroy is working properly
- * clean up code
- */
-
 export class CreateAnimation extends React.Component<CreateAnimationProps> {
   private nodes: Map<number, HTMLElement> = new Map();
   animation?: Animation;
@@ -94,10 +88,11 @@ export class CreateAnimation extends React.Component<CreateAnimationProps> {
 }
 
 const checkConfig = (animation: Animation, currentProps: any = {}, prevProps: any = {}) => {
+  const reservedProps = ['children', 'progressStart', 'progressStep', 'progressEnd', 'pause', 'stop', 'destroy', 'play', 'from', 'to', 'fromTo', 'onFinish'];
   for (const key in currentProps) {
     if (
       currentProps.hasOwnProperty(key) &&
-      !['children', 'progressStart', 'progressStep', 'progressEnd', 'play', 'from', 'to', 'fromTo', 'onFinish'].includes(key) &&
+      !reservedProps.includes(key) &&
       currentProps[key] !== prevProps[key]
     ) {
       (animation as any)[key]((currentProps as any)[key]);
@@ -158,7 +153,6 @@ const checkPlayback = (animation: Animation, currentProps: any = {}, prevProps: 
     animation.stop();
   }
 
-  console.log('prev', prevProps.destroy, 'current', currentProps.destroy);
   if (!prevProps.destroy && currentProps.destroy) {
     animation.destroy();
   }

--- a/packages/react/src/components/CreateAnimation.tsx
+++ b/packages/react/src/components/CreateAnimation.tsx
@@ -1,8 +1,10 @@
 import { Animation, AnimationCallbackOptions, AnimationDirection, AnimationFill, AnimationKeyFrames, AnimationLifecycle, createAnimation } from '@ionic/core';
 import React from 'react';
 
-type LifecycleCallback = { callback: AnimationLifecycle, opts?: AnimationCallbackOptions } | { callback: AnimationLifecycle, opts?: AnimationCallbackOptions }[];
-type HookCallback = () => void | (() => void)[];
+type LifecycleCallback = (callback: AnimationLifecycle, opts?: AnimationCallbackOptions) => void;
+type HookCallback = () => void;
+interface PartialPropertyValue { property: string; value: any; }
+interface PropertyValue { property: string; fromValue: any; toValue: any; }
 
 export interface CreateAnimationProps {
   delay?: number;
@@ -29,6 +31,9 @@ export interface CreateAnimationProps {
   onFinish?: LifecycleCallback;
 
   keyframes?: AnimationKeyFrames;
+  from?: PartialPropertyValue;
+  to?: PartialPropertyValue;
+  fromTo?: PropertyValue;
 
   play: boolean;
 }
@@ -42,130 +47,67 @@ export interface CreateAnimationProps {
  * progressStart
  * progressStep
  * progressEnd
- * from
- * to
- * fromTo
  * addAnimation
- * fix onFinish types (they aren't correct)
  */
 
  /**
   * QUESTIONS
-  * How do I call the getter methods? (i.e. getKeyframes())
   * How do I update props on the fly? (i.e. toggle play/pause)
   * Is there a better way to setup the animation
   * other than individually checking each prop?
   * Should the before/after hooks accept arrays of
   * callback in the core method?
+  * How do I accept multiples elements even if they aren't immediately nested?
   */
 
 export class CreateAnimation extends React.Component<CreateAnimationProps> {
-  ref: React.RefObject<HTMLElement> = React.createRef();
+  private nodes: Map<number, HTMLElement> = new Map();
   animation?: Animation;
 
   updateAnimation() {
     if (!this.animation) { return; }
 
-    if (this.ref.current) {
-      this.animation.addElement(this.ref.current);
+    console.log(this);
+    const animation = this.animation!;
+
+    if (this.nodes.size > 0) {
+      animation.addElement(Array.from(this.nodes.values()));
     }
 
-    if (this.props.iterations) {
-      this.animation.iterations(this.props.iterations);
+    const props = this.props;
+    for (const key in props) {
+      if (props.hasOwnProperty(key) && !['play', 'from', 'to', 'fromTo', 'onFinish'].includes(key)) {
+        (animation as any)[key]((props as any)[key]);
+      }
     }
 
-    if (this.props.fill) {
-      this.animation.fill(this.props.fill);
+    const fromValues = this.props.from;
+    if (fromValues) {
+      const values = (Array.isArray(fromValues)) ? fromValues : [fromValues];
+      values.forEach(val => animation.from(val.property, val.value));
     }
 
-    if (this.props.direction) {
-      this.animation.direction(this.props.direction);
+    const toValues = this.props.to;
+    if (toValues) {
+      const values = (Array.isArray(toValues)) ? toValues : [toValues];
+      values.forEach(val => animation.to(val.property, val.value));
     }
 
-    if (this.props.duration) {
-      this.animation.duration(this.props.duration);
+    const fromToValues = this.props.fromTo;
+    if (fromToValues) {
+      const values = (Array.isArray(fromToValues)) ? fromToValues : [fromToValues];
+      values.forEach(val => animation.fromTo(val.property, val.fromValue, val.toValue));
     }
 
-    if (this.props.easing) {
-      this.animation.easing(this.props.easing);
-    }
-
-    if (this.props.delay) {
-      this.animation.delay(this.props.delay);
-    }
-
-    if (this.props.keyframes) {
-      this.animation.keyframes(this.props.keyframes);
+    const onFinishValues = this.props.onFinish;
+    if (onFinishValues) {
+      const values = (Array.isArray(onFinishValues)) ? onFinishValues : [onFinishValues];
+      values.forEach(val => animation.onFinish(val.callback, val.opts));
     }
 
     if (this.props.play) {
-      this.animation.play();
+      animation.play();
     }
-
-    const afterAddRead = this.props.afterAddRead;
-    if (afterAddRead) {
-      this.setCallbacks(afterAddRead, this.animation.afterAddRead);
-    }
-
-    const afterAddWrite = this.props.afterAddWrite;
-    if (afterAddWrite) {
-      this.setCallbacks(afterAddWrite, this.animation.afterAddWrite);
-    }
-
-    const afterClearStyles = this.props.afterClearStyles;
-    if (afterClearStyles) {
-      this.setCallbacks(afterClearStyles, this.animation.afterClearStyles);
-    }
-
-    const afterStyles = this.props.afterStyles;
-    if (afterStyles) {
-      this.setCallbacks(afterStyles, this.animation.afterStyles);
-    }
-
-    const afterAddClass = this.props.afterAddClass;
-    if (afterAddClass) {
-      this.setCallbacks(afterAddClass, this.animation.afterAddClass);
-    }
-
-    const afterRemoveClass = this.props.afterRemoveClass;
-    if (afterRemoveClass) {
-      this.setCallbacks(afterRemoveClass, this.animation.afterRemoveClass);
-    }
-
-    const beforeAddRead = this.props.beforeAddRead;
-    if (beforeAddRead) {
-      this.setCallbacks(beforeAddRead, this.animation.beforeAddRead);
-    }
-
-    const beforeAddWrite = this.props.beforeAddWrite;
-    if (beforeAddWrite) {
-      this.setCallbacks(beforeAddWrite, this.animation.beforeAddWrite);
-    }
-
-    const beforeClearStyles = this.props.beforeClearStyles;
-    if (beforeClearStyles) {
-      this.setCallbacks(beforeClearStyles, this.animation.beforeClearStyles);
-    }
-
-    const beforeStyles = this.props.beforeStyles;
-    if (beforeStyles) {
-      this.setCallbacks(beforeStyles, this.animation.beforeStyles);
-    }
-
-    const beforeAddClass = this.props.beforeAddClass;
-    if (beforeAddClass) {
-      this.setCallbacks(beforeAddClass, this.animation.beforeAddClass);
-    }
-
-    const beforeRemoveClass = this.props.beforeRemoveClass;
-    if (beforeRemoveClass) {
-      this.setCallbacks(beforeRemoveClass, this.animation.beforeRemoveClass);
-    }
-  }
-
-  setCallbacks(prop: any, method: any) {
-    const fns = (Array.isArray(prop)) ? prop : [prop];
-    fns.forEach(fn => method(fn));
   }
 
   componentDidMount() {
@@ -177,8 +119,9 @@ export class CreateAnimation extends React.Component<CreateAnimationProps> {
     const { children } = this.props;
     return (
       <>
-        {React.cloneElement(children as any, { ref: this.ref })}
+        {React.Children.map(children, ((child, id) => React.cloneElement(child as any, { ref: (el: any) => this.nodes.set(id, el) })))}
       </>
     );
   }
+
 }

--- a/packages/react/src/components/CreateAnimation.tsx
+++ b/packages/react/src/components/CreateAnimation.tsx
@@ -76,7 +76,8 @@ export class CreateAnimation extends React.Component<CreateAnimationProps> {
 
     const props = this.props;
     for (const key in props) {
-      if (props.hasOwnProperty(key) && !['play', 'from', 'to', 'fromTo', 'onFinish'].includes(key)) {
+      if (props.hasOwnProperty(key) && !['children', 'play', 'from', 'to', 'fromTo', 'onFinish'].includes(key)) {
+        console.log(key as any, animation as any, props as any);
         (animation as any)[key]((props as any)[key]);
       }
     }

--- a/packages/react/src/components/CreateAnimation.tsx
+++ b/packages/react/src/components/CreateAnimation.tsx
@@ -52,10 +52,10 @@ export class CreateAnimation extends React.PureComponent<CreateAnimationProps> {
     super(props);
 
     this.animation = createAnimation(props.id);
-    this.updateAnimation(props);
+    this.setupAnimation(props);
   }
 
-  updateAnimation(props: any) {
+  setupAnimation(props: any) {
     const animation = this.animation;
 
     if (this.nodes.size > 0) {

--- a/packages/react/src/components/CreateAnimation.tsx
+++ b/packages/react/src/components/CreateAnimation.tsx
@@ -1,9 +1,6 @@
 import { Animation, AnimationCallbackOptions, AnimationDirection, AnimationFill, AnimationKeyFrames, AnimationLifecycle, createAnimation } from '@ionic/core';
 import React from 'react';
 
-type HookCallback = () => void;
-
-interface LifecycleCallback { callback: AnimationLifecycle; opts?: AnimationCallbackOptions; }
 interface PartialPropertyValue { property: string; value: any; }
 interface PropertyValue { property: string; fromValue: any; toValue: any; }
 
@@ -16,21 +13,21 @@ export interface CreateAnimationProps {
   iterations?: number;
   id?: string;
 
-  afterAddRead?: HookCallback;
-  afterAddWrite?: HookCallback;
+  afterAddRead?: () => void;
+  afterAddWrite?: () => void;
   afterClearStyles?: string[];
   afterStyles?: { [property: string]: any };
   afterAddClass?: string | string[];
   afterRemoveClass?: string | string[];
 
-  beforeAddRead?: HookCallback;
-  beforeAddWrite?: HookCallback;
+  beforeAddRead?: () => void;
+  beforeAddWrite?: () => void;
   beforeClearStyles?: string[];
   beforeStyles?: { [property: string]: any };
   beforeAddClass?: string | string[];
   beforeRemoveClass?: string | string[];
 
-  onFinish?: LifecycleCallback;
+  onFinish?: { callback: AnimationLifecycle; opts?: AnimationCallbackOptions; };
 
   keyframes?: AnimationKeyFrames;
   from?: PartialPropertyValue;
@@ -98,7 +95,6 @@ export class CreateAnimation extends React.Component<CreateAnimationProps> {
 
 const checkConfig = (animation: Animation, currentProps: any = {}, prevProps: any = {}) => {
   for (const key in currentProps) {
-    // TODO
     if (
       currentProps.hasOwnProperty(key) &&
       !['children', 'progressStart', 'progressStep', 'progressEnd', 'play', 'from', 'to', 'fromTo', 'onFinish'].includes(key) &&
@@ -162,6 +158,7 @@ const checkPlayback = (animation: Animation, currentProps: any = {}, prevProps: 
     animation.stop();
   }
 
+  console.log('prev', prevProps.destroy, 'current', currentProps.destroy);
   if (!prevProps.destroy && currentProps.destroy) {
     animation.destroy();
   }

--- a/packages/react/src/components/CreateAnimation.tsx
+++ b/packages/react/src/components/CreateAnimation.tsx
@@ -44,7 +44,7 @@ export interface CreateAnimationProps {
   progressEnd?: { playTo: 0 | 1 | undefined, step: number, dur?: number };
 }
 
-export class CreateAnimation extends React.Component<CreateAnimationProps> {
+export class CreateAnimation extends React.PureComponent<CreateAnimationProps> {
   private nodes: Map<number, HTMLElement> = new Map();
   animation: Animation;
 

--- a/packages/react/src/components/CreateAnimation.tsx
+++ b/packages/react/src/components/CreateAnimation.tsx
@@ -1,0 +1,184 @@
+import { Animation, AnimationCallbackOptions, AnimationDirection, AnimationFill, AnimationKeyFrames, AnimationLifecycle, createAnimation } from '@ionic/core';
+import React from 'react';
+
+type LifecycleCallback = { callback: AnimationLifecycle, opts?: AnimationCallbackOptions } | { callback: AnimationLifecycle, opts?: AnimationCallbackOptions }[];
+type HookCallback = () => void | (() => void)[];
+
+export interface CreateAnimationProps {
+  delay?: number;
+  direction?: AnimationDirection;
+  duration?: number;
+  easing?: string;
+  fill?: AnimationFill;
+  iterations?: number;
+
+  afterAddRead?: HookCallback;
+  afterAddWrite?: HookCallback;
+  afterClearStyles?: string[];
+  afterStyles?: { [property: string]: any };
+  afterAddClass?: string | string[];
+  afterRemoveClass?: string | string[];
+
+  beforeAddRead?: HookCallback;
+  beforeAddWrite?: HookCallback;
+  beforeClearStyles?: string[];
+  beforeStyles?: { [property: string]: any };
+  beforeAddClass?: string | string[];
+  beforeRemoveClass?: string | string[];
+
+  onFinish?: LifecycleCallback;
+
+  keyframes?: AnimationKeyFrames;
+
+  play: boolean;
+}
+
+/**
+ * TODO
+ * play
+ * pause
+ * stop
+ * destroy
+ * progressStart
+ * progressStep
+ * progressEnd
+ * from
+ * to
+ * fromTo
+ * addAnimation
+ * fix onFinish types (they aren't correct)
+ */
+
+ /**
+  * QUESTIONS
+  * How do I call the getter methods? (i.e. getKeyframes())
+  * How do I update props on the fly? (i.e. toggle play/pause)
+  * Is there a better way to setup the animation
+  * other than individually checking each prop?
+  * Should the before/after hooks accept arrays of
+  * callback in the core method?
+  */
+
+export class CreateAnimation extends React.Component<CreateAnimationProps> {
+  ref: React.RefObject<HTMLElement> = React.createRef();
+  animation?: Animation;
+
+  updateAnimation() {
+    if (!this.animation) { return; }
+
+    if (this.ref.current) {
+      this.animation.addElement(this.ref.current);
+    }
+
+    if (this.props.iterations) {
+      this.animation.iterations(this.props.iterations);
+    }
+
+    if (this.props.fill) {
+      this.animation.fill(this.props.fill);
+    }
+
+    if (this.props.direction) {
+      this.animation.direction(this.props.direction);
+    }
+
+    if (this.props.duration) {
+      this.animation.duration(this.props.duration);
+    }
+
+    if (this.props.easing) {
+      this.animation.easing(this.props.easing);
+    }
+
+    if (this.props.delay) {
+      this.animation.delay(this.props.delay);
+    }
+
+    if (this.props.keyframes) {
+      this.animation.keyframes(this.props.keyframes);
+    }
+
+    if (this.props.play) {
+      this.animation.play();
+    }
+
+    const afterAddRead = this.props.afterAddRead;
+    if (afterAddRead) {
+      this.setCallbacks(afterAddRead, this.animation.afterAddRead);
+    }
+
+    const afterAddWrite = this.props.afterAddWrite;
+    if (afterAddWrite) {
+      this.setCallbacks(afterAddWrite, this.animation.afterAddWrite);
+    }
+
+    const afterClearStyles = this.props.afterClearStyles;
+    if (afterClearStyles) {
+      this.setCallbacks(afterClearStyles, this.animation.afterClearStyles);
+    }
+
+    const afterStyles = this.props.afterStyles;
+    if (afterStyles) {
+      this.setCallbacks(afterStyles, this.animation.afterStyles);
+    }
+
+    const afterAddClass = this.props.afterAddClass;
+    if (afterAddClass) {
+      this.setCallbacks(afterAddClass, this.animation.afterAddClass);
+    }
+
+    const afterRemoveClass = this.props.afterRemoveClass;
+    if (afterRemoveClass) {
+      this.setCallbacks(afterRemoveClass, this.animation.afterRemoveClass);
+    }
+
+    const beforeAddRead = this.props.beforeAddRead;
+    if (beforeAddRead) {
+      this.setCallbacks(beforeAddRead, this.animation.beforeAddRead);
+    }
+
+    const beforeAddWrite = this.props.beforeAddWrite;
+    if (beforeAddWrite) {
+      this.setCallbacks(beforeAddWrite, this.animation.beforeAddWrite);
+    }
+
+    const beforeClearStyles = this.props.beforeClearStyles;
+    if (beforeClearStyles) {
+      this.setCallbacks(beforeClearStyles, this.animation.beforeClearStyles);
+    }
+
+    const beforeStyles = this.props.beforeStyles;
+    if (beforeStyles) {
+      this.setCallbacks(beforeStyles, this.animation.beforeStyles);
+    }
+
+    const beforeAddClass = this.props.beforeAddClass;
+    if (beforeAddClass) {
+      this.setCallbacks(beforeAddClass, this.animation.beforeAddClass);
+    }
+
+    const beforeRemoveClass = this.props.beforeRemoveClass;
+    if (beforeRemoveClass) {
+      this.setCallbacks(beforeRemoveClass, this.animation.beforeRemoveClass);
+    }
+  }
+
+  setCallbacks(prop: any, method: any) {
+    const fns = (Array.isArray(prop)) ? prop : [prop];
+    fns.forEach(fn => method(fn));
+  }
+
+  componentDidMount() {
+    this.animation = createAnimation();
+    this.updateAnimation();
+  }
+
+  render() {
+    const { children } = this.props;
+    return (
+      <>
+        {React.cloneElement(children as any, { ref: this.ref })}
+      </>
+    );
+  }
+}

--- a/packages/react/src/components/CreateAnimation.tsx
+++ b/packages/react/src/components/CreateAnimation.tsx
@@ -105,25 +105,25 @@ const checkConfig = (animation: Animation, currentProps: any = {}, prevProps: an
   }
 
   const fromValues = currentProps.from;
-  if (fromValues && fromValues.length !== (prevProps.from || [])) {
+  if (fromValues && fromValues.length !== (prevProps.from || []).length) {
     const values = (Array.isArray(fromValues)) ? fromValues : [fromValues];
     values.forEach(val => animation.from(val.property, val.value));
   }
 
   const toValues = currentProps.to;
-  if (toValues && toValues.length !== (prevProps.to || [])) {
+  if (toValues && toValues.length !== (prevProps.to || []).length) {
     const values = (Array.isArray(toValues)) ? toValues : [toValues];
     values.forEach(val => animation.to(val.property, val.value));
   }
 
   const fromToValues = currentProps.fromTo;
-  if (fromToValues && fromToValues.length !== (prevProps.fromTo || [])) {
+  if (fromToValues && fromToValues.length !== (prevProps.fromTo || []).length) {
     const values = (Array.isArray(fromToValues)) ? fromToValues : [fromToValues];
     values.forEach(val => animation.fromTo(val.property, val.fromValue, val.toValue));
   }
 
   const onFinishValues = currentProps.onFinish;
-  if (onFinishValues && onFinishValues.length !== (prevProps.onFinish || [])) {
+  if (onFinishValues && onFinishValues.length !== (prevProps.onFinish || []).length) {
     const values = (Array.isArray(onFinishValues)) ? onFinishValues : [onFinishValues];
     values.forEach(val => animation.onFinish(val.callback, val.opts));
   }

--- a/packages/react/src/components/CreateAnimation.tsx
+++ b/packages/react/src/components/CreateAnimation.tsx
@@ -46,11 +46,17 @@ export interface CreateAnimationProps {
 
 export class CreateAnimation extends React.Component<CreateAnimationProps> {
   private nodes: Map<number, HTMLElement> = new Map();
-  animation?: Animation;
+  animation: Animation;
+
+  constructor(props: any) {
+    super(props);
+
+    this.animation = createAnimation(props.id);
+    this.updateAnimation(props);
+  }
 
   updateAnimation(props: any) {
     const animation = this.animation;
-    if (animation === undefined) { return; }
 
     if (this.nodes.size > 0) {
       animation.addElement(Array.from(this.nodes.values()));
@@ -60,15 +66,8 @@ export class CreateAnimation extends React.Component<CreateAnimationProps> {
     checkPlayback(animation, props);
   }
 
-  componentDidMount() {
-    const props = this.props;
-    this.animation = createAnimation(props.id);
-    this.updateAnimation(props);
-  }
-
   componentDidUpdate(prevProps: any) {
     const animation = this.animation;
-    if (animation === undefined) { return; }
 
     const props = this.props;
 

--- a/packages/react/src/components/CreateAnimation.tsx
+++ b/packages/react/src/components/CreateAnimation.tsx
@@ -13,6 +13,7 @@ export interface CreateAnimationProps {
   easing?: string;
   fill?: AnimationFill;
   iterations?: number;
+  id?: string;
 
   afterAddRead?: HookCallback;
   afterAddWrite?: HookCallback;
@@ -51,14 +52,16 @@ export interface CreateAnimationProps {
  * progressStep
  * progressEnd
  * addAnimation
+ * addElement
+ * make sure onFinish is working properly
+ * make sure destroy is working properly
+ * clean up code
  */
 
  /**
   * QUESTIONS
-  * How do I update props on the fly? (i.e. toggle play/pause)
   * Should the before/after hooks accept arrays of
   * callback in the core method?
-  * How do I accept multiples elements even if they aren't immediately nested?
   */
 
 export class CreateAnimation extends React.Component<CreateAnimationProps> {
@@ -112,7 +115,7 @@ export class CreateAnimation extends React.Component<CreateAnimationProps> {
   }
 
   componentDidMount() {
-    this.animation = createAnimation();
+    this.animation = createAnimation(this.props.id);
     this.updateAnimation();
   }
 

--- a/packages/react/src/components/CreateAnimation.tsx
+++ b/packages/react/src/components/CreateAnimation.tsx
@@ -99,25 +99,25 @@ const checkConfig = (animation: Animation, currentProps: any = {}, prevProps: an
   }
 
   const fromValues = currentProps.from;
-  if (fromValues && fromValues.length !== (prevProps.from || []).length) {
+  if (fromValues && fromValues !== prevProps.from) {
     const values = (Array.isArray(fromValues)) ? fromValues : [fromValues];
     values.forEach(val => animation.from(val.property, val.value));
   }
 
   const toValues = currentProps.to;
-  if (toValues && toValues.length !== (prevProps.to || []).length) {
+  if (toValues && toValues !== prevProps.to) {
     const values = (Array.isArray(toValues)) ? toValues : [toValues];
     values.forEach(val => animation.to(val.property, val.value));
   }
 
   const fromToValues = currentProps.fromTo;
-  if (fromToValues && fromToValues.length !== (prevProps.fromTo || []).length) {
+  if (fromToValues && fromToValues !== prevProps.fromTo) {
     const values = (Array.isArray(fromToValues)) ? fromToValues : [fromToValues];
     values.forEach(val => animation.fromTo(val.property, val.fromValue, val.toValue));
   }
 
   const onFinishValues = currentProps.onFinish;
-  if (onFinishValues && onFinishValues.length !== (prevProps.onFinish || []).length) {
+  if (onFinishValues && onFinishValues !== prevProps.onFinish) {
     const values = (Array.isArray(onFinishValues)) ? onFinishValues : [onFinishValues];
     values.forEach(val => animation.onFinish(val.callback, val.opts));
   }

--- a/packages/react/src/components/CreateAnimation.tsx
+++ b/packages/react/src/components/CreateAnimation.tsx
@@ -52,7 +52,6 @@ export class CreateAnimation extends React.PureComponent<CreateAnimationProps> {
     super(props);
 
     this.animation = createAnimation(props.id);
-    this.setupAnimation(props);
   }
 
   setupAnimation(props: any) {
@@ -64,6 +63,11 @@ export class CreateAnimation extends React.PureComponent<CreateAnimationProps> {
 
     checkConfig(animation, props);
     checkPlayback(animation, props);
+  }
+
+  componentDidMount() {
+    const props = this.props;
+    this.setupAnimation(props);
   }
 
   componentDidUpdate(prevProps: any) {

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -28,6 +28,9 @@ export { IonIcon } from './IonIcon';
 export { isPlatform, getPlatforms, getConfig } from './utils';
 export { RouterDirection } from './hrefprops';
 
+// Ionic Animations
+export { CreateAnimation, CreateAnimationProps } from './CreateAnimation';
+
 // Icons that are used by internal components
 addIcons({
   'arrow-back-sharp': arrowBackSharp,

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -29,7 +29,7 @@ export { isPlatform, getPlatforms, getConfig } from './utils';
 export { RouterDirection } from './hrefprops';
 
 // Ionic Animations
-export { CreateAnimation, CreateAnimationProps } from './CreateAnimation';
+export { CreateAnimation } from './CreateAnimation';
 
 // Icons that are used by internal components
 addIcons({


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

React users would need to use the raw animations API to use Ionic Animations.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added an experimental wrapper component. Does not currently support everything (I.e. adding child animations, etc).
- Users can still access the raw animation object for more advanced features.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
