### PR TITLE
fix(ios): add haptic drag gesture for action sheet and alert components

### DIFF
--- a/core/src/components/action-sheet/action-sheet.ios.scss
+++ b/core/src/components/action-sheet/action-sheet.ios.scss
@@ -134,6 +134,8 @@
   @include margin-horizontal(null, $action-sheet-ios-button-icon-padding-right);
 
   font-size: $action-sheet-ios-button-icon-font-size;
+
+  pointer-events: none;
 }
 
 .action-sheet-button:last-child {

--- a/core/src/components/action-sheet/action-sheet.scss
+++ b/core/src/components/action-sheet/action-sheet.scss
@@ -110,6 +110,7 @@
   flex-shrink: 0;
   align-items: center;
   justify-content: center;
+  pointer-events: none;
 
   width: 100%;
   height: 100%;

--- a/core/src/components/alert/alert.ios.scss
+++ b/core/src/components/alert/alert.ios.scss
@@ -19,7 +19,7 @@
   overflow: hidden;
 }
 
-.alert-button-inner {
+.alert-button .alert-button-inner {
   pointer-events: none;
 }
 

--- a/core/src/components/alert/alert.ios.scss
+++ b/core/src/components/alert/alert.ios.scss
@@ -19,6 +19,10 @@
   overflow: hidden;
 }
 
+.alert-button-inner {
+  pointer-events: none;
+}
+
 
 // iOS Translucent Alert
 // -----------------------------------------

