### PR TITLE
feat(): add ability to continue processing hardware back button events

### DIFF
--- a/angular/src/providers/nav-controller.ts
+++ b/angular/src/providers/nav-controller.ts
@@ -45,7 +45,7 @@ export class NavController {
     }
 
     // Subscribe to backButton events
-    platform.backButton.subscribeWithPriority(0, (processNextHandler) => {
+    platform.backButton.subscribeWithPriority(0, processNextHandler => {
       this.pop();
       processNextHandler();
     });

--- a/angular/src/providers/nav-controller.ts
+++ b/angular/src/providers/nav-controller.ts
@@ -45,7 +45,10 @@ export class NavController {
     }
 
     // Subscribe to backButton events
-    platform.backButton.subscribeWithPriority(0, () => this.pop());
+    platform.backButton.subscribeWithPriority(0, (processNextHandler) => {
+      this.pop();
+      processNextHandler();
+    });
   }
 
   /**

--- a/angular/src/providers/platform.ts
+++ b/angular/src/providers/platform.ts
@@ -4,7 +4,7 @@ import { BackButtonEventDetail, Platforms, getPlatforms, isPlatform } from '@ion
 import { Subject, Subscription } from 'rxjs';
 
 export interface BackButtonEmitter extends Subject<BackButtonEventDetail> {
-  subscribeWithPriority(priority: number, callback: () => Promise<any> | void): Subscription;
+  subscribeWithPriority(priority: number, callback: (processNextHandler: () => void) => Promise<any> | void): Subscription;
 }
 
 @Injectable({
@@ -46,9 +46,9 @@ export class Platform {
     zone.run(() => {
       this.win = doc.defaultView;
       this.backButton.subscribeWithPriority = function(priority, callback) {
-        return this.subscribe(ev => (
-          ev.register(priority, () => zone.run(callback))
-        ));
+        return this.subscribe(ev => {
+          return ev.register(priority, (processNextHandler) => zone.run(() => callback(processNextHandler)));
+        });
       };
 
       proxyEvent(this.pause, doc, 'pause');

--- a/angular/src/providers/platform.ts
+++ b/angular/src/providers/platform.ts
@@ -47,7 +47,7 @@ export class Platform {
       this.win = doc.defaultView;
       this.backButton.subscribeWithPriority = function(priority, callback) {
         return this.subscribe(ev => {
-          return ev.register(priority, (processNextHandler) => zone.run(() => callback(processNextHandler)));
+          return ev.register(priority, processNextHandler => zone.run(() => callback(processNextHandler)));
         });
       };
 

--- a/core/src/components/router/router.tsx
+++ b/core/src/components/router/router.tsx
@@ -79,7 +79,10 @@ export class Router implements ComponentInterface {
 
   @Listen('ionBackButton', { target: 'document' })
   protected onBackButton(ev: BackButtonEvent) {
-    ev.detail.register(0, () => this.back());
+    ev.detail.register(0, processNextHandler => {
+      this.back();
+      processNextHandler();
+    });
   }
 
   /**

--- a/core/src/interface.d.ts
+++ b/core/src/interface.d.ts
@@ -53,7 +53,7 @@ export interface FrameworkDelegate {
 }
 
 export interface BackButtonEventDetail {
-  register(priority: number, handler: () => Promise<any> | void): void;
+  register(priority: number, handler: (processNextHandler: () => void) => Promise<any> | void): void;
 }
 
 export interface StyleEventDetail {

--- a/core/src/utils/hardware-back-button.ts
+++ b/core/src/utils/hardware-back-button.ts
@@ -31,7 +31,7 @@ export const startHardwareBackButton = () => {
 
     const executeAction = async (handlerRegister: HandlerRegister | undefined) => {
       try {
-        if (handlerRegister) {
+        if (handlerRegister && handlerRegister.handler) {
           const result = handlerRegister.handler(processHandlers);
           if (result != null) {
             await result;
@@ -46,7 +46,7 @@ export const startHardwareBackButton = () => {
       if (handlers.length > 0) {
         let selectedHandler: HandlerRegister = {
           priority: Number.MIN_SAFE_INTEGER,
-          handler: undefined,
+          handler: () => undefined,
           id: -1
         };
         handlers.forEach(handler => {

--- a/core/src/utils/hardware-back-button.ts
+++ b/core/src/utils/hardware-back-button.ts
@@ -1,10 +1,11 @@
 import { BackButtonEvent } from '../interface';
 
-type Handler = () => Promise<any> | void | null;
+type Handler = (processNextHandler: () => void) => Promise<any> | void | null;
 
 interface HandlerRegister {
   priority: number;
   handler: Handler;
+  id: number;
 }
 
 export const startHardwareBackButton = () => {
@@ -16,44 +17,52 @@ export const startHardwareBackButton = () => {
       return;
     }
 
-    const handlers: HandlerRegister[] = [];
+    let index = 0;
+    let handlers: HandlerRegister[] = [];
     const ev: BackButtonEvent = new CustomEvent('ionBackButton', {
       bubbles: false,
       detail: {
         register(priority: number, handler: Handler) {
-          handlers.push({ priority, handler });
+          handlers.push({ priority, handler, id: index++ });
         }
       }
     });
     doc.dispatchEvent(ev);
 
-    if (handlers.length > 0) {
-      let selectedPriority = Number.MIN_SAFE_INTEGER;
-      let selectedHandler: Handler | undefined;
-      handlers.forEach(({ priority, handler }) => {
-        if (priority >= selectedPriority) {
-          selectedPriority = priority;
-          selectedHandler = handler;
+    const executeAction = async (handlerRegister: HandlerRegister | undefined) => {
+      try {
+        if (handlerRegister) {
+          const result = handlerRegister.handler(processHandlers);
+          if (result != null) {
+            await result;
+          }
         }
-      });
-
-      busy = true;
-      executeAction(selectedHandler).then(() => busy = false);
-    }
-  });
-};
-
-const executeAction = async (handler: Handler | undefined) => {
-  try {
-    if (handler) {
-      const result = handler();
-      if (result != null) {
-        await result;
+      } catch (e) {
+        console.error(e);
       }
-    }
-  } catch (e) {
-    console.error(e);
-  }
+    };
+
+    const processHandlers = () => {
+      if (handlers.length > 0) {
+        let selectedHandler: HandlerRegister = {
+          priority: Number.MIN_SAFE_INTEGER,
+          handler: undefined,
+          id: -1
+        };
+        handlers.forEach(handler => {
+          if (handler.priority >= selectedHandler.priority) {
+            selectedHandler = handler;
+          }
+        });
+
+        busy = true;
+        handlers = handlers.filter(handler => handler.id !== selectedHandler.id);
+        executeAction(selectedHandler).then(() => busy = false);
+      }
+    };
+
+    processHandlers();
+  });
 };
 
 export const OVERLAY_BACK_BUTTON_PRIORITY = 100;

--- a/core/src/utils/test/hardware-back-button.spec.ts
+++ b/core/src/utils/test/hardware-back-button.spec.ts
@@ -1,0 +1,4 @@
+describe('Hardware Back Button', () => {
+  it('hello', () => {
+  });
+});

--- a/core/src/utils/test/hardware-back-button.spec.ts
+++ b/core/src/utils/test/hardware-back-button.spec.ts
@@ -1,4 +1,59 @@
+import { startHardwareBackButton } from '../hardware-back-button';
+
 describe('Hardware Back Button', () => {
-  it('hello', () => {
+  beforeEach(() => startHardwareBackButton());
+  it('should call handler', () => {
+    const cbSpy = jest.fn();
+    document.addEventListener('ionBackButton', (ev) => {
+      ev.detail.register(0, cbSpy);
+    });
+
+    dispatchBackButtonEvent();
+    expect(cbSpy).toHaveBeenCalled();
+  });
+
+  it('should call handlers in order of priority', () => {
+    const cbSpy = jest.fn();
+    const cbSpyTwo = jest.fn();
+    document.addEventListener('ionBackButton', (ev) => {
+      ev.detail.register(100, cbSpy);
+      ev.detail.register(99, cbSpyTwo);
+    });
+
+    dispatchBackButtonEvent();
+    expect(cbSpy).toHaveBeenCalled();
+    expect(cbSpyTwo).not.toHaveBeenCalled();
+  });
+
+  it('should only call last handler to be added for handlers with same priority', () => {
+    const cbSpy = jest.fn();
+    const cbSpyTwo = jest.fn();
+    document.addEventListener('ionBackButton', (ev) => {
+      ev.detail.register(100, cbSpy);
+      ev.detail.register(100, cbSpyTwo);
+    });
+
+    dispatchBackButtonEvent();
+    expect(cbSpy).not.toHaveBeenCalled();
+    expect(cbSpyTwo).toHaveBeenCalled();
+  });
+
+  it('should call multiple callbacks', () => {
+    const cbSpy = (processNextHandler) => {
+      processNextHandler();
+    }
+    const cbSpyTwo = jest.fn();
+    document.addEventListener('ionBackButton', (ev) => {
+      ev.detail.register(100, cbSpy);
+      ev.detail.register(99, cbSpyTwo);
+    });
+
+    dispatchBackButtonEvent();
+    expect(cbSpyTwo).toHaveBeenCalled();
   });
 });
+
+const dispatchBackButtonEvent = () => {
+  const ev = new Event('backbutton');
+  document.dispatchEvent(ev);
+}

--- a/packages/react-router/src/ReactRouter/NavManager.tsx
+++ b/packages/react-router/src/ReactRouter/NavManager.tsx
@@ -36,7 +36,7 @@ export class NavManager extends React.Component<NavManagerProps, NavContextState
 
     if (document) {
       document.addEventListener('ionBackButton', (e: any) => {
-        e.detail.register(0, processNextHandler => {
+        e.detail.register(0, (processNextHandler: () => void) => {
           this.props.history.goBack();
           processNextHandler();
         });

--- a/packages/react-router/src/ReactRouter/NavManager.tsx
+++ b/packages/react-router/src/ReactRouter/NavManager.tsx
@@ -36,8 +36,9 @@ export class NavManager extends React.Component<NavManagerProps, NavContextState
 
     if (document) {
       document.addEventListener('ionBackButton', (e: any) => {
-        e.detail.register(0, () => {
+        e.detail.register(0, processNextHandler => {
           this.props.history.goBack();
+          processNextHandler();
         });
       });
     }

--- a/vue/src/router.ts
+++ b/vue/src/router.ts
@@ -37,7 +37,10 @@ export default class Router extends VueRouter {
 
     // Listen to Ionic's back button event
     document.addEventListener('ionBackButton', (e: Event) => {
-      (e as BackButtonEvent).detail.register(0, () => this.back());
+      (e as BackButtonEvent).detail.register(0, processNextHandler => {
+        this.back();
+        processNextHandler();
+      });
     });
   }
 


### PR DESCRIPTION
blocks https://github.com/ionic-team/ionic-docs/pull/1356

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic/issues/17824


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added feature to allow multiple handlers to be processed sequentially
- Added docs with examples
- Added tests

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
