### PR TITLE
fix(segment): only emit ionChange when user releases pointer from screen

### DIFF
--- a/angular/src/directives/control-value-accessors/value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/value-accessor.ts
@@ -12,7 +12,7 @@ export class ValueAccessor implements ControlValueAccessor {
   constructor(protected el: ElementRef) {}
 
   writeValue(value: any) {
-    this.el.nativeElement.value = this.lastValue = value == null ? '' : value;
+    this.el.nativeElement.value = this.lastValue = value;
     setIonicClasses(this.el);
   }
 

--- a/angular/src/directives/control-value-accessors/value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/value-accessor.ts
@@ -12,7 +12,14 @@ export class ValueAccessor implements ControlValueAccessor {
   constructor(protected el: ElementRef) {}
 
   writeValue(value: any) {
-    this.el.nativeElement.value = this.lastValue = value;
+    /**
+     * TODO for Ionic 6:
+     * Change `value == null ? '' : value;`
+     * to `value`. This was a fix for IE9, but IE9
+     * is no longer supported; however, this change
+     * is potentially a breaking change
+     */
+    this.el.nativeElement.value = this.lastValue = value == null ? '' : value;
     setIonicClasses(this.el);
   }
 

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -5209,7 +5209,7 @@ declare namespace LocalJSX {
     */
     'mode'?: "ios" | "md";
     /**
-    * Emitted when the value property has changed.
+    * Emitted when the value property has changed and any dragging pointer has been released from `ion-segment`.
     */
     'onIonChange'?: (event: CustomEvent<SegmentChangeEventDetail>) => void;
     /**

--- a/core/src/components/segment-button/segment-button.tsx
+++ b/core/src/components/segment-button/segment-button.tsx
@@ -49,14 +49,14 @@ export class SegmentButton implements ComponentInterface, ButtonInterface {
     const segmentEl = this.segmentEl = this.el.closest('ion-segment');
     if (segmentEl) {
       this.updateState();
-      segmentEl.addEventListener('ionChange', this.updateState);
+      segmentEl.addEventListener('ionSelect', this.updateState);
     }
   }
 
   disconnectedCallback() {
     const segmentEl = this.segmentEl;
     if (segmentEl) {
-      segmentEl.removeEventListener('ionChange', this.updateState);
+      segmentEl.removeEventListener('ionSelect', this.updateState);
       this.segmentEl = null;
     }
   }

--- a/core/src/components/segment/readme.md
+++ b/core/src/components/segment/readme.md
@@ -449,9 +449,9 @@ export const SegmentExample: React.FC = () => (
 
 ## Events
 
-| Event       | Description                                  | Type                                    |
-| ----------- | -------------------------------------------- | --------------------------------------- |
-| `ionChange` | Emitted when the value property has changed. | `CustomEvent<SegmentChangeEventDetail>` |
+| Event       | Description                                                                                                | Type                                    |
+| ----------- | ---------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `ionChange` | Emitted when the value property has changed and any dragging pointer has been released from `ion-segment`. | `CustomEvent<SegmentChangeEventDetail>` |
 
 
 ## CSS Custom Properties

--- a/core/src/components/segment/segment.tsx
+++ b/core/src/components/segment/segment.tsx
@@ -21,7 +21,6 @@ export class Segment implements ComponentInterface {
   private gesture?: Gesture;
   private didInit = false;
   private checked?: HTMLIonSegmentButtonElement;
-  private pointerDown = false;
 
   // Value to be emitted when gesture ends
   private valueAfterGesture?: any;
@@ -58,7 +57,7 @@ export class Segment implements ComponentInterface {
   protected valueChanged(value: string | undefined) {
     if (this.didInit) {
       this.ionSelect.emit({ value });
-      if (!this.pointerDown) {
+      if (!this.activated) {
         this.ionChange.emit({ value });
       } else {
         this.valueAfterGesture = value;
@@ -131,7 +130,6 @@ export class Segment implements ComponentInterface {
   }
 
   onStart(detail: GestureDetail) {
-    this.pointerDown = true;
     this.activate(detail);
   }
 
@@ -140,7 +138,6 @@ export class Segment implements ComponentInterface {
   }
 
   onEnd(detail: GestureDetail) {
-    this.pointerDown = false;
     this.setActivated(false);
 
     const checkedValidButton = this.setNextIndex(detail, true);

--- a/core/src/components/segment/segment.tsx
+++ b/core/src/components/segment/segment.tsx
@@ -56,7 +56,7 @@ export class Segment implements ComponentInterface {
   @Watch('value')
   protected valueChanged(value: string | undefined, oldValue: string | undefined | null) {
     this.ionSelect.emit({ value });
-    if (oldValue !== null || this.didInit) {
+    if (oldValue !== '' || this.didInit) {
       if (!this.activated) {
         this.ionChange.emit({ value });
       } else {

--- a/core/src/components/segment/segment.tsx
+++ b/core/src/components/segment/segment.tsx
@@ -54,9 +54,9 @@ export class Segment implements ComponentInterface {
   @Prop({ mutable: true }) value?: string | null;
 
   @Watch('value')
-  protected valueChanged(value: string | undefined) {
-    if (this.didInit) {
-      this.ionSelect.emit({ value });
+  protected valueChanged(value: string | undefined, oldValue: string | undefined | null) {
+    this.ionSelect.emit({ value });
+    if (oldValue !== null || this.didInit) {
       if (!this.activated) {
         this.ionChange.emit({ value });
       } else {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic/issues/20257 https://github.com/ionic-team/ionic/issues/20500


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `ionChange` is now emitted when the user removes their pointer from screen (And if the value has changed)
- This moves segment back in line with the iOS spec, so it is being considered a bug instead of a breaking change.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
