### PR TITLE
feat(gesture): add option to run inside NgZone for Angular apps

### DIFF
--- a/angular/src/providers/gesture-controller.ts
+++ b/angular/src/providers/gesture-controller.ts
@@ -1,14 +1,24 @@
-import { Injectable } from '@angular/core';
+import { Injectable, NgZone } from '@angular/core';
 import { Gesture, GestureConfig, createGesture } from '@ionic/core';
 
 @Injectable({
   providedIn: 'root',
 })
 export class GestureController {
+  constructor(private zone: NgZone) {}
   /**
    * Create a new gesture
    */
-  create(opts: GestureConfig): Gesture {
+  create(opts: GestureConfig, runInsideAngularZone = false): Gesture {
+    if (runInsideAngularZone) {
+      Object.getOwnPropertyNames(opts).forEach(key => {
+        if (typeof opts[key] === 'function') {
+          const fn = opts[key];
+          opts[key] = (...props) => this.zone.run(() => fn(...props));
+        }
+      });
+    }
+
     return createGesture(opts);
   }
 }


### PR DESCRIPTION
blocks https://github.com/ionic-team/ionic-docs/pull/1383

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic/issues/20529

For performance reasons, we do not run gesture callbacks inside of angular zones. This has a side effect of causing templates to not update when using gesture handlers to alter the state of the app.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added an option to run all callbacks inside of angular zone. Defaults to `false`.

Developers can also selectively run their handlers in ngzone by wrapping their callbacks like this:

```typescript
import { NgZone } from '@angular/core';

...

constructor(private zone: NgZone) {}

...

const gesture = this.gestureController.create({
  el: this.contentElement.nativeElement,
  gestureName: 'swipe',
  onMove: (ev) => this.onSwipeMove(ev),
  onEnd: (ev) => this.zone.run(() => this.onSwipeEnd(ev))
});
```

In this case, the `onEnd` handler will run inside of a zone, but the `onMove` handler will not.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
