### PR TITLE
fix(schematic): correct path for angular project

### DIFF
--- a/angular/src/schematics/add/index.ts
+++ b/angular/src/schematics/add/index.ts
@@ -117,7 +117,7 @@ export default function ngAdd(options: IonAddOptions): Rule {
         `Ionic Add requires a project type of "application".`
       );
     }
-    const sourcePath: Path = join(project.root as Path, project.sourceRoot as Path);
+    const sourcePath: Path = join(project.sourceRoot as Path);
     const rootTemplateSource = apply(url('./files/root'), [
       template({ ...options }),
       move(sourcePath)


### PR DESCRIPTION
`ng add @ionic/angular@next` throws error when add to angular project, because it have duplicate project root. 
Example: 
> `Could not find file for path: projects/mobile/projects/mobile/src/app/app.module.ts` this fix will only use project root once

This fix will update for Angular Ivy (Angular 9.0.1)

## Pull request checklist
Please check if your PR fulfills the following requirements:
Already try so much but I unable to make build and test on windows, I getting much error on `sass` so I not tested yet
- [ ] Tests for the changes have been added (for bug fixes / features)

## Pull request type
- Fix schematic for Angular project

Please check the type of change your PR introduces:
- [x] Bugfix

## What is the current behavior?
`ng add @ionic/angular` or `ng add @ionic/angular@next`

Issue Number: #20435

## What is the new behavior?
Unchanges

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

