### PR TITLE
fix(slides): check that mutation observer is defined for ssr

### DIFF
--- a/core/src/components/slides/slides.tsx
+++ b/core/src/components/slides/slides.tsx
@@ -132,6 +132,7 @@ export class Slides implements ComponentInterface {
   @Event() ionSlideTouchEnd!: EventEmitter<void>;
 
   connectedCallback() {
+    // tslint:disable-next-line: strict-type-predicates
     if (typeof MutationObserver !== 'undefined') {
       const mut = this.mutationO = new MutationObserver(() => {
         if (this.swiperReady) {

--- a/core/src/components/slides/slides.tsx
+++ b/core/src/components/slides/slides.tsx
@@ -132,16 +132,18 @@ export class Slides implements ComponentInterface {
   @Event() ionSlideTouchEnd!: EventEmitter<void>;
 
   connectedCallback() {
-    const mut = this.mutationO = new MutationObserver(() => {
-      if (this.swiperReady) {
-        this.update();
-      }
-    });
-    mut.observe(this.el, {
-      childList: true,
-      subtree: true
-    });
-    this.el.componentOnReady().then(() => this.initSwiper());
+    if (typeof MutationObserver !== 'undefined') {
+      const mut = this.mutationO = new MutationObserver(() => {
+        if (this.swiperReady) {
+          this.update();
+        }
+      });
+      mut.observe(this.el, {
+        childList: true,
+        subtree: true
+      });
+      this.el.componentOnReady().then(() => this.initSwiper());
+    }
   }
 
   async disconnectedCallback() {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

When running `stencil build --prod` in the stencil conference app the following error happens prior to this PR:

```
[12:28.5]  prerendering failed in 4.75
           s

[ ERROR ]  Hydrate Error: /tutorial
           ReferenceError: MutationObserver is not defined at
           Slides.connectedCallback
```


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- This fixes that error on the prerender

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
