### PR TITLE
fix(menu): hardware back button now dismisses side menu if open

### DIFF
--- a/core/src/utils/hardware-back-button.ts
+++ b/core/src/utils/hardware-back-button.ts
@@ -55,3 +55,6 @@ const executeAction = async (handler: Handler | undefined) => {
     console.error(e);
   }
 };
+
+export const OVERLAY_BACK_BUTTON_PRIORITY = 100;
+export const MENU_BACK_BUTTON_PRIORITY = 99; // 1 less than overlay priority since menu is displayed behind overlays

--- a/core/src/utils/menu-controller/index.ts
+++ b/core/src/utils/menu-controller/index.ts
@@ -1,4 +1,5 @@
-import { AnimationBuilder, MenuI } from '../../interface';
+import { AnimationBuilder, BackButtonEvent, MenuI } from '../../interface';
+import { MENU_BACK_BUTTON_PRIORITY } from '../hardware-back-button';
 
 import { menuOverlayAnimation } from './animations/overlay';
 import { menuPushAnimation } from './animations/push';
@@ -205,6 +206,16 @@ const createMenuController = () => {
   registerAnimation('reveal', menuRevealAnimation);
   registerAnimation('push', menuPushAnimation);
   registerAnimation('overlay', menuOverlayAnimation);
+
+  const doc: Document = document;
+  doc.addEventListener('ionBackButton', (ev: any) => {
+    const openMenu = _getOpenSync();
+    if (openMenu) {
+      (ev as BackButtonEvent).detail.register(MENU_BACK_BUTTON_PRIORITY, () => {
+        return openMenu.close();
+      });
+    }
+  });
 
   return {
     registerAnimation,

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -1,6 +1,8 @@
 import { config } from '../global/config';
 import { ActionSheetOptions, AlertOptions, Animation, AnimationBuilder, BackButtonEvent, HTMLIonOverlayElement, IonicConfig, LoadingOptions, ModalOptions, OverlayInterface, PickerOptions, PopoverOptions, ToastOptions } from '../interface';
 
+import { OVERLAY_BACK_BUTTON_PRIORITY } from './hardware-back-button';
+
 let lastId = 0;
 
 export const activeAnimations = new WeakMap<OverlayInterface, Animation[]>();
@@ -72,7 +74,7 @@ export const connectListeners = (doc: Document) => {
     doc.addEventListener('ionBackButton', ev => {
       const lastOverlay = getOverlay(doc);
       if (lastOverlay && lastOverlay.backdropDismiss) {
-        (ev as BackButtonEvent).detail.register(100, () => {
+        (ev as BackButtonEvent).detail.register(OVERLAY_BACK_BUTTON_PRIORITY, () => {
           return lastOverlay.dismiss(undefined, BACKDROP);
         });
       }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic/issues/20559
Tapping the hardware back button does not close an open side menu


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Tapping the hardware back button closes the open side menu

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
