### PR TITLE
fix(header): fix race condition in collapsible header

### DIFF
--- a/core/src/components/header/header.tsx
+++ b/core/src/components/header/header.tsx
@@ -114,7 +114,6 @@ export class Header implements ComponentInterface {
      */
     const toolbarIntersection = (ev: any) => { handleToolbarIntersection(ev, mainHeaderIndex, scrollHeaderIndex); };
 
-    // Subtracting 1 pixel gives us some wiggle room for ensuring everything is reset in different edge cases
     this.intersectionObserver = new IntersectionObserver(toolbarIntersection, { root: contentEl, threshold: [0.25, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1] });
     this.intersectionObserver.observe(scrollHeaderIndex.toolbars[scrollHeaderIndex.toolbars.length - 1].el);
 

--- a/core/src/components/header/header.tsx
+++ b/core/src/components/header/header.tsx
@@ -1,4 +1,4 @@
-import { Component, ComponentInterface, Element, Host, Prop, h, readTask, writeTask } from '@stencil/core';
+import { Component, ComponentInterface, Element, Host, Prop, h, writeTask } from '@stencil/core';
 
 import { getIonMode } from '../../global/ionic-global';
 
@@ -106,29 +106,25 @@ export class Header implements ComponentInterface {
       setToolbarBackgroundOpacity(toolbar, 0);
     });
 
-    readTask(() => {
-        const mainHeaderHeight = mainHeaderIndex.el.clientHeight;
+    /**
+     * Handle interaction between toolbar collapse and
+     * showing/hiding content in the primary ion-header
+     * as well as progressively showing/hiding the main header
+     * border as the top-most toolbar collapses or expands.
+     */
+    const toolbarIntersection = (ev: any) => { handleToolbarIntersection(ev, mainHeaderIndex, scrollHeaderIndex); };
 
-        /**
-         * Handle interaction between toolbar collapse and
-         * showing/hiding content in the primary ion-header
-         * as well as progressively showing/hiding the main header
-         * border as the top-most toolbar collapses or expands.
-         */
-        const toolbarIntersection = (ev: any) => { handleToolbarIntersection(ev, mainHeaderIndex, scrollHeaderIndex); };
+    // Subtracting 1 pixel gives us some wiggle room for ensuring everything is reset in different edge cases
+    this.intersectionObserver = new IntersectionObserver(toolbarIntersection, { root: contentEl, threshold: [0.25, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1] });
+    this.intersectionObserver.observe(scrollHeaderIndex.toolbars[scrollHeaderIndex.toolbars.length - 1].el);
 
-        // Subtracting 1 pixel gives us some wiggle room for ensuring everything is reset in different edge cases
-        this.intersectionObserver = new IntersectionObserver(toolbarIntersection, { threshold: [0.25, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1], rootMargin: `-${mainHeaderHeight - 1}px 0px 0px 0px` });
-        this.intersectionObserver.observe(scrollHeaderIndex.toolbars[scrollHeaderIndex.toolbars.length - 1].el);
-
-      /**
-       * Handle scaling of large iOS titles and
-       * showing/hiding border on last toolbar
-       * in primary header
-       */
-        this.contentScrollCallback = () => { handleContentScroll(this.scrollEl!, scrollHeaderIndex, contentEl); };
-        this.scrollEl!.addEventListener('scroll', this.contentScrollCallback);
-    });
+    /**
+     * Handle scaling of large iOS titles and
+     * showing/hiding border on last toolbar
+     * in primary header
+     */
+    this.contentScrollCallback = () => { handleContentScroll(this.scrollEl!, scrollHeaderIndex, contentEl); };
+    this.scrollEl!.addEventListener('scroll', this.contentScrollCallback);
 
     writeTask(() => {
       cloneElement('ion-title');

--- a/core/src/components/header/header.utils.ts
+++ b/core/src/components/header/header.utils.ts
@@ -75,7 +75,13 @@ export const setToolbarBackgroundOpacity = (toolbar: ToolbarIndex, opacity?: num
 const handleToolbarBorderIntersection = (ev: any, mainHeaderIndex: HeaderIndex) => {
   if (!ev[0].isIntersecting) { return; }
 
-  const scale = ((1 - ev[0].intersectionRatio) * 100) / 75;
+  /**
+   * There is a bug in Safari where overflow scrolling on a non-body element
+   * does not always reset the scrollTop position to 0 when letting go. It will
+   * set to 1 once the rubber band effect has ended. This causes the background to
+   * appear slightly on certain app setups.
+   */
+  const scale = (ev[0].intersectionRatio > 0.9) ? 0 : ((1 - ev[0].intersectionRatio) * 100) / 75;
 
   mainHeaderIndex.toolbars.forEach(toolbar => {
     setToolbarBackgroundOpacity(toolbar, (scale === 1) ? undefined : scale);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There was a race condition where the outer header had not fully loaded and so its clientHeight was 0. This caused the IntersectionObserver to have the wrong margins causing the collapsible header to sometimes not work.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Set the IO root to be `ion-content` rather than the document root. Allowed me to remove a DOM read as well.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
