### PR TITLE
fix(modal): swipeable modal styles only apply to ios

### DIFF
--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -255,7 +255,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
         aria-modal="true"
         class={{
           [mode]: true,
-          [`modal-card`]: this.presentingElement !== undefined,
+          [`modal-card`]: this.presentingElement !== undefined && mode === 'ios',
           ...getClassMap(this.cssClass)
         }}
         style={{

--- a/core/src/css/core.scss
+++ b/core/src/css/core.scss
@@ -35,7 +35,7 @@ body.backdrop-no-scroll {
 // The card style does not reach all the way to
 // the top of the screen, so there does not need
 // to be any safe area padding added
-ion-modal.modal-card .ion-page > ion-header > ion-toolbar:first-child {
+html.ios ion-modal.modal-card .ion-page > ion-header > ion-toolbar:first-child {
   padding-top: 0px;
 }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic/issues/20569


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Ensure that global modal card styles only apply to iOS mode
- Ensure that `modal-card` class only added when mode === ios

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
