### PR TITLE
fix(select): add icon-inner & placeholder part

### DIFF
--- a/core/src/components/select/select.scss
+++ b/core/src/components/select/select.scss
@@ -21,6 +21,8 @@
   display: flex;
   position: relative;
 
+  align-items: center;
+
   font-family: $font-family-base;
 
   overflow: hidden;

--- a/core/src/components/select/select.scss
+++ b/core/src/components/select/select.scss
@@ -87,7 +87,5 @@ button {
 
   color: currentColor;
 
-  opacity: inherit;
-
   pointer-events: none;
 }

--- a/core/src/components/select/select.scss
+++ b/core/src/components/select/select.scss
@@ -54,6 +54,8 @@ button {
 
 .select-icon {
   position: relative;
+
+  opacity: .33;
 }
 
 .select-text {
@@ -85,7 +87,7 @@ button {
 
   color: currentColor;
 
-  opacity: .33;
+  opacity: inherit;
 
   pointer-events: none;
 }

--- a/core/src/components/select/select.tsx
+++ b/core/src/components/select/select.tsx
@@ -11,6 +11,11 @@ import { SelectCompareFn } from './select-interface';
 
 /**
  * @virtualProp {"ios" | "md"} mode - The mode determines which platform styles to use.
+ *
+ * @part placeholder - The text displayed in the select when there is no value.
+ * @part text - The displayed value of the select.
+ * @part icon - The select icon container.
+ * @part icon-inner - The select icon.
  */
 @Component({
   tag: 'ion-select',
@@ -426,6 +431,8 @@ export class Select implements ComponentInterface {
       'select-placeholder': addPlaceholderClass
     };
 
+    const textPart = addPlaceholderClass ? 'placeholder' : 'text';
+
     return (
       <Host
         onClick={this.onClick}
@@ -440,11 +447,11 @@ export class Select implements ComponentInterface {
           'select-disabled': disabled,
         }}
       >
-        <div class={selectTextClasses} part="text">
+        <div class={selectTextClasses} part={textPart}>
           {selectText}
         </div>
         <div class="select-icon" role="presentation" part="icon">
-          <div class="select-icon-inner"></div>
+          <div class="select-icon-inner" part="icon-inner"></div>
         </div>
         <button
           type="button"

--- a/core/src/components/select/test/custom/e2e.ts
+++ b/core/src/components/select/test/custom/e2e.ts
@@ -1,0 +1,27 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+test('select: custom', async () => {
+  const page = await newE2EPage({
+    url: '/src/components/select/test/custom?ionic:_testing=true'
+  });
+
+  const compares = [];
+  compares.push(await page.compareScreenshot());
+
+  for (const compare of compares) {
+    expect(compare).toMatchScreenshot();
+  }
+});
+
+test('select:rtl: custom', async () => {
+  const page = await newE2EPage({
+    url: '/src/components/select/test/custom?ionic:_testing=true&rtl=true'
+  });
+
+  const compares = [];
+  compares.push(await page.compareScreenshot());
+
+  for (const compare of compares) {
+    expect(compare).toMatchScreenshot();
+  }
+});

--- a/core/src/components/select/test/custom/index.html
+++ b/core/src/components/select/test/custom/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html dir="ltr">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Select - Custom</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <link href="../../../../../css/ionic.bundle.css" rel="stylesheet">
+  <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
+  <script src="../../../../../scripts/testing/scripts.js"></script>
+  <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
+  <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script></head>
+
+<body>
+  <ion-app>
+
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Select - Custom</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content class="outer-content test-content">
+      <ion-list>
+        <ion-list-header>
+          <ion-label>
+            Standalone Select
+          </ion-label>
+        </ion-list-header>
+
+        <ion-select placeholder="Default Select">
+          <ion-select-option value="madison">Madison, WI</ion-select-option>
+          <ion-select-option value="austin">Austin, TX</ion-select-option>
+          <ion-select-option value="chicago">Chicago, IL</ion-select-option>
+          <ion-select-option value="seattle">Seattle, WA</ion-select-option>
+        </ion-select>
+
+        <ion-select placeholder="Placeholder" class="custom-part-colors">
+          <ion-select-option value="madison">Madison, WI</ion-select-option>
+          <ion-select-option value="austin">Austin, TX</ion-select-option>
+          <ion-select-option value="chicago">Chicago, IL</ion-select-option>
+          <ion-select-option value="seattle">Seattle, WA</ion-select-option>
+        </ion-select>
+
+        <ion-select value="austin" class="custom-part-colors">
+          <ion-select-option value="madison">Madison, WI</ion-select-option>
+          <ion-select-option value="austin">Austin, TX</ion-select-option>
+          <ion-select-option value="chicago">Chicago, IL</ion-select-option>
+          <ion-select-option value="seattle">Seattle, WA</ion-select-option>
+        </ion-select>
+
+        <ion-list-header>
+          <ion-label>
+            Item Select
+          </ion-label>
+        </ion-list-header>
+
+        <ion-item>
+          <ion-label>Gender</ion-label>
+          <ion-select placeholder="Default Select">
+            <ion-select-option value="madison">Madison, WI</ion-select-option>
+            <ion-select-option value="austin">Austin, TX</ion-select-option>
+            <ion-select-option value="chicago">Chicago, IL</ion-select-option>
+            <ion-select-option value="seattle">Seattle, WA</ion-select-option>
+          </ion-select>
+        </ion-item>
+      </ion-list>
+    </ion-content>
+
+    <style>
+      .custom-part-colors {
+        text-align: center;
+        justify-content: center;
+
+        border-radius: 6px;
+        box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
+
+        width: 80%;
+        margin: 10px auto;
+      }
+
+      .custom-part-colors::part(placeholder),
+      .custom-part-colors::part(text) {
+        flex: 0 0 auto;
+      }
+
+      .custom-part-colors::part(placeholder) {
+        color: green;
+        opacity: 1;
+      }
+
+      .custom-part-colors::part(text) {
+        color: blue;
+      }
+
+      .custom-part-colors::part(icon) {
+        color: red;
+        opacity: 1;
+      }
+    </style>
+
+  </ion-app>
+</body>
+
+</html>

--- a/core/src/components/select/test/custom/index.html
+++ b/core/src/components/select/test/custom/index.html
@@ -71,6 +71,7 @@
       .custom-part-colors {
         text-align: center;
         justify-content: center;
+        font-size: 13px;
 
         border-radius: 6px;
         box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);

--- a/core/src/components/select/test/custom/index.html
+++ b/core/src/components/select/test/custom/index.html
@@ -56,7 +56,7 @@
         </ion-list-header>
 
         <ion-item>
-          <ion-label>Gender</ion-label>
+          <ion-label>Location</ion-label>
           <ion-select placeholder="Default Select">
             <ion-select-option value="madison">Madison, WI</ion-select-option>
             <ion-select-option value="austin">Austin, TX</ion-select-option>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

This can be considered a feature or a fix, due to the fact it adds a new part, but we haven't documented any of these yet so I'm not sure which way to lean here.

You cannot change the opacity of the select icon or target the placeholder color with the current parts.

Placeholder - Due to the fact that the placeholder and value share the same div, you would have to be able to target it based on the `select-placeholder` class which does not work with parts. 

Select Icon - The opacity was set on the inner icon, so you can change the color using `::part(icon)` but it will still have the default `.33` opacity. I added a part for `icon-inner` since that is where the actual arrow is created, and also moved opacity so it is set on the parent wrapper which fixes this problem. 

Issue Number: #17248 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- adds `icon-inner` and `placeholder` parts
- adds custom test for styling the select parts
- remove opacity in icon-inner and set it on the icon wrapper
- align items center (vertically) - this makes alignment look nicer especially when font size changes

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
