### PR TITLE
fix(angular): Fix --multi-app support for ng-add schematic

### DIFF
--- a/angular/src/schematics/add/index.ts
+++ b/angular/src/schematics/add/index.ts
@@ -2,7 +2,7 @@ import { join, Path } from '@angular-devkit/core';
 import { apply, chain, mergeWith, move, Rule, SchematicContext, SchematicsException, template, Tree, url } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import { addModuleImportToRootModule } from './../utils/ast';
-import { addArchitectBuilder, addStyle, getWorkspace, addAsset, WorkspaceProject, WorkspaceSchema } from './../utils/config';
+import { addArchitectBuilder, addAsset, addStyle, getDefaultAngularAppName, getWorkspace, WorkspaceProject, WorkspaceSchema } from './../utils/config';
 import { addPackageToPackageJson } from './../utils/package';
 import { Schema as IonAddOptions } from './schema';
 
@@ -109,7 +109,7 @@ export default function ngAdd(options: IonAddOptions): Rule {
   return (host: Tree) => {
     const workspace: WorkspaceSchema = getWorkspace(host);
     if (!options.project) {
-      options.project = Object.keys(workspace.projects)[0];
+      options.project = getDefaultAngularAppName(workspace);
     }
     const project: WorkspaceProject = workspace.projects[options.project];
     if (project.projectType !== 'application') {

--- a/angular/src/schematics/add/index.ts
+++ b/angular/src/schematics/add/index.ts
@@ -37,7 +37,7 @@ function addIonicAngularModuleToAppModule(projectSourceRoot: Path): Rule {
   };
 }
 
-function addIonicStyles(projectSourceRoot: Path): Rule {
+function addIonicStyles(projectName: string, projectSourceRoot: Path): Rule {
   return (host: Tree) => {
     const ionicStyles = [
       'node_modules/@ionic/angular/css/normalize.css',
@@ -51,27 +51,27 @@ function addIonicStyles(projectSourceRoot: Path): Rule {
       'node_modules/@ionic/angular/css/flex-utils.css',
       `${projectSourceRoot}/theme/variables.css`
     ].forEach(entry => {
-      addStyle(host, entry);
+      addStyle(host, projectName, entry);
     });
     return host;
   };
 }
 
-function addIonicons(): Rule {
+function addIonicons(projectName: string): Rule {
   return (host: Tree) => {
     const ioniconsGlob = {
       glob: '**/*.svg',
       input: 'node_modules/ionicons/dist/ionicons/svg',
       output: './svg'
     };
-    addAsset(host, ioniconsGlob);
+    addAsset(host, projectName, ioniconsGlob);
     return host;
   };
 }
 
 function addIonicBuilder(projectName: string): Rule {
   return (host: Tree) => {
-    addArchitectBuilder(host, 'ionic-cordova-serve', {
+    addArchitectBuilder(host, projectName, 'ionic-cordova-serve', {
       builder: '@ionic/angular-toolkit:cordova-serve',
       options: {
         cordovaBuildTarget: `${projectName}:ionic-cordova-build`,
@@ -84,7 +84,7 @@ function addIonicBuilder(projectName: string): Rule {
         }
       }
     });
-    addArchitectBuilder(host, 'ionic-cordova-build', {
+    addArchitectBuilder(host, projectName, 'ionic-cordova-build', {
       builder: '@ionic/angular-toolkit:cordova-build',
       options: {
         browserTarget: `${projectName}:build`
@@ -128,8 +128,8 @@ export default function ngAdd(options: IonAddOptions): Rule {
       addIonicAngularToolkitToPackageJson(),
       addIonicAngularModuleToAppModule(sourcePath),
       addIonicBuilder(options.project),
-      addIonicStyles(sourcePath),
-      addIonicons(),
+      addIonicStyles(options.project, sourcePath),
+      addIonicons(options.project),
       mergeWith(rootTemplateSource),
       // install freshly added dependencies
       installNodeDeps()

--- a/angular/src/schematics/utils/ast.ts
+++ b/angular/src/schematics/utils/ast.ts
@@ -27,7 +27,7 @@ export function getSourceFile(host: Tree, path: string): ts.SourceFile {
  */
 export function addModuleImportToRootModule(
   host: Tree,
-  projectSourceRoot,
+  projectSourceRoot: string,
   moduleName: string,
   importSrc: string
 ) {

--- a/angular/src/schematics/utils/config.ts
+++ b/angular/src/schematics/utils/config.ts
@@ -81,7 +81,7 @@ export function addArchitectBuilder(host: Tree, builderName: string, builderOpts
   const appConfig = getAngularAppConfig(config);
 
   if (appConfig) {
-    appConfig.architect[builderName] = builderOpts
+    appConfig.architect[builderName] = builderOpts;
     writeConfig(host, config);
   } else {
     throw new SchematicsException(`Cannot find valid app`);

--- a/angular/src/schematics/utils/config.ts
+++ b/angular/src/schematics/utils/config.ts
@@ -35,12 +35,9 @@ export function getDefaultAngularAppName(config: any): string {
   return projectNames[0];
 }
 
-export function getAngularAppConfig(config: any): any | null {
-  const projects = config.projects;
-  const projectNames = Object.keys(projects);
-
-  for (const projectName of projectNames) {
-    const projectConfig = projects[projectName];
+export function getAngularAppConfig(config: any, projectName: string): any | null {
+  if (config.projects.hasOwnProperty(projectName)) {
+    const projectConfig = config.projects[projectName];
     if (isAngularBrowserProject(projectConfig)) {
       return projectConfig;
     }
@@ -49,9 +46,9 @@ export function getAngularAppConfig(config: any): any | null {
   return null;
 }
 
-export function addStyle(host: Tree, stylePath: string) {
+export function addStyle(host: Tree, projectName: string, stylePath: string) {
   const config = readConfig(host);
-  const appConfig = getAngularAppConfig(config);
+  const appConfig = getAngularAppConfig(config, projectName);
 
   if (appConfig) {
     appConfig.architect.build.options.styles.push({
@@ -64,9 +61,9 @@ export function addStyle(host: Tree, stylePath: string) {
   }
 }
 
-export function addAsset(host: Tree, asset: string | {glob: string; input: string; output: string}) {
+export function addAsset(host: Tree, projectName: string, asset: string | {glob: string; input: string; output: string}) {
   const config = readConfig(host);
-  const appConfig = getAngularAppConfig(config);
+  const appConfig = getAngularAppConfig(config, projectName);
 
   if (appConfig) {
     appConfig.architect.build.options.assets.push(asset);
@@ -76,9 +73,9 @@ export function addAsset(host: Tree, asset: string | {glob: string; input: strin
   }
 }
 
-export function addArchitectBuilder(host: Tree, builderName: string, builderOpts: any){
+export function addArchitectBuilder(host: Tree, projectName: string, builderName: string, builderOpts: any): void | never {
   const config = readConfig(host);
-  const appConfig = getAngularAppConfig(config);
+  const appConfig = getAngularAppConfig(config, projectName);
 
   if (appConfig) {
     appConfig.architect[builderName] = builderOpts;

--- a/angular/src/schematics/utils/config.ts
+++ b/angular/src/schematics/utils/config.ts
@@ -35,54 +35,45 @@ export function getDefaultAngularAppName(config: any): string {
   return projectNames[0];
 }
 
-export function getAngularAppConfig(config: any, projectName: string): any | null {
-  if (config.projects.hasOwnProperty(projectName)) {
-    const projectConfig = config.projects[projectName];
-    if (isAngularBrowserProject(projectConfig)) {
-      return projectConfig;
-    }
+export function getAngularAppConfig(config: any, projectName: string): any | never {
+  if (!config.projects.hasOwnProperty(projectName)) {
+    throw new SchematicsException(`Could not find project: ${projectName}`);
   }
 
-  return null;
+  const projectConfig = config.projects[projectName];
+  if (isAngularBrowserProject(projectConfig)) {
+    return projectConfig;
+  }
+
+  if (config.projectType !== 'application') {
+    throw new SchematicsException(`Invalid projectType for ${projectName}: ${config.projectType}`);
+  } else {
+    const buildConfig = projectConfig.architect.build;
+    throw new SchematicsException(`Invalid builder for ${projectName}: ${buildConfig.builder}`);
+  }
 }
 
 export function addStyle(host: Tree, projectName: string, stylePath: string) {
   const config = readConfig(host);
   const appConfig = getAngularAppConfig(config, projectName);
-
-  if (appConfig) {
-    appConfig.architect.build.options.styles.push({
-      input: stylePath
-    });
-
-    writeConfig(host, config);
-  } else {
-    throw new SchematicsException(`Cannot find valid app`);
-  }
+  appConfig.architect.build.options.styles.push({
+    input: stylePath
+  });
+  writeConfig(host, config);
 }
 
 export function addAsset(host: Tree, projectName: string, asset: string | {glob: string; input: string; output: string}) {
   const config = readConfig(host);
   const appConfig = getAngularAppConfig(config, projectName);
-
-  if (appConfig) {
-    appConfig.architect.build.options.assets.push(asset);
-    writeConfig(host, config);
-  } else {
-    throw new SchematicsException(`Cannot find valid app`);
-  }
+  appConfig.architect.build.options.assets.push(asset);
+  writeConfig(host, config);
 }
 
 export function addArchitectBuilder(host: Tree, projectName: string, builderName: string, builderOpts: any): void | never {
   const config = readConfig(host);
   const appConfig = getAngularAppConfig(config, projectName);
-
-  if (appConfig) {
-    appConfig.architect[builderName] = builderOpts;
-    writeConfig(host, config);
-  } else {
-    throw new SchematicsException(`Cannot find valid app`);
-  }
+  appConfig.architect[builderName] = builderOpts;
+  writeConfig(host, config);
 }
 
 export type WorkspaceSchema = experimental.workspace.WorkspaceSchema;

--- a/angular/src/schematics/utils/config.ts
+++ b/angular/src/schematics/utils/config.ts
@@ -21,7 +21,7 @@ function isAngularBrowserProject(projectConfig: any) {
   return false;
 }
 
-export function getAngularAppName(config: any): string | null {
+export function getDefaultAngularAppName(config: any): string {
   const projects = config.projects;
   const projectNames = Object.keys(projects);
 
@@ -32,7 +32,7 @@ export function getAngularAppName(config: any): string | null {
     }
   }
 
-  return null;
+  return projectNames[0];
 }
 
 export function getAngularAppConfig(config: any): any | null {


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

Ionic CLI added a new "--multi-app" option for working with mono-repositories in https://github.com/ionic-team/ionic-cli/commit/42c51996632cdbc6ad6e514f36a584e3a450e380, this includes improved support for updating Angular CLI workspaces by using
```
ng add @ionic/angular --project=demo-project
```
This behavior is documented in the new [Angular-Monorepo](https://github.com/ionic-team/ionic-cli/wiki/Angular-Monorepo) wiki page; but the generated `angular.json` file is not valid because some schematic code always uses `app` as the project name.

To reproduce the issue, just follow the steps described in the [Angular-Monorepo](https://github.com/ionic-team/ionic-cli/wiki/Angular-Monorepo) wiki page, but don't use `app` as the default project name, use `mobile` or whatever you prefer.


This MR is related to one of the issues for which the new flag was introduced: https://github.com/ionic-team/ionic-cli/issues/4192


## What is the new behavior?

The `--project=...` argument  is now respected by the `ng add` schematic.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

cc: @dwieeb 