### PR TITLE
fix(searchbar): properly align placeholder

### DIFF
--- a/core/src/components/searchbar/searchbar.tsx
+++ b/core/src/components/searchbar/searchbar.tsx
@@ -3,8 +3,7 @@ import { Component, ComponentInterface, Element, Event, EventEmitter, Host, Meth
 import { config } from '../../global/config';
 import { getIonMode } from '../../global/ionic-global';
 import { Color, SearchbarChangeEventDetail, StyleEventDetail } from '../../interface';
-import { debounceEvent } from '../../utils/helpers';
-import { sanitizeDOMString } from '../../utils/sanitization';
+import { debounceEvent, raf } from '../../utils/helpers';
 import { createColorClasses } from '../../utils/theme';
 
 /**
@@ -335,27 +334,29 @@ export class Searchbar implements ComponentInterface {
       // Create a dummy span to get the placeholder width
       const doc = document;
       const tempSpan = doc.createElement('span');
-      tempSpan.innerHTML = sanitizeDOMString(this.placeholder) || '';
+      tempSpan.innerText = this.placeholder || '';
       doc.body.appendChild(tempSpan);
 
       // Get the width of the span then remove it
-      const textWidth = tempSpan.offsetWidth;
-      tempSpan.remove();
+      raf(() => {
+        const textWidth = tempSpan.offsetWidth;
+        tempSpan.remove();
 
-      // Calculate the input padding
-      const inputLeft = 'calc(50% - ' + (textWidth / 2) + 'px)';
+        // Calculate the input padding
+        const inputLeft = 'calc(50% - ' + (textWidth / 2) + 'px)';
 
-      // Calculate the icon margin
-      const iconLeft = 'calc(50% - ' + ((textWidth / 2) + 30) + 'px)';
+        // Calculate the icon margin
+        const iconLeft = 'calc(50% - ' + ((textWidth / 2) + 30) + 'px)';
 
-      // Set the input padding start and icon margin start
-      if (isRTL) {
-        inputEl.style.paddingRight = inputLeft;
-        iconEl.style.marginRight = iconLeft;
-      } else {
-        inputEl.style.paddingLeft = inputLeft;
-        iconEl.style.marginLeft = iconLeft;
-      }
+        // Set the input padding start and icon margin start
+        if (isRTL) {
+          inputEl.style.paddingRight = inputLeft;
+          iconEl.style.marginRight = iconLeft;
+        } else {
+          inputEl.style.paddingLeft = inputLeft;
+          iconEl.style.marginLeft = iconLeft;
+        }
+      });
     }
   }
 

--- a/core/src/components/searchbar/test/basic/index.html
+++ b/core/src/components/searchbar/test/basic/index.html
@@ -103,6 +103,10 @@
       <ion-searchbar id="dynamicAttr" placeholder="Search" animated="true" show-cancel-button="never">
       </ion-searchbar>
 
+      <h5 class="ion-padding-start ion-padding-top"> Search - HTML Placeholder Treated As Text </h5>
+      <ion-searchbar mode="ios" animated="true" show-cancel-button="focus" placeholder="<ion-button>Hello</ion-button>">
+      </ion-searchbar>
+
       <p class="ion-padding">
         <ion-button expand="block" (click)="changeValue()">Change Value</ion-button>
       </p>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic/issues/20456


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Ensured that placeholder content is being interpreted as plain text.
- Also added an `raf` to help with race conditions when getting the width of the temporary span. It doesn't 100% fix the issue, but it significantly helps.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
