### PR TITLE
fix(textarea): set correct height in a modal when auto-grow is set

### DIFF
--- a/core/src/components/textarea/textarea.tsx
+++ b/core/src/components/textarea/textarea.tsx
@@ -191,7 +191,7 @@ export class Textarea implements ComponentInterface {
   componentDidLoad() {
     setTimeout(() => {
       this.runAutoGrow();
-    })
+    });
   }
 
   private runAutoGrow() {

--- a/core/src/components/textarea/textarea.tsx
+++ b/core/src/components/textarea/textarea.tsx
@@ -189,7 +189,9 @@ export class Textarea implements ComponentInterface {
   }
 
   componentDidLoad() {
-    this.runAutoGrow();
+    setTimeout(() => {
+      this.runAutoGrow();
+    })
   }
 
   private runAutoGrow() {

--- a/core/src/components/textarea/textarea.tsx
+++ b/core/src/components/textarea/textarea.tsx
@@ -2,7 +2,7 @@ import { Build, Component, ComponentInterface, Element, Event, EventEmitter, Hos
 
 import { getIonMode } from '../../global/ionic-global';
 import { Color, StyleEventDetail, TextareaChangeEventDetail } from '../../interface';
-import { debounceEvent, findItemLabel } from '../../utils/helpers';
+import { debounceEvent, findItemLabel, raf } from '../../utils/helpers';
 import { createColorClasses } from '../../utils/theme';
 
 /**
@@ -189,9 +189,7 @@ export class Textarea implements ComponentInterface {
   }
 
   componentDidLoad() {
-    setTimeout(() => {
-      this.runAutoGrow();
-    });
+    raf(() => this.runAutoGrow());
   }
 
   private runAutoGrow() {


### PR DESCRIPTION
Fixes #18993

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
When an `ion-textarea` element with `auto-grow="true"` is used within an `ion-modal`, it is shown correctly on the first load, but each subsequent load of the modal results in a `textarea` element height of 0.

Issue Number: #18993


## What is the new behavior?
The `textarea` now loads with the correct height on subsequent loads of the modal

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

I went to add tests for this and realised that the problem is not present when used in a pure javascript project. I first saw the issue in an `@ionic/angular` project. I have tested this with a locally linked build of `@ionic/core` and this solves the problem.
