### PR TITLE
fix(ios): clamp out of bounds values for swipe to go back

### DIFF
--- a/core/src/utils/gesture/swipe-back.ts
+++ b/core/src/utils/gesture/swipe-back.ts
@@ -1,5 +1,6 @@
-import { Gesture, GestureDetail, createGesture } from './index';
 import { clamp } from '../helpers';
+
+import { Gesture, GestureDetail, createGesture } from './index';
 
 export const createSwipeBackGesture = (
   el: HTMLElement,

--- a/core/src/utils/gesture/swipe-back.ts
+++ b/core/src/utils/gesture/swipe-back.ts
@@ -1,4 +1,5 @@
 import { Gesture, GestureDetail, createGesture } from './index';
+import { clamp } from '../helpers';
 
 export const createSwipeBackGesture = (
   el: HTMLElement,
@@ -38,12 +39,11 @@ export const createSwipeBackGesture = (
     }
 
     /**
-     * TODO: stepValue can sometimes return a negative
-     * value, but you can't have a negative time value
-     * for the cubic bezier curve (at least with web animations)
-     * Not sure if the negative step value is an error or not
+     * TODO: stepValue can sometimes return negative values
+     * or values greater than 1 which should not be possible.
+     * Need to investigate more to find where the issue is.
      */
-    onEndHandler(shouldComplete, (stepValue <= 0) ? 0.01 : stepValue, realDur);
+    onEndHandler(shouldComplete, (stepValue <= 0) ? 0.01 : clamp(0, stepValue, 0.9999), realDur);
   };
 
   return createGesture({


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic/issues/20505

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Swipe handler for some reason gives values <0 and >1 which is incorrect. Added a TODO to investigate, but for now just clamp the values

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
