### PR TITLE
fix(buttons): use proper button colors with variables set inside of a toolbar

### DIFF
--- a/core/src/components/back-button/back-button.scss
+++ b/core/src/components/back-button/back-button.scss
@@ -239,6 +239,6 @@ ion-icon {
 // Back Button in Toolbar: Global Theming
 // --------------------------------------------------
 
-:host(.in-toolbar) {
+:host(.in-toolbar:not(.in-toolbar-color)) {
   color: #{var(--ion-toolbar-color, var(--color))};
 }

--- a/core/src/components/back-button/back-button.tsx
+++ b/core/src/components/back-button/back-button.tsx
@@ -114,6 +114,7 @@ export class BackButton implements ComponentInterface, ButtonInterface {
           'back-button-disabled': disabled,
           'back-button-has-icon-only': hasIconOnly,
           'in-toolbar': hostContext('ion-toolbar', this.el),
+          'in-toolbar-color': hostContext('ion-toolbar[color]', this.el),
           'ion-activatable': true,
           'ion-focusable': true,
           'show-back-button': showBackButton

--- a/core/src/components/button/button.ios.scss
+++ b/core/src/components/button/button.ios.scss
@@ -176,11 +176,11 @@
     background: #{current-color(tint)};
   }
 
-  // Solid buttons inside of a toolbar should use the toolbar background to
-  // appear opaque
+  // Solid buttons inside of a toolbar should use a tint of the current
+  // background so use white to tint it
   :host(:hover.button-solid.in-toolbar:not(.ion-color):not(.in-toolbar-color)) .button-native::after {
-    background: #{var(--ion-toolbar-background, var(--background, var(--background-hover)))};
+    background: #fff;
 
-    opacity: 0.45;
+    opacity: 0.10;
   }
 }

--- a/core/src/components/button/button.ios.scss
+++ b/core/src/components/button/button.ios.scss
@@ -175,4 +175,12 @@
   :host(.button-solid.ion-color:hover) .button-native::after {
     background: #{current-color(tint)};
   }
+
+  // Solid buttons inside of a toolbar should use the toolbar background to
+  // appear opaque
+  :host(:hover.button-solid.in-toolbar:not(.ion-color):not(.in-toolbar-color)) .button-native::after {
+    background: #{var(--ion-toolbar-background, var(--background, var(--background-hover)))};
+
+    opacity: 0.45;
+  }
 }

--- a/core/src/components/button/button.scss
+++ b/core/src/components/button/button.scss
@@ -305,3 +305,19 @@ ion-ripple-effect {
   background: transparent;
   color: current-color(base);
 }
+
+// Button in Toolbar
+// --------------------------------------------------
+
+:host(.in-toolbar:not(.ion-color):not(.in-toolbar-color)) .button-native {
+  color: #{var(--ion-toolbar-color, var(--color))};
+}
+
+:host(.button-outline.in-toolbar:not(.ion-color):not(.in-toolbar-color)) .button-native {
+  border-color: #{var(--ion-toolbar-color, var(--color, var(--border-color)))};
+}
+
+:host(.button-solid.in-toolbar:not(.ion-color):not(.in-toolbar-color)) .button-native {
+  background: #{var(--ion-toolbar-color, var(--background))};
+  color: #{var(--ion-toolbar-background, var(--color))};
+}

--- a/core/src/components/button/button.tsx
+++ b/core/src/components/button/button.tsx
@@ -4,7 +4,7 @@ import { getIonMode } from '../../global/ionic-global';
 import { Color, RouterDirection } from '../../interface';
 import { AnchorInterface, ButtonInterface } from '../../utils/element-interface';
 import { hasShadowDom } from '../../utils/helpers';