--- a/core/src/components/alert/alert.tsx
+++ b/core/src/components/alert/alert.tsx
@@ -2,6 +2,8 @@ import { Component, ComponentInterface, Element, Event, EventEmitter, Host, Meth
 
 import { getIonMode } from '../../global/ionic-global';
 import { AlertButton, AlertInput, AnimationBuilder, CssClassMap, OverlayEventDetail, OverlayInterface } from '../../interface';
+import { Gesture } from '../../utils/gesture';
+import { createButtonActiveGesture } from '../../utils/gesture/button-active';
 import { BACKDROP, dismiss, eventMethod, isCancel, prepareOverlay, present, safeCall } from '../../utils/overlays';
 import { sanitizeDOMString } from '../../utils/sanitization';
 import { getClassMap } from '../../utils/theme';
@@ -28,6 +30,8 @@ export class Alert implements ComponentInterface, OverlayInterface {
   private inputType?: string;
   private processedInputs: AlertInput[] = [];
   private processedButtons: AlertButton[] = [];
+  private wrapperEl?: HTMLElement;
+  private gesture?: Gesture;
 
   presented = false;
 
@@ -168,6 +172,30 @@ export class Alert implements ComponentInterface, OverlayInterface {
   componentWillLoad() {
     this.inputsChanged();
     this.buttonsChanged();
+  }
+
+  componentDidUnload() {
+    if (this.gesture) {
+      this.gesture.destroy();
+      this.gesture = undefined;
+    }
+  }
+
+  componentDidLoad() {
+    /**
+     * Do not create gesture if:
+     * 1. A gesture already exists
+     * 2. App is running in MD mode
+     * 3. A wrapper ref does not exist
+     */
+    if (this.gesture || getIonMode(this) === 'md' || !this.wrapperEl) { return; }
+
+    this.gesture = createButtonActiveGesture(
+      this.wrapperEl,
+      (refEl: HTMLElement) => refEl.classList.contains('alert-button')
+    );
+    this.gesture.enable(true);
+    console.log(this.gesture, this.wrapperEl);
   }
 
   /**
@@ -480,7 +508,7 @@ export class Alert implements ComponentInterface, OverlayInterface {
 
         <ion-backdrop tappable={this.backdropDismiss}/>
 
-        <div class="alert-wrapper">
+        <div class="alert-wrapper" ref={el => this.wrapperEl = el}>
 
           <div class="alert-head">
             {header && <h2 id={hdrId} class="alert-title">{header}</h2>}

--- a/core/src/components/alert/alert.tsx
+++ b/core/src/components/alert/alert.tsx
@@ -195,7 +195,6 @@ export class Alert implements ComponentInterface, OverlayInterface {
       (refEl: HTMLElement) => refEl.classList.contains('alert-button')
     );
     this.gesture.enable(true);
-    console.log(this.gesture, this.wrapperEl);
   }
 
   /**

--- a/core/src/utils/gesture/button-active.ts
+++ b/core/src/utils/gesture/button-active.ts
@@ -11,7 +11,6 @@ export const createButtonActiveGesture = (
 
   const activateButtonAtPoint = (x: number, y: number, hapticFeedbackFn: () => void) => {
     const target = document.elementFromPoint(x, y) as HTMLElement | null;
-    console.log(target);
     if (!target || !isButton(target)) {
       clearActiveButton();
       return;

--- a/core/src/utils/gesture/button-active.ts
+++ b/core/src/utils/gesture/button-active.ts
@@ -1,0 +1,55 @@
+import { raf } from '../helpers';
+import { hapticSelectionChanged, hapticSelectionEnd, hapticSelectionStart } from '../native/haptic';
+
+import { Gesture, createGesture } from './index';
+
+export const createButtonActiveGesture = (
+  el: HTMLElement,
+  isButton: (refEl: HTMLElement) => boolean
+): Gesture => {
+  let touchedButton: HTMLElement | undefined;
+
+  const activateButtonAtPoint = (x: number, y: number, hapticFeedbackFn: () => void) => {
+    const target = document.elementFromPoint(x, y) as HTMLElement | null;
+    console.log(target);
+    if (!target || !isButton(target)) {
+      clearActiveButton();
+      return;
+    }
+
+    if (target !== touchedButton) {
+      clearActiveButton();
+      setActiveButton(target, hapticFeedbackFn);
+    }
+  };
+
+  const setActiveButton = (button: HTMLElement, hapticFeedbackFn: () => void) => {
+    touchedButton = button;
+    raf(() => touchedButton!.classList.add('ion-activated'));
+    hapticFeedbackFn();
+  };
+
+  const clearActiveButton = (dispatchClick = false) => {
+    if (!touchedButton) { return; }
+
+    touchedButton!.classList.remove('ion-activated');
+
+    if (dispatchClick) {
+      touchedButton.click();
+    }
+
+    touchedButton = undefined;
+  };
+
+  return createGesture({
+    el,
+    gestureName: 'buttonActiveDrag',
+    threshold: 0,
+    onStart: ev => activateButtonAtPoint(ev.currentX, ev.currentY, hapticSelectionStart),
+    onMove: ev => activateButtonAtPoint(ev.currentX, ev.currentY, hapticSelectionChanged),
+    onEnd: () => {
+      clearActiveButton(true);
+      hapticSelectionEnd();
+    }
+  });
+};

--- a/core/src/utils/gesture/button-active.ts
+++ b/core/src/utils/gesture/button-active.ts
@@ -1,4 +1,4 @@
-import { raf } from '../helpers';
+import { writeTask } from '@stencil/core';
 import { hapticSelectionChanged, hapticSelectionEnd, hapticSelectionStart } from '../native/haptic';
 
 import { Gesture, createGesture } from './index';
@@ -25,14 +25,16 @@ export const createButtonActiveGesture = (
 
   const setActiveButton = (button: HTMLElement, hapticFeedbackFn: () => void) => {
     touchedButton = button;
-    raf(() => touchedButton!.classList.add('ion-activated'));
+    const buttonToModify = touchedButton;
+    writeTask(() => buttonToModify.classList.add('ion-activated'));
     hapticFeedbackFn();
   };
 
   const clearActiveButton = (dispatchClick = false) => {
     if (!touchedButton) { return; }
 
-    touchedButton!.classList.remove('ion-activated');
+    const buttonToModify = touchedButton;
+    writeTask(() => buttonToModify.classList.remove('ion-activated'));
 
     if (dispatchClick) {
       touchedButton.click();

--- a/core/src/utils/gesture/button-active.ts
+++ b/core/src/utils/gesture/button-active.ts
@@ -1,4 +1,5 @@
 import { writeTask } from '@stencil/core';
+
 import { hapticSelectionChanged, hapticSelectionEnd, hapticSelectionStart } from '../native/haptic';
 
 import { Gesture, createGesture } from './index';

--- a/core/src/utils/gesture/button-active.ts
+++ b/core/src/utils/gesture/button-active.ts
@@ -11,6 +11,7 @@ export const createButtonActiveGesture = (
   let touchedButton: HTMLElement | undefined;
 
   const activateButtonAtPoint = (x: number, y: number, hapticFeedbackFn: () => void) => {
+    if (typeof (document as any) === 'undefined') { return; }
     const target = document.elementFromPoint(x, y) as HTMLElement | null;
     if (!target || !isButton(target)) {
       clearActiveButton();

--- a/core/src/utils/native/haptic.ts
+++ b/core/src/utils/native/haptic.ts
@@ -69,9 +69,9 @@ const HapticEngine = {
       return;
     }
     if (this.isCapacitor()) {
-      engine.selectionChanged();
+      engine.selectionEnd();
     } else {
-      engine.gestureSelectionChanged();
+      engine.gestureSelectionEnd();
     }
   }
 };


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fixes https://github.com/ionic-team/ionic/issues/21052


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added a custom gesture that a) adds `ion-activated` to action sheet/alert buttons and b) triggers a "selectionChanged" haptic feedback when pointer is over a button

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
