### PR TITLE
fix(slides): slides no longer breaks when Angular Ivy enabled

### DIFF
--- a/core/src/components/slides/slides.tsx
+++ b/core/src/components/slides/slides.tsx
@@ -24,6 +24,7 @@ export class Slides implements ComponentInterface {
   private readySwiper!: (swiper: SwiperInterface) => void;
   private swiper: Promise<SwiperInterface> = new Promise(resolve => { this.readySwiper = resolve; });
   private syncSwiper?: SwiperInterface;
+  private didInit = false;
 
   @Element() el!: HTMLIonSlidesElement;
 
@@ -144,7 +145,13 @@ export class Slides implements ComponentInterface {
         childList: true,
         subtree: true
       });
-      this.el.componentOnReady().then(() => this.initSwiper());
+
+      this.el.componentOnReady().then(() => {
+        if (!this.didInit) {
+          this.didInit = true;
+          this.initSwiper();
+        }
+      });
     }
   }
 
@@ -168,6 +175,8 @@ export class Slides implements ComponentInterface {
       this.swiperReady = false;
       this.syncSwiper = undefined;
     }
+
+    this.didInit = false;
   }
 
   /**


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic/issues/20356


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Synchronously destroy swiper instances to avoid race conditions in multiple connected/disconnected callbacks

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

short breakdown of the issue for future reference:

1. Component is added as a sibling to ion-router-outlet.
2. connectedCallback is called. Swiper is initialized.
3. Ionic moves the component to be a child of ion-router-outlet.
4. disconnectedCallback is called. Work begins to tear down Swiper.
5. connectedCallback is called. Swiper is initialized.

The problem lies in step 4. The code to destroy swiper is called after an asynchronous call to get the Swiper instance. In other words, while disconnectedCallback is called before the second connectedCallback, the actual code to destroy the swiper instance is called after the second connectedCallback.
