### PR TITLE
fix(modal): properly inherit border radius for modals on Safari

### DIFF
--- a/core/src/css/core.scss
+++ b/core/src/css/core.scss
@@ -41,9 +41,8 @@ html.ios ion-modal.modal-card .ion-page > ion-header > ion-toolbar:first-of-type
 
 // .ion-page needs to explicitly inherit
 // the border radius in safari otherwise
-// a card modal with ion-content[fullscreen=true]
-// will not show border radius properly
-html.ios ion-modal.modal-card .ion-page {
+// modals will not show border radius properly
+html.ios ion-modal .ion-page {
   border-radius: inherit;
 }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic/issues/20878


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Previously our workaround applied to card-style modals only, but a user pointed out this issue happens with all modals. I have expanded the CSS workaround to apply to all modals on iOS mode.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
