### PR TITLE
fix(label): remove subpixel font-size to prevent visual glitches

### DIFF
--- a/core/src/components/label/label.ios.scss
+++ b/core/src/components/label/label.ios.scss
@@ -37,7 +37,7 @@
 :host-context(.item-has-focus).label-floating,
 :host-context(.item-has-placeholder).label-floating,
 :host-context(.item-has-value).label-floating {
-  @include transform(translate3d(0, 0, 0), scale(.8));
+  @include transform(translate3d(0, 0, 0), scale(.82));
 }
 
 

--- a/core/src/components/label/label.ios.scss
+++ b/core/src/components/label/label.ios.scss
@@ -18,7 +18,7 @@
 :host(.label-stacked) {
   @include margin(null, null, 4px, null);
 
-  font-size: 13.6px;
+  font-size: 14px;
 }
 
 :host(.label-floating) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic/issues/20407

Subpixel font-sizes + CSS animations seem to cause some odd visual glitches in Safari, so I've opted to remove the subpixel font size here. There should be no noticeable difference in most browsers as the difference in size is only 0.4px.

This bug has no impact on browsers that support Web Animations.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Changed `13.6px` --> `14px`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
