### PR TITLE
fix(title): large title now inherits global color styling during nav transition

### DIFF
--- a/core/src/components/header/header.tsx
+++ b/core/src/components/header/header.tsx
@@ -126,7 +126,8 @@ export class Header implements ComponentInterface {
     this.scrollEl!.addEventListener('scroll', this.contentScrollCallback);
 
     writeTask(() => {
-      cloneElement('ion-title');
+      const title = cloneElement('ion-title') as HTMLIonTitleElement;
+      title.size = "large";
       cloneElement('ion-back-button');
 
       if (this.collapsibleMainHeader !== undefined) {

--- a/core/src/components/header/header.tsx
+++ b/core/src/components/header/header.tsx
@@ -127,7 +127,7 @@ export class Header implements ComponentInterface {
 
     writeTask(() => {
       const title = cloneElement('ion-title') as HTMLIonTitleElement;
-      title.size = "large";
+      title.size = 'large';
       cloneElement('ion-back-button');
 
       if (this.collapsibleMainHeader !== undefined) {

--- a/core/src/components/title/title.ios.scss
+++ b/core/src/components/title/title.ios.scss
@@ -55,3 +55,7 @@
 
   text-align: start;
 }
+
+:host(.title-large.ion-cloned-element) {
+  --color: var(--ion-text-color, #000);
+}

--- a/core/src/components/title/title.ios.scss
+++ b/core/src/components/title/title.ios.scss
@@ -57,5 +57,5 @@
 }
 
 :host(.title-large.ion-cloned-element) {
-  --color: var(--ion-toolbar-color, --ion-text-color, #fff);
+  --color: #{$text-color};
 }

--- a/core/src/components/title/title.ios.scss
+++ b/core/src/components/title/title.ios.scss
@@ -57,5 +57,5 @@
 }
 
 :host(.title-large.ion-cloned-element) {
-  --color: var(--ion-text-color, #fff);
+  --color: var(--ion-toolbar-color, --ion-text-color, #fff);
 }

--- a/core/src/components/title/title.ios.scss
+++ b/core/src/components/title/title.ios.scss
@@ -57,5 +57,5 @@
 }
 
 :host(.title-large.ion-cloned-element) {
-  --color: var(--ion-text-color, #000);
+  --color: var(--ion-text-color, #fff);
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Sets default for cloned element to be `--ion-text-color`. This helps on dark mode where the large title during the transition used to be black

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
