### PR TITLE
fix(label): text overflow for slotted headings

### DIFF
--- a/core/src/components/label/label.scss
+++ b/core/src/components/label/label.scss
@@ -79,3 +79,17 @@
 :host(.label-no-animate.label-floating) {
   transition: none;
 }
+
+// Headings
+// --------------------------------------------------
+
+::slotted(*) h1,
+::slotted(*) h2,
+::slotted(*) h3,
+::slotted(*) h4,
+::slotted(*) h5,
+::slotted(*) h6 {
+  text-overflow: inherit;
+
+  overflow: inherit;
+}

--- a/core/src/components/label/test/headings/e2e.ts
+++ b/core/src/components/label/test/headings/e2e.ts
@@ -1,0 +1,10 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+test('label: headings', async () => {
+  const page = await newE2EPage({
+    url: '/src/components/label/test/headings?ionic:_testing=true'
+  });
+
+  const compare = await page.compareScreenshot();
+  expect(compare).toMatchScreenshot();
+});

--- a/core/src/components/label/test/headings/index.html
+++ b/core/src/components/label/test/headings/index.html
@@ -24,42 +24,42 @@
       <ion-list>
         <ion-item>
           <ion-label>
-            Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro? Ipsa pariatur, earum sapiente nihil sed perspiciatis nostrum voluptas ipsum mollitia repellendus.
+            Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro?
           </ion-label>
         </ion-item>
         <ion-item>
           <ion-label>
-            <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro? Ipsa pariatur, earum sapiente nihil sed perspiciatis nostrum voluptas ipsum mollitia repellendus.</p>
+            <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro?</p>
           </ion-label>
         </ion-item>
         <ion-item>
           <ion-label>
-            <h1>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro? Ipsa pariatur, earum sapiente nihil sed perspiciatis nostrum voluptas ipsum mollitia repellendus.</h1>
+            <h1>Lorem, ipsum dolor sit amet consectetur adipisicing elit.</h1>
           </ion-label>
         </ion-item>
         <ion-item>
           <ion-label class="ion-text-wrap">
-            <h1>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro? Ipsa pariatur, earum sapiente nihil sed perspiciatis nostrum voluptas ipsum mollitia repellendus.</h1>
+            <h1>Lorem, ipsum dolor sit amet consectetur adipisicing elit.</h1>
           </ion-label>
         </ion-item>
         <ion-item>
           <ion-label>
-            <h2>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro? Ipsa pariatur, earum sapiente nihil sed perspiciatis nostrum voluptas ipsum mollitia repellendus.</h2>
+            <h2>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro?</h2>
           </ion-label>
         </ion-item>
         <ion-item>
           <ion-label class="ion-text-wrap">
-            <h2>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro? Ipsa pariatur, earum sapiente nihil sed perspiciatis nostrum voluptas ipsum mollitia repellendus.</h2>
+            <h2>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro?</h2>
           </ion-label>
         </ion-item>
         <ion-item>
           <ion-label>
-            <h3>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro? Ipsa pariatur, earum sapiente nihil sed perspiciatis nostrum voluptas ipsum mollitia repellendus.</h3>
+            <h3>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro?</h3>
           </ion-label>
         </ion-item>
         <ion-item>
           <ion-label class="ion-text-wrap">
-            <h3>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro? Ipsa pariatur, earum sapiente nihil sed perspiciatis nostrum voluptas ipsum mollitia repellendus.</h3>
+            <h3>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro?</h3>
           </ion-label>
         </ion-item>
       </ion-list>

--- a/core/src/components/label/test/headings/index.html
+++ b/core/src/components/label/test/headings/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html dir="ltr">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Label - Headings</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+  <link href="../../../../../css/ionic.bundle.css" rel="stylesheet">
+  <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
+  <script src="../../../../../scripts/testing/scripts.js"></script>
+  <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
+  <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script></head>
+
+<body>
+  <ion-app>
+
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Label - Headings</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content>
+      <ion-list>
+        <ion-item>
+          <ion-label>
+            Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro? Ipsa pariatur, earum sapiente nihil sed perspiciatis nostrum voluptas ipsum mollitia repellendus.
+          </ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-label>
+            <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro? Ipsa pariatur, earum sapiente nihil sed perspiciatis nostrum voluptas ipsum mollitia repellendus.</p>
+          </ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-label>
+            <h1>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro? Ipsa pariatur, earum sapiente nihil sed perspiciatis nostrum voluptas ipsum mollitia repellendus.</h1>
+          </ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-label class="ion-text-wrap">
+            <h1>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro? Ipsa pariatur, earum sapiente nihil sed perspiciatis nostrum voluptas ipsum mollitia repellendus.</h1>
+          </ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-label>
+            <h2>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro? Ipsa pariatur, earum sapiente nihil sed perspiciatis nostrum voluptas ipsum mollitia repellendus.</h2>
+          </ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-label class="ion-text-wrap">
+            <h2>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro? Ipsa pariatur, earum sapiente nihil sed perspiciatis nostrum voluptas ipsum mollitia repellendus.</h2>
+          </ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-label>
+            <h3>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro? Ipsa pariatur, earum sapiente nihil sed perspiciatis nostrum voluptas ipsum mollitia repellendus.</h3>
+          </ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-label class="ion-text-wrap">
+            <h3>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto laborum, voluptatum corporis reprehenderit ipsa nostrum aperiam optio porro? Ipsa pariatur, earum sapiente nihil sed perspiciatis nostrum voluptas ipsum mollitia repellendus.</h3>
+          </ion-label>
+        </ion-item>
+      </ion-list>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] ~Docs have been reviewed and added / updated if needed (for bug fixes / features)~
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

Headings that are put in the slot of an `ion-label` don't inherit the `text-overflow: ellipsis` style.

Issue Number: #17087.


## What is the new behavior?

- Adds styling for slotted headings to inherit `overflow` and `text-overflow`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

If anyone really wanted headings inside labels to just have hidden overflow (very unlikely), they'd need to explicitly set the overflow.

## Other information

Closes #17087.

| `master` | `branch` |
| ---| ---|
| ![`master`](https://user-images.githubusercontent.com/6577830/76435610-989a2980-638d-11ea-906c-beeebc1dd57d.png) | ![`branch`](https://user-images.githubusercontent.com/6577830/76435623-9b951a00-638d-11ea-9037-c1a56204bc17.png) |
