### PR TITLE
fix(segment): inner div no longer interferes with click events

### DIFF
--- a/core/src/components/segment-button/segment-button.scss
+++ b/core/src/components/segment-button/segment-button.scss
@@ -72,6 +72,8 @@
   white-space: nowrap;
 
   font-kerning: none;
+
+  cursor: pointer;
 }
 
 .button-native {
@@ -107,7 +109,7 @@
   background: transparent;
 
   contain: content;
-  cursor: pointer;
+  pointer-events: none;
 
   overflow: hidden;
 
@@ -130,7 +132,6 @@
   height: 100%;
 
   z-index: 1;
-  pointer-events: none;
 }
 
 

--- a/core/src/components/segment-button/segment-button.scss
+++ b/core/src/components/segment-button/segment-button.scss
@@ -130,6 +130,7 @@
   height: 100%;
 
   z-index: 1;
+  pointer-events: none;
 }
 
 

--- a/core/src/components/segment/test/basic/index.html
+++ b/core/src/components/segment/test/basic/index.html
@@ -164,6 +164,18 @@
           </ion-segment-button>
         </ion-segment>
 
+        <ion-segment>
+          <ion-segment-button value="active">
+            <div class="square red"></div>
+          </ion-segment-button>
+          <ion-segment-button name="dynamicAttrDisable">
+            <div class="square green"></div>
+          </ion-segment-button>
+          <ion-segment-button value="inactive">
+            <div class="square blue"></div>
+          </ion-segment-button>
+        </ion-segment>
+
         <!-- Dynamic Buttons -->
         <ion-segment id="dynamicButtons"></ion-segment>
       </div>
@@ -236,6 +248,24 @@
     </ion-content>
 
     <style>
+      .square {
+        width: 20px;
+        height: 20px;
+        background: black;
+      }
+
+      .square.red {
+        background: red;
+      }
+
+      .square.green {
+        background: green;
+      }
+
+      .square.blue {
+        background: blue;
+      }
+
       ion-content ion-segment {
         margin-bottom: 10px;
       }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic/issues/20381 Adding divs and other content inside of `ion-segment-button` prevented that button from getting selected when clicking inside of the custom content.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Inner divs no longer have pointer events, so they cannot interfere with the click events on segment

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
