### PR TITLE
fix(segment): scrollable segments only show scrollbar if they overflow

### DIFF
--- a/core/src/components/segment/segment.scss
+++ b/core/src/components/segment/segment.scss
@@ -38,7 +38,7 @@
 
   width: auto;
 
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 :host(.segment-scrollable::-webkit-scrollbar) {


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

A scrollable segment shows a horizontal scrollbar (e. g. on Windows) even if there is no overflow.

Issue Number: #20758


## What is the new behavior?

A scrollable segment only shows a scrollbar if it overflows horizontally.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Closes #20758.