### PR TITLE
feat(action-sheet): Added 'disabled' Property for ActionSheetButtons

### DIFF
--- a/core/src/components/action-sheet/action-sheet-interface.ts
+++ b/core/src/components/action-sheet/action-sheet-interface.ts
@@ -19,6 +19,7 @@ export interface ActionSheetOptions {
 export interface ActionSheetButton {
   text?: string;
   role?: 'cancel' | 'destructive' | 'selected' | string;
+  disabled?: boolean;
   icon?: string;
   cssClass?: string | string[];
   handler?: () => boolean | void | Promise<boolean>;

--- a/core/src/components/action-sheet/action-sheet.scss
+++ b/core/src/components/action-sheet/action-sheet.scss
@@ -155,6 +155,12 @@
   @include button-state();
 }
 
+.action-sheet-button-disabled {
+  pointer-events: none;
+
+  opacity: .5;
+}
+
 
 // Action Sheet: Selected
 // --------------------------------------------------

--- a/core/src/components/action-sheet/action-sheet.tsx
+++ b/core/src/components/action-sheet/action-sheet.tsx
@@ -226,7 +226,7 @@ export class ActionSheet implements ComponentInterface, OverlayInterface {
                 </div>
               }
               {buttons.map(b =>
-                <button type="button" class={buttonClass(b)} onClick={() => this.buttonClick(b)}>
+                <button type="button" disabled={b.disabled} class={buttonClass(b)} onClick={() => this.buttonClick(b)}>
                   <span class="action-sheet-button-inner">
                     {b.icon && <ion-icon icon={b.icon} lazy={false} class="action-sheet-icon" />}
                     {b.text}
@@ -240,6 +240,7 @@ export class ActionSheet implements ComponentInterface, OverlayInterface {
               <div class="action-sheet-group action-sheet-group-cancel">
                 <button
                   type="button"
+                  disabled={cancelButton.disabled}
                   class={buttonClass(cancelButton)}
                   onClick={() => this.buttonClick(cancelButton)}
                 >
@@ -268,6 +269,7 @@ const buttonClass = (button: ActionSheetButton): CssClassMap => {
     'action-sheet-button': true,
     'ion-activatable': true,
     'ion-focusable': true,
+    'action-sheet-button-disabled': !!button.disabled,
     [`action-sheet-${button.role}`]: button.role !== undefined,
     ...getClassMap(button.cssClass),
   };


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #17236


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Buttons can be disabled via `disabled` Property

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### iOS (the Delete Button is hovered)
<img width="508" alt="Bildschirmfoto 2020-03-01 um 21 12 02" src="https://user-images.githubusercontent.com/20899975/75633200-2a25d080-5c03-11ea-9597-7b8dfdeaa196.png">

### Android
<img width="516" alt="Bildschirmfoto 2020-03-01 um 21 12 15" src="https://user-images.githubusercontent.com/20899975/75633202-2f831b00-5c03-11ea-8f1c-e6fedd17fa1f.png">

