### PR TITLE
Workaround for (virtual-scroll) stacking content Bug

### DIFF
--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -20,6 +20,7 @@ import {
   DatetimeOptions,
   DomRenderFn,
   FooterHeightFn,
+  MinimumItemHeightFn,
   FrameworkDelegate,
   HeaderFn,
   HeaderHeightFn,
@@ -2631,6 +2632,10 @@ export namespace Components {
     * An optional function that maps each item footer within their height.
     */
     'footerHeight'?: FooterHeightFn;
+    /**
+    * An optional function that forces minimum item height.
+    */
+    'minimumItemHeight'?: MinimumItemHeightFn;
     /**
     * Section headers and the data used within its given template can be dynamically created by passing a function to `headerFn`. For example, a large list of contacts usually has dividers between each letter in the alphabet. App's can provide their own custom `headerFn` which is called with each record within the dataset. The logic within the header function can decide if the header template should be used, and what data to give to the header template. The function must return `null` if a header cell shouldn't be created.
     */
@@ -5792,6 +5797,10 @@ declare namespace LocalJSX {
     * An optional function that maps each item footer within their height.
     */
     'footerHeight'?: FooterHeightFn;
+    /**
+    * An optional function that forces minimum item height.
+    */
+    'minimumItemHeight'?: MinimumItemHeightFn;
     /**
     * Section headers and the data used within its given template can be dynamically created by passing a function to `headerFn`. For example, a large list of contacts usually has dividers between each letter in the alphabet. App's can provide their own custom `headerFn` which is called with each record within the dataset. The logic within the header function can decide if the header template should be used, and what data to give to the header template. The function must return `null` if a header cell shouldn't be created.
     */

--- a/core/src/components/virtual-scroll/virtual-scroll-interface.ts
+++ b/core/src/components/virtual-scroll/virtual-scroll-interface.ts
@@ -23,5 +23,6 @@ export type HeaderFn = (item: any, index: number, items: any[]) => string | null
 export type ItemHeightFn = (item: any, index: number) => number;
 export type HeaderHeightFn = (item: any, index: number) => number;
 export type FooterHeightFn = (item: any, index: number) => number;
+export type MinimumItemHeightFn = (item: any, index: number) => number;
 export type ItemRenderFn = (el: HTMLElement | null, cell: Cell, domIndex: number) => HTMLElement;
 export type DomRenderFn = (dom: VirtualNode[]) => void;

--- a/core/src/components/virtual-scroll/virtual-scroll.tsx
+++ b/core/src/components/virtual-scroll/virtual-scroll.tsx
@@ -443,7 +443,7 @@ export class VirtualScroll implements ComponentInterface {
   }
 }
 
-const VirtualProxy: FunctionalComponent<{dom: VirtualNode[], minimumItemHeight: number}> = ({ dom, minimumItemHeight }, children, utils) => {
+const VirtualProxy: FunctionalComponent<{dom: VirtualNode[], minimumItemHeight: number | undefined}> = ({ dom, minimumItemHeight }, children, utils) => {
   return utils.map(children, (child, i) => {
     const node = dom[i];
     const vattrs = child.vattrs || {};

--- a/core/src/components/virtual-scroll/virtual-scroll.tsx
+++ b/core/src/components/virtual-scroll/virtual-scroll.tsx
@@ -443,7 +443,7 @@ export class VirtualScroll implements ComponentInterface {
   }
 }
 
-const VirtualProxy: FunctionalComponent<{dom: VirtualNode[], minIHeight: number | undefined}> = ({ dom, minimumItemHeight }, children, utils) => {
+const VirtualProxy: FunctionalComponent<{dom: VirtualNode[], minIHeight: MinimumItemHeightFn | undefined}> = ({ dom, minimumItemHeight }, children, utils) => {
   return utils.map(children, (child, i) => {
     const node = dom[i];
     const vattrs = child.vattrs || {};

--- a/core/src/components/virtual-scroll/virtual-scroll.tsx
+++ b/core/src/components/virtual-scroll/virtual-scroll.tsx
@@ -443,7 +443,7 @@ export class VirtualScroll implements ComponentInterface {
   }
 }
 
-const VirtualProxy: FunctionalComponent<{dom: VirtualNode[], minIHeight: MinimumItemHeightFn | undefined}> = ({ dom, minimumItemHeight }, children, utils) => {
+const VirtualProxy: FunctionalComponent<{dom: VirtualNode[], minIHeight: MinimumItemHeightFn | undefined}> = ({ dom, minIHeight }, children, utils) => {
   return utils.map(children, (child, i) => {
     const node = dom[i];
     const vattrs = child.vattrs || {};
@@ -453,9 +453,9 @@ const VirtualProxy: FunctionalComponent<{dom: VirtualNode[], minIHeight: Minimum
     if (!node.visible) {
       classes += 'virtual-loading';
     }
-    if(minimumItemHeight !== undefined && shift > 0 && shift < minimumItemHeight){
-      //minimumItemHeight prevents content stacking
-      shift = minimumItemHeight;
+    if(minIHeight !== undefined && shift > 0 && shift < minIHeight){
+      //minIHeight prevents content stacking
+      shift = minIHeight;
     }
     return {
       ...child,

--- a/core/src/components/virtual-scroll/virtual-scroll.tsx
+++ b/core/src/components/virtual-scroll/virtual-scroll.tsx
@@ -434,7 +434,7 @@ export class VirtualScroll implements ComponentInterface {
         }}
       >
         {this.renderItem && (
-          <VirtualProxy dom={this.virtualDom} minimumItemHeight={this.minimumItemHeight}>
+          <VirtualProxy dom={this.virtualDom} minIHeight={this.minimumItemHeight}>
             {this.virtualDom.map(node => this.renderVirtualNode(node))}
           </VirtualProxy>
         )}
@@ -443,7 +443,7 @@ export class VirtualScroll implements ComponentInterface {
   }
 }
 
-const VirtualProxy: FunctionalComponent<{dom: VirtualNode[], minimumItemHeight: MinimumItemHeightFn}> = ({ dom, minimumItemHeight }, children, utils) => {
+const VirtualProxy: FunctionalComponent<{dom: VirtualNode[], minIHeight: number | undefined}> = ({ dom, minimumItemHeight }, children, utils) => {
   return utils.map(children, (child, i) => {
     const node = dom[i];
     const vattrs = child.vattrs || {};

--- a/core/src/components/virtual-scroll/virtual-scroll.tsx
+++ b/core/src/components/virtual-scroll/virtual-scroll.tsx
@@ -1,6 +1,6 @@
 import { Component, ComponentInterface, Element, FunctionalComponent, Host, Listen, Method, Prop, State, Watch, h, readTask, writeTask } from '@stencil/core';
 
-import { Cell, DomRenderFn, FooterHeightFn, HeaderFn, HeaderHeightFn, ItemHeightFn, ItemRenderFn, VirtualNode } from '../../interface';
+import { Cell, DomRenderFn, FooterHeightFn, MinimumItemHeightFn, HeaderFn, HeaderHeightFn, ItemHeightFn, ItemRenderFn, VirtualNode } from '../../interface';
 
 import { CELL_TYPE_FOOTER, CELL_TYPE_HEADER, CELL_TYPE_ITEM } from './constants';
 import { Range, calcCells, calcHeightIndex, doRender, findCellIndex, getRange, getShouldUpdate, getViewport, inplaceUpdate, positionForIndex, resizeBuffer, updateVDom } from './virtual-scroll-utils';
@@ -117,7 +117,7 @@ export class VirtualScroll implements ComponentInterface {
   /**
    * An optional parameter that prevents content-stacking and forces items to have a minimum height.
    */
-  @Prop() minimumItemHeight?: number;
+  @Prop() minimumItemHeight?: MinimumItemHeightFn;
 
   /**
    * NOTE: only JSX API for stencil.
@@ -443,7 +443,7 @@ export class VirtualScroll implements ComponentInterface {
   }
 }
 
-const VirtualProxy: FunctionalComponent<{dom: VirtualNode[], minimumItemHeight: number | undefined}> = ({ dom, minimumItemHeight }, children, utils) => {
+const VirtualProxy: FunctionalComponent<{dom: VirtualNode[], minimumItemHeight: MinimumItemHeightFn}> = ({ dom, minimumItemHeight }, children, utils) => {
   return utils.map(children, (child, i) => {
     const node = dom[i];
     const vattrs = child.vattrs || {};
@@ -453,7 +453,7 @@ const VirtualProxy: FunctionalComponent<{dom: VirtualNode[], minimumItemHeight: 
     if (!node.visible) {
       classes += 'virtual-loading';
     }
-    if(minimumItemHeight && shift > 0 && shift < minimumItemHeight){
+    if(minimumItemHeight !== undefined && shift > 0 && shift < minimumItemHeight){
       //minimumItemHeight prevents content stacking
       shift = minimumItemHeight;
     }

--- a/core/src/components/virtual-scroll/virtual-scroll.tsx
+++ b/core/src/components/virtual-scroll/virtual-scroll.tsx
@@ -443,7 +443,7 @@ export class VirtualScroll implements ComponentInterface {
   }
 }
 
-const VirtualProxy: FunctionalComponent<{dom: VirtualNode[], minIHeight: MinimumItemHeightFn | undefined}> = ({ dom, minIHeight }, children, utils) => {
+const VirtualProxy: FunctionalComponent<{dom: VirtualNode[], minIHeight: any}> = ({ dom, minIHeight }, children, utils) => {
   return utils.map(children, (child, i) => {
     const node = dom[i];
     const vattrs = child.vattrs || {};

--- a/core/src/components/virtual-scroll/virtual-scroll.tsx
+++ b/core/src/components/virtual-scroll/virtual-scroll.tsx
@@ -453,9 +453,9 @@ const VirtualProxy: FunctionalComponent<{dom: VirtualNode[], minimumItemHeight: 
     if (!node.visible) {
       classes += 'virtual-loading';
     }
-    if(minimumItemHeight && shift > 0 && shift < approxItemHeight){
+    if(minimumItemHeight && shift > 0 && shift < minimumItemHeight){
       //minimumItemHeight prevents content stacking
-      shift = approxItemHeight;
+      shift = minimumItemHeight;
     }
     return {
       ...child,

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   },
   "engines": {
     "node": ">= 10"
+  },
+  "dependencies": {
+    "typescript": "^3.8.3"
   }
 }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type


Please check the type of change your PR introduces:
- [X] Wrokaround-Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
If you have and observable that throws data at virtual-scroll, you will have an overlapping issue.

Issue Number: 18409


## What is the new behavior?
You can optionally set new parameter that prevents content stacking if needed.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
[One of the many issues](https://github.com/ionic-team/ionic/issues/18409) . 
Pls check if the fix works.