### PR TITLE
fix(refresher): add correct fallbacks for native refreshers

### DIFF
--- a/core/src/components/refresher-content/refresher-content.tsx
+++ b/core/src/components/refresher-content/refresher-content.tsx
@@ -1,4 +1,4 @@
-import { Component, ComponentInterface, Host, Prop, h } from '@stencil/core';
+import { Component, ComponentInterface, Element, Host, Prop, h } from '@stencil/core';
 
 import { config } from '../../global/config';
 import { getIonMode } from '../../global/ionic-global';
@@ -11,6 +11,8 @@ import { SPINNERS } from '../spinner/spinner-configs';
   tag: 'ion-refresher-content'
 })
 export class RefresherContent implements ComponentInterface {
+
+  @Element() el!: HTMLIonRefresherContentElement;
 
   /**
    * A static icon or a spinner to display when you begin to pull down.
@@ -49,9 +51,10 @@ export class RefresherContent implements ComponentInterface {
   componentWillLoad() {
     if (this.pullingIcon === undefined) {
       const mode = getIonMode(this);
+      const overflowRefresher = (this.el.style as any).webkitOverflowScrolling !== undefined ? 'lines' : 'arrow-down';
       this.pullingIcon = config.get(
         'refreshingIcon',
-        mode === 'ios' && isPlatform('mobile') ? config.get('spinner', 'lines') : 'circular'
+        mode === 'ios' && isPlatform('mobile') ? config.get('spinner', overflowRefresher) : 'circular'
       );
     }
     if (this.refreshingSpinner === undefined) {

--- a/core/src/components/refresher/refresher.utils.ts
+++ b/core/src/components/refresher/refresher.utils.ts
@@ -174,7 +174,7 @@ export const shouldUseNativeRefresher = (referenceEl: HTMLIonRefresherElement, m
     pullingSpinner !== null &&
     refreshingSpinner !== null &&
     (
-      (mode === 'ios' && isPlatform('mobile')) ||
+      (mode === 'ios' && isPlatform('mobile') && (referenceEl.style as any).webkitOverflowScrolling !== undefined) ||
       mode === 'md'
     )
 

--- a/core/src/themes/ionic.globals.scss
+++ b/core/src/themes/ionic.globals.scss
@@ -46,7 +46,7 @@ $z-index-click-block:            99999;
 
 $z-index-fixed-content:          999;
 $z-index-scroll-content:         1;
-$z-index-refresher:              -1;
+$z-index-refresher:              0;
 
 $z-index-page-container:         0;
 $z-index-toolbar:                10;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Native refreshers were not falling back properly. Running in iOS mode on Chrome should fallback to the old refresher but was not.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added checks to do a best guess at detecting overflow scrolling support (I don't know if iOS 14 will remove the webkitOverflowScrolling property so I'll need to test the betas as they come out)
- Updated the icon defaults so the iOS fallback doesn't look as bad 
- Fixed the z-index issue with the old refresher

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
