### PR TITLE
fix(slides): set height to 100% for vertical slides

### DIFF
--- a/core/src/components/slides/slides-vendor.scss
+++ b/core/src/components/slides/slides-vendor.scss
@@ -21,6 +21,9 @@
 .swiper-container-no-flexbox .swiper-slide {
   float: left;
 }
+.swiper-container-vertical {
+  height: 100%;
+}
 .swiper-container-vertical > .swiper-wrapper {
   -webkit-box-orient: vertical;
   -webkit-box-direction: normal;

--- a/core/src/components/slides/test/vertical/e2e.ts
+++ b/core/src/components/slides/test/vertical/e2e.ts
@@ -1,0 +1,10 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+test('slides: basic', async () => {
+  const page = await newE2EPage({
+    url: '/src/components/slides/test/basic?ionic:_testing=true'
+  });
+
+  const compare = await page.compareScreenshot();
+  expect(compare).toMatchScreenshot();
+});

--- a/core/src/components/slides/test/vertical/e2e.ts
+++ b/core/src/components/slides/test/vertical/e2e.ts
@@ -1,8 +1,8 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-test('slides: basic', async () => {
+test('slides: vertical', async () => {
   const page = await newE2EPage({
-    url: '/src/components/slides/test/basic?ionic:_testing=true'
+    url: '/src/components/slides/test/vertical?ionic:_testing=true'
   });
 
   const compare = await page.compareScreenshot();

--- a/core/src/components/slides/test/vertical/index.html
+++ b/core/src/components/slides/test/vertical/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html dir="ltr">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Slides - Vertical</title>
+
+  <meta name="viewport" content="viewport-fit=cover, width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <link href="../../../../../css/ionic.bundle.css" rel="stylesheet">
+  <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
+  <script src="../../../../../scripts/testing/scripts.js"></script>
+  <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
+  <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content id="content">
+      <ion-slides pager>
+        <ion-slide style="background: #24a5a3; color: white;">
+          <h1>Slide 1</h1>
+        </ion-slide>
+        <ion-slide style="background: #a52466; color: white;">
+          <h1>Slide 2</h1>
+        </ion-slide>
+        <ion-slide style="background: #24a562; color: white;">
+          <h1>Slide 3</h1>
+        </ion-slide>
+      </ion-slides>
+    </ion-content>
+
+  </ion-app>
+
+  <script>
+    const slides = document.querySelector('ion-slides');
+
+    slides.options = {
+      direction: 'vertical'
+    };
+  </script>
+
+  <style>
+    /* Important is required due to slides being scoped */
+    ion-slides {
+      --bullet-background-active: white !important;
+    }
+  </style>
+</body>
+
+</html>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Slides doesn't take up a set height so it will show some of the inactive slides when direction is set to vertical

Issue Number: fixes #17341

Dev build: `5.1.0-dev.202002241801.ce23bbc`

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This sets the slides height to 100% which will ensure that only the active slide is visible until swiping. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
