### PR TITLE
fix core router, not to reload on every back press, to prevent the sc…

### DIFF
--- a/core/src/components/router/router.tsx
+++ b/core/src/components/router/router.tsx
@@ -171,7 +171,7 @@ export class Router implements ComponentInterface {
 
     if (state > lastState) {
       return ROUTER_INTENT_FORWARD;
-    } else if (state < lastState) {
+    } else if (state <= lastState) {
       return ROUTER_INTENT_BACK;
     } else {
       return ROUTER_INTENT_NONE;


### PR DESCRIPTION
fix core router, not to reload on every back press, to prevent the scroll position for the ion-nav stack.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ x] Build (`npm run build`) was run locally and any changes were pushed
- [ x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
If i use the core router and click on a new link(ion-item href or ion-router-link), the page opens. If i press back, the page closes and the parent page that now is present will make a reload (scroll every time up).


## What is the new behavior?
The parent page does not reload.


## Does this introduce a breaking change?

- [ ] Yes
- [x ] No

