### PR TITLE
fix(split-pane): show border in RTL mode

### DIFF
--- a/core/src/components/split-pane/split-pane.ios.scss
+++ b/core/src/components/split-pane/split-pane.ios.scss
@@ -11,6 +11,11 @@
 }
 
 :host(.split-pane-visible) ::slotted(.split-pane-side) {
+  @include rtl() {
+    border-right: 0;
+    border-left: var(--border);
+  }
+
   min-width: var(--side-min-width);
   max-width: var(--side-max-width);
 
@@ -19,6 +24,11 @@
 }
 
 :host(.split-pane-visible) ::slotted(.split-pane-side[side=end]) {
+  @include rtl() {
+    border-right: var(--border);
+    border-left: 0;
+  }
+  
   min-width: var(--side-min-width);
   max-width: var(--side-max-width);
 

--- a/core/src/components/split-pane/split-pane.ios.scss
+++ b/core/src/components/split-pane/split-pane.ios.scss
@@ -11,27 +11,15 @@
 }
 
 :host(.split-pane-visible) ::slotted(.split-pane-side) {
-  @include rtl() {
-    border-right: 0;
-    border-left: var(--border);
-  }
+  @include border(0, var(--border), 0, 0);
 
   min-width: var(--side-min-width);
   max-width: var(--side-max-width);
-
-  border-right: var(--border);
-  border-left: 0;
 }
 
 :host(.split-pane-visible) ::slotted(.split-pane-side[side=end]) {
-  @include rtl() {
-    border-right: var(--border);
-    border-left: 0;
-  }
+  @include border(0, 0, 0, var(--border));
   
   min-width: var(--side-min-width);
   max-width: var(--side-max-width);
-
-  border-right: 0;
-  border-left: var(--border);
 }

--- a/core/src/components/split-pane/split-pane.md.scss
+++ b/core/src/components/split-pane/split-pane.md.scss
@@ -11,6 +11,11 @@
 }
 
 :host(.split-pane-visible) ::slotted(.split-pane-side) {
+  @include rtl() {
+    border-right: 0;
+    border-left: var(--border);
+  }
+
   min-width: var(--side-min-width);
   max-width: var(--side-max-width);
 
@@ -19,6 +24,11 @@
 }
 
 :host(.split-pane-visible) ::slotted(.split-pane-side[side=end]) {
+  @include rtl() {
+    border-right: var(--border);
+    border-left: 0;
+  }
+  
   min-width: var(--side-min-width);
   max-width: var(--side-max-width);
 

--- a/core/src/components/split-pane/split-pane.md.scss
+++ b/core/src/components/split-pane/split-pane.md.scss
@@ -11,27 +11,15 @@
 }
 
 :host(.split-pane-visible) ::slotted(.split-pane-side) {
-  @include rtl() {
-    border-right: 0;
-    border-left: var(--border);
-  }
+  @include border(0, var(--border), 0, 0);
 
   min-width: var(--side-min-width);
   max-width: var(--side-max-width);
-
-  border-right: var(--border);
-  border-left: 0;
 }
 
 :host(.split-pane-visible) ::slotted(.split-pane-side[side=end]) {
-  @include rtl() {
-    border-right: var(--border);
-    border-left: 0;
-  }
-  
+  @include border(0, 0, 0, var(--border));
+
   min-width: var(--side-min-width);
   max-width: var(--side-max-width);
-
-  border-right: 0;
-  border-left: var(--border);
 }

--- a/core/src/themes/ionic.mixins.scss
+++ b/core/src/themes/ionic.mixins.scss
@@ -324,6 +324,16 @@
   bottom: $bottom;
 }
 
+// Add border for all directions
+// @param {string} $top
+// @param {string} $end
+// @param {string} $bottom
+// @param {string} $start
+// ----------------------------------------------------------
+@mixin border($top, $end: $top, $bottom: $top, $start: $end) {
+  @include property(border, $top, $end, $bottom, $start);
+}
+
 // Add border radius for all directions
 // @param {string} $top-start
 // @param {string} $top-end


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

Issue Number: 20994
[https://github.com/ionic-team/ionic/issues/20994]()

## What is the new behavior?
In split-pane component, RTL mode now shows the border between the two panes

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
