### PR TITLE
fix(item-sliding): account for swipe to go back gesture when opening item-options

### DIFF
--- a/core/src/components/item-sliding/item-sliding.tsx
+++ b/core/src/components/item-sliding/item-sliding.tsx
@@ -73,7 +73,7 @@ export class ItemSliding implements ComponentInterface {
       gestureName: 'item-swipe',
       gesturePriority: 100,
       threshold: 5,
-      canStart: () => this.canStart(),
+      canStart: ev => this.canStart(ev),
       onStart: () => this.onStart(),
       onMove: ev => this.onMove(ev),
       onEnd: ev => this.onEnd(ev),
@@ -225,7 +225,16 @@ export class ItemSliding implements ComponentInterface {
     this.sides = sides;
   }
 
-  private canStart(): boolean {
+  private canStart(gesture: GestureDetail): boolean {
+    /**
+     * If very close to start of the screen
+     * do not open left side so swipe to go
+     * back will still work.
+     */
+    if (gesture.startX < 15) {
+      return false;
+    }
+
     const selected = openSlidingItem;
     if (selected && selected !== this.el) {
       this.closeOpened();

--- a/core/src/components/item-sliding/item-sliding.tsx
+++ b/core/src/components/item-sliding/item-sliding.tsx
@@ -231,7 +231,9 @@ export class ItemSliding implements ComponentInterface {
      * do not open left side so swipe to go
      * back will still work.
      */
-    if (gesture.startX < 15) {
+    const rtl = document.dir === 'rtl';
+    const atEdge = (rtl) ? (window.innerWidth - gesture.startX) < 15 : gesture.startX < 15;
+    if (atEdge) {
       return false;
     }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic/issues/20773

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added gesture offset to ensure swipe to go back can still work with item-sliding

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