-import { createColorClasses, openURL } from '../../utils/theme';
+import { createColorClasses, hostContext, openURL } from '../../utils/theme';
 
 /**
  * @virtualProp {"ios" | "md"} mode - The mode determines which platform styles to use.
@@ -208,7 +208,8 @@ export class Button implements ComponentInterface, AnchorInterface, ButtonInterf
           [`${buttonType}-${shape}`]: shape !== undefined,
           [`${buttonType}-${fill}`]: true,
           [`${buttonType}-strong`]: strong,
-
+          'in-toolbar': hostContext('ion-toolbar', this.el),
+          'in-toolbar-color': hostContext('ion-toolbar[color]', this.el),
           'button-has-icon-only': hasIconOnly,
           'button-disabled': disabled,
           'ion-activatable': true,

--- a/core/src/components/buttons/buttons.ios.scss
+++ b/core/src/components/buttons/buttons.ios.scss
@@ -17,11 +17,10 @@
   font-weight: 400;
 }
 
-
-
 ::slotted(*) ion-button:not(.button-round) {
   --border-radius: #{$toolbar-ios-button-border-radius};
 }
+
 
 // iOS Toolbar with Color: Default Buttons
 // --------------------------------------------------
@@ -38,6 +37,8 @@
   --background-focused-opacity: .12;
   --background-activated: #000;
   --background-activated-opacity: .12;
+  --background-hover: #{current-color(base)};
+  --background-hover-opacity: 0.45;
   --color: #{current-color(base)};
   --color-focused: #{current-color(base)};
 }
@@ -53,38 +54,21 @@
 }
 
 
-// iOS Toolbar Button Clear
+// iOS Toolbar Button Clear / Outline
 // --------------------------------------------------
 
-:host-context(ion-toolbar:not(.ion-color))::slotted(*) .button-clear:not(.ion-color) {
-  --color: #{var(--ion-toolbar-color, ion-color(primary, base))};
-  --color-focused: #{var(--ion-toolbar-color, ion-color(primary, base))};
-  --background-focused: #{var(--ion-toolbar-color, ion-color(primary, base))};
-}
-
-
-// iOS Toolbar Button Outline
-// --------------------------------------------------
-
-:host-context(ion-toolbar:not(.ion-color))::slotted(*) .button-outline:not(.ion-color) {
-  --color: #{var(--ion-toolbar-color, ion-color(primary, base))};
-  --color-activated: #{var(--ion-toolbar-background, ion-color(primary, contrast))};
-  --color-focused: #{var(--ion-toolbar-color, ion-color(primary, base))};
-  --border-color: #{var(--ion-toolbar-color, ion-color(primary, base))};
-  --background-focused: #{var(--ion-toolbar-color, ion-color(primary, base))};
+::slotted(*) .button-clear,
+::slotted(*) .button-outline {
+  --background-activated: transparent;
+  --background-focused: currentColor;
+  --background-hover: transparent;
 }
 
 
 // iOS Toolbar Button Solid
 // --------------------------------------------------
 
-:host-context(ion-toolbar:not(.ion-color))::slotted(*) .button-solid:not(.ion-color) {
-  --color: #{$toolbar-ios-background};
-  --color-activated: #{$toolbar-ios-background};
-  --color-focused: #{$toolbar-ios-background};
-  --background: #{var(--ion-toolbar-color, ion-color(primary, base))};
-  --background-hover: #{var(--ion-toolbar-background, ion-color(primary, contrast))};
-  --background-hover-opacity: 0.1;
+::slotted(*) .button-solid:not(.ion-color) {
   --background-focused: #000;
   --background-focused-opacity: .12;
   --background-activated: #000;
@@ -121,25 +105,3 @@
 
   line-height: .67;
 }
-
-
-// iOS Toolbar Menu Toggle
-// --------------------------------------------------
-
-// .button-menutoggle-ios {
-//   order: map-get($toolbar-order-ios, menu-toggle-start);
-
-//   min-width: 36px;
-
-//   --padding-top: 0;
-//   --padding-bottom: 0;
-//   --padding-start: 0;
-//   --padding-end: 0;
-
-//   ion-icon {
-//     @include padding(0, 6px);
-
-//     font-size: 28px;
-//   }
-// }
-

--- a/core/src/components/buttons/buttons.md.scss
+++ b/core/src/components/buttons/buttons.md.scss
@@ -77,7 +77,6 @@
 
 ::slotted(*) .button-solid {
   --color: #{$toolbar-md-background};
-  --color-activated: #{$toolbar-md-background};
   --background: #{$toolbar-md-color};
   --background-activated: transparent;
   --background-focused: currentColor;
@@ -89,8 +88,6 @@
 
 ::slotted(*) .button-outline {
   --color: initial;
-  --color-activated: currentColor;
-  --color-focused: currentColor;
   --background: transparent;
   --background-activated: transparent;
   --background-focused: currentColor;
@@ -104,8 +101,6 @@
 
 ::slotted(*) .button-clear {
   --color: initial;
-  --color-focused: currentColor;
-  --color-activated: currentColor;
   --background: transparent;
   --background-activated: transparent;
   --background-focused: currentColor;

--- a/core/src/components/buttons/buttons.md.scss
+++ b/core/src/components/buttons/buttons.md.scss
@@ -90,12 +90,12 @@
 ::slotted(*) .button-outline {
   --color: initial;
   --color-activated: currentColor;
-  --color-focused: #{$toolbar-md-color};
+  --color-focused: currentColor;
   --background: transparent;
   --background-activated: transparent;
   --background-focused: currentColor;
   --background-hover: currentColor;
-  --border-color: #{$toolbar-md-color};
+  --border-color: currentColor;
 }
 
 
@@ -104,7 +104,7 @@
 
 ::slotted(*) .button-clear {
   --color: initial;
-  --color-focused: #{$toolbar-md-color};
+  --color-focused: currentColor;
   --color-activated: currentColor;
   --background: transparent;
   --background-activated: transparent;

--- a/core/src/components/menu-button/menu-button.scss
+++ b/core/src/components/menu-button/menu-button.scss
@@ -158,6 +158,6 @@ ion-icon {
 // Menu Button in Toolbar: Global Theming
 // --------------------------------------------------
 
-:host(.in-toolbar) {
+:host(.in-toolbar:not(.in-toolbar-color)) {
   color: #{var(--ion-toolbar-color, var(--color))};
 }

--- a/core/src/components/menu-button/menu-button.tsx
+++ b/core/src/components/menu-button/menu-button.tsx
@@ -86,6 +86,7 @@ export class MenuButton implements ComponentInterface, ButtonInterface {
           'menu-button-hidden': hidden,
           'menu-button-disabled': disabled,
           'in-toolbar': hostContext('ion-toolbar', this.el),
+          'in-toolbar-color': hostContext('ion-toolbar[color]', this.el),
           'ion-activatable': true,
           'ion-focusable': true
         }}

--- a/core/src/components/toolbar/test/custom/e2e.ts
+++ b/core/src/components/toolbar/test/custom/e2e.ts
@@ -1,0 +1,19 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+test('toolbar: custom', async () => {
+  const page = await newE2EPage({
+    url: '/src/components/toolbar/test/custom?ionic:_testing=true'
+  });
+
+  const compare = await page.compareScreenshot();
+  expect(compare).toMatchScreenshot();
+});
+
+test('toolbar:rtl: custom', async () => {
+  const page = await newE2EPage({
+    url: '/src/components/toolbar/test/custom?ionic:_testing=true&rtl=true'
+  });
+
+  const compare = await page.compareScreenshot();
+  expect(compare).toMatchScreenshot();
+});

--- a/core/src/components/toolbar/test/custom/index.html
+++ b/core/src/components/toolbar/test/custom/index.html
@@ -88,6 +88,42 @@
         <ion-title>Color</ion-title>
       </ion-toolbar>
 
+      <ion-toolbar color="tertiary" class="themed-colors">
+        <ion-buttons slot="start">
+          <ion-back-button default-href="/" text=""></ion-back-button>
+          <ion-menu-button auto-hide="false"></ion-menu-button>
+        </ion-buttons>
+        <ion-buttons slot="primary">
+          <ion-button>
+            <ion-icon slot="icon-only" name="person-circle"></ion-icon>
+          </ion-button>
+          <ion-button>
+            <ion-icon slot="icon-only" ios="ellipsis-horizontal" md="ellipsis-vertical"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-title>Color: Themed</ion-title>
+      </ion-toolbar>
+
+      <ion-toolbar color="tertiary" class="themed-colors">
+        <ion-buttons slot="secondary">
+          <ion-button fill="clear">
+            <ion-icon slot="icon-only" ios="list-outline" md="list"></ion-icon>
+          </ion-button>
+          <ion-button>
+            <ion-icon slot="icon-only" name="star"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-buttons slot="primary">
+          <ion-button fill="solid">
+            <ion-icon slot="icon-only" name="person-circle"></ion-icon>
+          </ion-button>
+          <ion-button fill="outline">
+            <ion-icon slot="icon-only" ios="ellipsis-horizontal" md="ellipsis-vertical"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-title>Color: Themed</ion-title>
+      </ion-toolbar>
+
       <ion-toolbar class="themed-colors">
         <ion-buttons slot="start">
           <ion-back-button default-href="/" text=""></ion-back-button>
@@ -237,7 +273,7 @@
   <style>
     .themed-colors {
       --ion-toolbar-background: #d9fae0;
-      --ion-toolbar-color: #105f10;
+      --ion-toolbar-color: #b68928;
     }
 
     .component-colors {
@@ -247,13 +283,13 @@
     .component-colors,
     .component-colors ion-back-button,
     .component-colors ion-menu-button,
-    .component-colors ion-button[fill="clear"],
-    .component-colors ion-button[fill="outline"] {
+    .component-colors ion-button {
       --color: #aa3723;
     }
 
     .component-colors ion-button[fill="solid"] {
       --background: #aa3723;
+      --color: #fff;
     }
 
   </style>

--- a/core/src/components/toolbar/test/custom/index.html
+++ b/core/src/components/toolbar/test/custom/index.html
@@ -88,7 +88,7 @@
         <ion-title>Color</ion-title>
       </ion-toolbar>
 
-      <ion-toolbar color="tertiary" class="themed-colors">
+      <ion-toolbar color="tertiary" class="themed-colors component-colors">
         <ion-buttons slot="start">
           <ion-back-button default-href="/" text=""></ion-back-button>
           <ion-menu-button auto-hide="false"></ion-menu-button>
@@ -104,7 +104,7 @@
         <ion-title>Color: Themed</ion-title>
       </ion-toolbar>
 
-      <ion-toolbar color="tertiary" class="themed-colors">
+      <ion-toolbar color="tertiary" class="themed-colors component-colors">
         <ion-buttons slot="secondary">
           <ion-button fill="clear">
             <ion-icon slot="icon-only" ios="list-outline" md="list"></ion-icon>

--- a/core/src/components/toolbar/test/custom/index.html
+++ b/core/src/components/toolbar/test/custom/index.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html dir="ltr">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Toolbar - Custom</title>
+  <meta name="viewport"
+    content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <link href="../../../../../css/ionic.bundle.css" rel="stylesheet">
+  <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
+  <script src="../../../../../scripts/testing/scripts.js"></script>
+  <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
+  <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content id="content">
+      <ion-toolbar>
+        <ion-buttons slot="start">
+          <ion-back-button default-href="/" text=""></ion-back-button>
+          <ion-menu-button auto-hide="false"></ion-menu-button>
+        </ion-buttons>
+        <ion-buttons slot="primary">
+          <ion-button>
+            <ion-icon slot="icon-only" name="person-circle"></ion-icon>
+          </ion-button>
+          <ion-button>
+            <ion-icon slot="icon-only" ios="ellipsis-horizontal" md="ellipsis-vertical"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-title>Default</ion-title>
+      </ion-toolbar>
+
+      <ion-toolbar>
+        <ion-buttons slot="secondary">
+          <ion-button fill="clear">
+            <ion-icon slot="icon-only" ios="list-outline" md="list"></ion-icon>
+          </ion-button>
+          <ion-button>
+            <ion-icon slot="icon-only" name="star"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-buttons slot="primary">
+          <ion-button fill="solid">
+            <ion-icon slot="icon-only" name="person-circle"></ion-icon>
+          </ion-button>
+          <ion-button fill="outline">
+            <ion-icon slot="icon-only" ios="ellipsis-horizontal" md="ellipsis-vertical"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-title>Default</ion-title>
+      </ion-toolbar>
+
+      <ion-toolbar color="tertiary">
+        <ion-buttons slot="start">
+          <ion-back-button default-href="/" text=""></ion-back-button>
+          <ion-menu-button auto-hide="false"></ion-menu-button>
+        </ion-buttons>
+        <ion-buttons slot="primary">
+          <ion-button>
+            <ion-icon slot="icon-only" name="person-circle"></ion-icon>
+          </ion-button>
+          <ion-button>
+            <ion-icon slot="icon-only" ios="ellipsis-horizontal" md="ellipsis-vertical"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-title>Color</ion-title>
+      </ion-toolbar>
+
+      <ion-toolbar color="tertiary">
+        <ion-buttons slot="secondary">
+          <ion-button fill="clear">
+            <ion-icon slot="icon-only" ios="list-outline" md="list"></ion-icon>
+          </ion-button>
+          <ion-button>
+            <ion-icon slot="icon-only" name="star"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-buttons slot="primary">
+          <ion-button fill="solid">
+            <ion-icon slot="icon-only" name="person-circle"></ion-icon>
+          </ion-button>
+          <ion-button fill="outline">
+            <ion-icon slot="icon-only" ios="ellipsis-horizontal" md="ellipsis-vertical"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-title>Color</ion-title>
+      </ion-toolbar>
+
+      <ion-toolbar class="themed-colors">
+        <ion-buttons slot="start">
+          <ion-back-button default-href="/" text=""></ion-back-button>
+          <ion-menu-button auto-hide="false"></ion-menu-button>
+        </ion-buttons>
+        <ion-buttons slot="primary">
+          <ion-button>
+            <ion-icon slot="icon-only" name="person-circle"></ion-icon>
+          </ion-button>
+          <ion-button>
+            <ion-icon slot="icon-only" ios="ellipsis-horizontal" md="ellipsis-vertical"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-title>Themed</ion-title>
+      </ion-toolbar>
+
+      <ion-toolbar class="themed-colors">
+        <ion-buttons slot="secondary">
+          <ion-button fill="clear">
+            <ion-icon slot="icon-only" ios="list-outline" md="list"></ion-icon>
+          </ion-button>
+          <ion-button>
+            <ion-icon slot="icon-only" name="star"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-buttons slot="primary">
+          <ion-button fill="solid">
+            <ion-icon slot="icon-only" name="person-circle"></ion-icon>
+          </ion-button>
+          <ion-button fill="outline">
+            <ion-icon slot="icon-only" ios="ellipsis-horizontal" md="ellipsis-vertical"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-title>Themed</ion-title>
+      </ion-toolbar>
+
+      <ion-toolbar class="themed-colors">
+        <ion-buttons slot="start">
+          <ion-back-button color="danger" default-href="/" text=""></ion-back-button>
+          <ion-menu-button color="danger" auto-hide="false"></ion-menu-button>
+        </ion-buttons>
+        <ion-buttons slot="primary">
+          <ion-button color="danger">
+            <ion-icon slot="icon-only" name="person-circle"></ion-icon>
+          </ion-button>
+          <ion-button color="danger">
+            <ion-icon slot="icon-only" ios="ellipsis-horizontal" md="ellipsis-vertical"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-title>Themed w / Color Buttons</ion-title>
+      </ion-toolbar>
+
+      <ion-toolbar class="themed-colors">
+        <ion-buttons slot="secondary">
+          <ion-button color="danger" fill="clear">
+            <ion-icon slot="icon-only" ios="list-outline" md="list"></ion-icon>
+          </ion-button>
+          <ion-button color="danger">
+            <ion-icon slot="icon-only" name="star"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-buttons slot="primary">
+          <ion-button color="danger" fill="solid">
+            <ion-icon slot="icon-only" name="person-circle"></ion-icon>
+          </ion-button>
+          <ion-button color="danger" fill="outline">
+            <ion-icon slot="icon-only" ios="ellipsis-horizontal" md="ellipsis-vertical"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-title>Themed w / Color Buttons</ion-title>
+      </ion-toolbar>
+
+      <ion-toolbar class="component-colors">
+        <ion-buttons slot="start">
+          <ion-back-button default-href="/" text=""></ion-back-button>
+          <ion-menu-button auto-hide="false"></ion-menu-button>
+        </ion-buttons>
+        <ion-buttons slot="primary">
+          <ion-button>
+            <ion-icon slot="icon-only" name="person-circle"></ion-icon>
+          </ion-button>
+          <ion-button>
+            <ion-icon slot="icon-only" ios="ellipsis-horizontal" md="ellipsis-vertical"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-title>Component Level Vars</ion-title>
+      </ion-toolbar>
+
+      <ion-toolbar class="component-colors">
+        <ion-buttons slot="secondary">
+          <ion-button fill="clear">
+            <ion-icon slot="icon-only" ios="list-outline" md="list"></ion-icon>
+          </ion-button>
+          <ion-button>
+            <ion-icon slot="icon-only" name="star"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-buttons slot="primary">
+          <ion-button fill="solid">
+            <ion-icon slot="icon-only" name="person-circle"></ion-icon>
+          </ion-button>
+          <ion-button fill="outline">
+            <ion-icon slot="icon-only" ios="ellipsis-horizontal" md="ellipsis-vertical"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-title>Component Level Vars</ion-title>
+      </ion-toolbar>
+
+      <ion-toolbar class="component-colors">
+        <ion-buttons slot="start">
+          <ion-back-button color="secondary" default-href="/" text=""></ion-back-button>
+          <ion-menu-button color="secondary" auto-hide="false"></ion-menu-button>
+        </ion-buttons>
+        <ion-buttons slot="primary">
+          <ion-button color="secondary">
+            <ion-icon slot="icon-only" name="person-circle"></ion-icon>
+          </ion-button>
+          <ion-button color="secondary">
+            <ion-icon slot="icon-only" ios="ellipsis-horizontal" md="ellipsis-vertical"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-title>Component Level Vars w/ Color Buttons</ion-title>
+      </ion-toolbar>
+
+      <ion-toolbar class="component-colors">
+        <ion-buttons slot="secondary">
+          <ion-button color="secondary" fill="clear">
+            <ion-icon slot="icon-only" ios="list-outline" md="list"></ion-icon>
+          </ion-button>
+          <ion-button color="secondary">
+            <ion-icon slot="icon-only" name="star"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-buttons slot="primary">
+          <ion-button color="secondary" fill="solid">
+            <ion-icon slot="icon-only" name="person-circle"></ion-icon>
+          </ion-button>
+          <ion-button color="secondary" fill="outline">
+            <ion-icon slot="icon-only" ios="ellipsis-horizontal" md="ellipsis-vertical"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-title>Component Level Vars w/ Color Buttons</ion-title>
+      </ion-toolbar>
+    </ion-content>
+  </ion-app>
+
+  <style>
+    .themed-colors {
+      --ion-toolbar-background: #d9fae0;
+      --ion-toolbar-color: #105f10;
+    }
+
+    .component-colors {
+      --background: #fff4f5;
+    }
+
+    .component-colors,
+    .component-colors ion-back-button,
+    .component-colors ion-menu-button,
+    .component-colors ion-button[fill="clear"],
+    .component-colors ion-button[fill="outline"] {
+      --color: #aa3723;
+    }
+
+    .component-colors ion-button[fill="solid"] {
+      --background: #aa3723;
+    }
+
+  </style>
+</body>
+
+</html>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Ran into issues during the conference app redesign & realized that certain variables when set for buttons in a toolbar did not behave as expected. You can see the below & after images in the next section. The test is under `toolbar/custom`.

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

| `master` | `branch` |
| ---| ---|
| ![android-master](https://user-images.githubusercontent.com/6577830/75401362-eb74db00-58cf-11ea-8016-33b9544bb4e6.png) | ![android-branch](https://user-images.githubusercontent.com/6577830/75401269-9b961400-58cf-11ea-821f-91248e5b6508.png) |
| ![ios-master](https://user-images.githubusercontent.com/6577830/75401364-eca60800-58cf-11ea-969a-0ca385954f24.png) | ![ios-branch](https://user-images.githubusercontent.com/6577830/75401270-9c2eaa80-58cf-11ea-906e-c9639f380318.png) |

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
