### PR TITLE
fix(modal): swipeToClose property is now reactive

### DIFF
--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -1,4 +1,4 @@
-import { Component, ComponentInterface, Element, Event, EventEmitter, Host, Method, Prop, h, Watch, writeTask } from '@stencil/core';
+import { Component, ComponentInterface, Element, Event, EventEmitter, Host, Method, Prop, Watch, h, writeTask } from '@stencil/core';
 
 import { config } from '../../global/config';
 import { getIonMode } from '../../global/ionic-global';

--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -122,9 +122,11 @@ export class Modal implements ComponentInterface, OverlayInterface {
   @Event({ eventName: 'ionModalDidDismiss' }) didDismiss!: EventEmitter<OverlayEventDetail>;
 
   @Watch('swipeToClose')
-  swipeToCloseChanged(newValue: boolean) {
+  swipeToCloseChanged(enable: boolean) {
     if (this.gesture) {
-      this.gesture.enable(newValue);
+      this.gesture.enable(enable);
+    } else if (enable) {
+      this.initSwipeToClose();
     }
   }
 
@@ -157,34 +159,38 @@ export class Modal implements ComponentInterface, OverlayInterface {
 
     const mode = getIonMode(this);
     if (this.swipeToClose && mode === 'ios') {
-      // All of the elements needed for the swipe gesture
-      // should be in the DOM and referenced by now, except
-      // for the presenting el
-      const animationBuilder = this.leaveAnimation || config.get('modalLeave', iosLeaveAnimation);
-      const ani = this.animation = animationBuilder(this.el, this.presentingElement);
-      this.gesture = createSwipeToCloseGesture(
-        this.el,
-        ani,
-        () => {
-          /**
-           * While the gesture animation is finishing
-           * it is possible for a user to tap the backdrop.
-           * This would result in the dismiss animation
-           * being played again. Typically this is avoided
-           * by setting `presented = false` on the overlay
-           * component; however, we cannot do that here as
-           * that would prevent the element from being
-           * removed from the DOM.
-           */
-          this.gestureAnimationDismissing = true;
-          this.animation!.onFinish(async () => {
-            await this.dismiss(undefined, 'gesture');
-            this.gestureAnimationDismissing = false;
-          });
-        },
-      );
-      this.gesture.enable(true);
+      this.initSwipeToClose();
     }
+  }
+
+  private initSwipeToClose() {
+    // All of the elements needed for the swipe gesture
+    // should be in the DOM and referenced by now, except
+    // for the presenting el
+    const animationBuilder = this.leaveAnimation || config.get('modalLeave', iosLeaveAnimation);
+    const ani = this.animation = animationBuilder(this.el, this.presentingElement);
+    this.gesture = createSwipeToCloseGesture(
+      this.el,
+      ani,
+      () => {
+        /**
+         * While the gesture animation is finishing
+         * it is possible for a user to tap the backdrop.
+         * This would result in the dismiss animation
+         * being played again. Typically this is avoided
+         * by setting `presented = false` on the overlay
+         * component; however, we cannot do that here as
+         * that would prevent the element from being
+         * removed from the DOM.
+         */
+        this.gestureAnimationDismissing = true;
+        this.animation!.onFinish(async () => {
+          await this.dismiss(undefined, 'gesture');
+          this.gestureAnimationDismissing = false;
+        });
+      },
+    );
+    this.gesture.enable(true);
   }
 
   /**

--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -157,13 +157,14 @@ export class Modal implements ComponentInterface, OverlayInterface {
 
     await present(this, 'modalEnter', iosEnterAnimation, mdEnterAnimation, this.presentingElement);
 
-    const mode = getIonMode(this);
-    if (this.swipeToClose && mode === 'ios') {
+    if (this.swipeToClose) {
       this.initSwipeToClose();
     }
   }
 
   private initSwipeToClose() {
+    if (getIonMode(this) !== 'ios') { return; }
+
     // All of the elements needed for the swipe gesture
     // should be in the DOM and referenced by now, except
     // for the presenting el

--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -1,4 +1,4 @@
-import { Component, ComponentInterface, Element, Event, EventEmitter, Host, Method, Prop, h, writeTask } from '@stencil/core';
+import { Component, ComponentInterface, Element, Event, EventEmitter, Host, Method, Prop, h, Watch, writeTask } from '@stencil/core';
 
 import { config } from '../../global/config';
 import { getIonMode } from '../../global/ionic-global';
@@ -120,6 +120,13 @@ export class Modal implements ComponentInterface, OverlayInterface {
    * Emitted after the modal has dismissed.
    */
   @Event({ eventName: 'ionModalDidDismiss' }) didDismiss!: EventEmitter<OverlayEventDetail>;
+
+  @Watch('swipeToClose')
+  swipeToCloseChanged(newValue: boolean) {
+    if (this.gesture) {
+      this.gesture.enable(newValue);
+    }
+  }
 
   constructor() {
     prepareOverlay(this.el);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ionic-team/ionic/issues/21072


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Swipe To Close gesture is now enabled/disabled is swipeToClose prop is updated.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
