### PR TITLE
chore(release): update to latest octokit and usage

### DIFF
--- a/.scripts/common.js
+++ b/.scripts/common.js
@@ -36,11 +36,11 @@ function projectPath(project) {
   return path.join(rootDir, project);
 }
 
-async function askTag() {
+async function askNpmTag(version) {
   const prompts = [
     {
       type: 'list',
-      name: 'tag',
+      name: 'npmTag',
       message: 'Select npm tag or specify a new tag',
       choices: ['latest', 'next', 'v4-lts']
         .concat([
@@ -55,13 +55,13 @@ async function askTag() {
       type: 'confirm',
       name: 'confirm',
       message: answers => {
-        return `Will publish to ${tc.cyan(answers.tag)}. Continue?`;
+        return `Will publish ${tc.cyan(version)} to ${tc.cyan(answers.npmTag)}. Continue?`;
       }
     }
   ];
 
-  const { tag, confirm } = await inquirer.prompt(prompts);
-  return { tag, confirm };
+  const { npmTag, confirm } = await inquirer.prompt(prompts);
+  return { npmTag, confirm };
 }
 
 function checkGit(tasks) {
@@ -310,7 +310,7 @@ function copyPackageToDist(tasks, packages) {
   });
 }
 
-function publishPackages(tasks, packages, version, tag = 'latest') {
+function publishPackages(tasks, packages, version, npmTag = 'latest') {
   // first verify version
   packages.forEach(package => {
     if (package === 'core') {
@@ -338,9 +338,9 @@ function publishPackages(tasks, packages, version, tag = 'latest') {
     }
 
     tasks.push({
-      title: `${package}: publish to ${tag} tag`,
+      title: `${package}: publish to ${npmTag} tag`,
       task: async () => {
-        await execa('npm', ['publish', '--tag', tag], { cwd: projectRoot });
+        await execa('npm', ['publish', '--tag', npmTag], { cwd: projectRoot });
       }
     });
   });
@@ -375,7 +375,7 @@ function copyCDNLoader(tasks, version) {
 module.exports = {
   checkTestDist,
   checkGit,
-  askTag,
+  askNpmTag,
   isValidVersion,
   isVersionGreater,
   copyCDNLoader,

--- a/.scripts/release.js
+++ b/.scripts/release.js
@@ -6,7 +6,7 @@ const tc = require('turbocolor');
 const execa = require('execa');
 const Listr = require('listr');
 const path = require('path');
-const octokit = require('@octokit/rest')()
+const { Octokit } = require("@octokit/rest");
 const common = require('./common');
 const fs = require('fs-extra');
 
@@ -28,7 +28,7 @@ async function main() {
     // repo must be clean
     common.checkGit(tasks);
 
-    const { tag, confirm } = await common.askTag();
+    const { npmTag, confirm } = await common.askNpmTag(version);
 
     if (!confirm) {
       return;
@@ -36,10 +36,10 @@ async function main() {
 
     if(!dryRun) {
       // publish each package in NPM
-      common.publishPackages(tasks, common.packages, version, tag);
+      common.publishPackages(tasks, common.packages, version, npmTag);
 
       // push tag to git remote
-      publishGit(tasks, version, changelog);
+      publishGit(tasks, version, changelog, npmTag);
     }
 
     const listr = new Listr(tasks);
@@ -48,10 +48,10 @@ async function main() {
     // Dry run doesn't publish to npm or git
     if (dryRun) {
       console.log(`
-        \n${tc.yellow('Did not publish. Remove the "--dry-run" flag to publish:')}\n${tc.green(version)} to ${tc.cyan(tag)}\n
+        \n${tc.yellow('Did not publish. Remove the "--dry-run" flag to publish:')}\n${tc.green(version)} to ${tc.cyan(npmTag)}\n
       `);
     } else {
-      console.log(`\nionic ${version} published to ${tag}!! 🎉\n`);
+      console.log(`\nionic ${version} published to ${npmTag}!! 🎉\n`);
     }
 
   } catch (err) {
@@ -70,13 +70,13 @@ function checkProductionRelease() {
   }
 }
 
-function publishGit(tasks, version, changelog) {
-  const tag = `v${version}`;
+function publishGit(tasks, version, changelog, npmTag) {
+  const gitTag = `v${version}`;
 
   tasks.push(
     {
-      title: `Tag latest commit ${tc.dim(`(${tag})`)}`,
-      task: () => execa('git', ['tag', `${tag}`], { cwd: common.rootDir })
+      title: `Tag latest commit ${tc.dim(`(${gitTag})`)}`,
+      task: () => execa('git', ['tag', `${gitTag}`], { cwd: common.rootDir })
     },
     {
       title: 'Push branches to remote',
@@ -88,7 +88,7 @@ function publishGit(tasks, version, changelog) {
     },
     {
       title: 'Publish Github release',
-      task: () => publishGithub(version, tag, changelog)
+      task: () => publishGithub(version, gitTag, changelog, npmTag)
     }
   );
 }
@@ -116,10 +116,12 @@ function findChangelog() {
   return lines.slice(start, end).join('\n').trim();
 }
 
-async function publishGithub(version, tag, changelog) {
-  octokit.authenticate({
-    type: 'oauth',
-    token: process.env.GH_TOKEN
+async function publishGithub(version, gitTag, changelog, npmTag) {
+  // If the npm tag is next then publish as a prerelease
+  const prerelease = npmTag === 'next' ? true : false;
+
+  const octokit = new Octokit({
+    auth: process.env.GH_TOKEN
   });
 
   let branch = await execa.stdout('git', ['symbolic-ref', '--short', 'HEAD']);
@@ -132,9 +134,10 @@ async function publishGithub(version, tag, changelog) {
     owner: 'ionic-team',
     repo: 'ionic',
     target_commitish: branch,
-    tag_name: tag,
+    tag_name: gitTag,
     name: version,
     body: changelog,
+    prerelease: prerelease
   });
 }
 

--- a/.scripts/release.js
+++ b/.scripts/release.js
@@ -6,7 +6,7 @@ const tc = require('turbocolor');
 const execa = require('execa');
 const Listr = require('listr');
 const path = require('path');
-const { Octokit } = require("@octokit/rest");
+const { Octokit } = require('@octokit/rest');
 const common = require('./common');
 const fs = require('fs-extra');
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "changelog": "conventional-changelog -p angular -i ./CHANGELOG.md -k core -s"
   },
   "devDependencies": {
-    "@octokit/rest": "^15.2.6",
+    "@octokit/rest": "^17.0.0",
     "conventional-changelog-cli": "^2.0.1",
     "execa": "^0.10.0",
     "fs-extra": "^7.0.0",


### PR DESCRIPTION
- rename all references of `tag` to either `gitTag` or `npmTag` based on what they contain since this was confusing throughout
- add the code to publish to git as a prerelease if the npm tag is `next`
- log the version when asking if the npm tag is correct