### PR TITLE
chore(): update contributing docs, update ionitron bot

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,6 +4,7 @@ Thanks for your interest in contributing to the Ionic Framework! :tada:
 
 - [Contributing Etiquette](#contributing-etiquette)
 - [Creating an Issue](#creating-an-issue)
+  * [Creating a Good Code Reproduction](#creating-a-good-code-reproduction)
 - [Creating a Pull Request](#creating-a-pull-request)
   * [Setup](#setup)
   * [Core](#core)
@@ -45,6 +46,32 @@ Please see our [Contributor Code of Conduct](https://github.com/ionic-team/ionic
 * If you think you have found a bug, or have a new feature idea, please start by making sure it hasn't already been [reported](https://github.com/ionic-team/ionic/issues?utf8=%E2%9C%93&q=is%3Aissue). You can search through existing issues to see if there is a similar one reported. Include closed issues as it may have been closed with a solution.
 
 * Next, [create a new issue](https://github.com/ionic-team/ionic/issues/new/choose) that thoroughly explains the problem. Please fill out the populated issue form before submitting the issue.
+
+### Creating a Good Code Reproduction
+
+####What is a code reproduction?
+
+A code reproduction is a small Ionic Framework application that is built to demonstrate a particular issue. The code reproduction should contain the minimal amount of code needed to recreate the issue you are experiencing. In addition, the code reproduction should be reliable. This means that we should be able to reproduce the issue every  time we follow your steps to reproduce. Code reproductions that do not reproduce the issue every time are not considered reliable.
+
+#### Why should you create a reproduction?
+
+A code reproduction of the issue you are experiencing helps us better isolate the cause of the problem. This is an important first step to getting any bugs fixed! 
+
+Without a reliable code reproduction, it is unlikely we will be able to address the issue. Issues that do not have a code reproduction will be closed. In short, creating a code reproduction of the issue helps us help you faster.
+
+#### How to create a reproduction
+
+* Create a new Ionic application using one of our starter templates. The `blank` starter application is a great choice for this. You can create one using the following Ionic CLI command: `ionic start myApp blank`
+* Add the minimal amount of code needed to recreate the issue you are experiencing. Do not include anything that is not required to reproduce the issue. This includes any 3rd party plugins you have installed.
+* Publish the application on GitHub and include a link to it when [creating an issue](https://github.com/ionic-team/ionic/issues/new/choose).
+* Be sure to include steps to reproduce the issue. These steps should be clear and easy to follow.
+
+#### Benefits of Creating a Reproduction
+
+* Uses the latest version of Ionic: By creating a new Ionic application, you are ensuring that you are testing against the latest version of the framework. Sometimes the issues you are experiencing have already been resolved in a newer version of the framework!
+* Minimal surface area: By removing code that is not needed in order to reproduce the issue, it makes it easier to identify the cause of the issue.
+* No secret code needed: Creating a minimal reproduction of the issue prevents you from having to publish any proprietary code used in your project.
+* Get help fixing the issue: If we can reliably reproduce an issue, there is a good chance we will be able to address it.
 
 
 ## Creating a Pull Request

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Please see our [Contributor Code of Conduct](https://github.com/ionic-team/ionic
 
 ### Creating a Good Code Reproduction
 
-####What is a code reproduction?
+#### What is a code reproduction?
 
 A code reproduction is a small Ionic Framework application that is built to demonstrate a particular issue. The code reproduction should contain the minimal amount of code needed to recreate the issue you are experiencing. In addition, the code reproduction should be reliable. This means that we should be able to reproduce the issue every  time we follow your steps to reproduce. Code reproductions that do not reproduce the issue every time are not considered reliable.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Please see our [Contributor Code of Conduct](https://github.com/ionic-team/ionic
 
 * The issue list of this repository is exclusively for bug reports and feature requests. Non-conforming issues will be closed immediately.
 
-* Issues with no clear steps to reproduce will not be triaged. If an issue is labeled with "needs: reply" and receives no further replies from the author of the issue for more than 30 days, it will be closed.
+* Issues with no clear steps to reproduce will not be triaged. If an issue is labeled with "needs: reply" and receives no further replies from the author of the issue for more than 14 days, it will be closed.
 
 * If you think you have found a bug, or have a new feature idea, please start by making sure it hasn't already been [reported](https://github.com/ionic-team/ionic/issues?utf8=%E2%9C%93&q=is%3Aissue). You can search through existing issues to see if there is a similar one reported. Include closed issues as it may have been closed with a solution.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -51,13 +51,13 @@ Please see our [Contributor Code of Conduct](https://github.com/ionic-team/ionic
 
 #### What is a code reproduction?
 
-A code reproduction is a small Ionic Framework application that is built to demonstrate a particular issue. The code reproduction should contain the minimal amount of code needed to recreate the issue you are experiencing. In addition, the code reproduction should be reliable. This means that we should be able to reproduce the issue every  time we follow your steps to reproduce. Code reproductions that do not reproduce the issue every time are not considered reliable.
+A code reproduction is a small application that is built to demonstrate a particular issue. The code reproduction should contain the minimal amount of code needed to recreate the issue you are experiencing.
 
 #### Why should you create a reproduction?
 
-A code reproduction of the issue you are experiencing helps us better isolate the cause of the problem. This is an important first step to getting any bugs fixed! 
+A code reproduction of the issue you are experiencing helps us better isolate the cause of the problem. This is an important first step to getting any bug fixed! 
 
-Without a reliable code reproduction, it is unlikely we will be able to address the issue. Issues that do not have a code reproduction will be closed. In short, creating a code reproduction of the issue helps us help you faster.
+Without a reliable code reproduction, it is unlikely we will be able to address the issue. In other words, creating a code reproduction of the issue helps us help you faster.
 
 #### How to create a reproduction
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -47,31 +47,32 @@ Please see our [Contributor Code of Conduct](https://github.com/ionic-team/ionic
 
 * Next, [create a new issue](https://github.com/ionic-team/ionic/issues/new/choose) that thoroughly explains the problem. Please fill out the populated issue form before submitting the issue.
 
-### Creating a Good Code Reproduction
 
-#### What is a code reproduction?
+## Creating a Good Code Reproduction
 
-A code reproduction is a small application that is built to demonstrate a particular issue. The code reproduction should contain the minimal amount of code needed to recreate the issue you are experiencing.
+### What is a code reproduction?
 
-#### Why should you create a reproduction?
+A code reproduction is a small application that is built to demonstrate a particular issue. The code reproduction should contain the minimum amount of code needed to recreate the issue and should focus on a single issue.
+
+### Why should you create a reproduction?
 
 A code reproduction of the issue you are experiencing helps us better isolate the cause of the problem. This is an important first step to getting any bug fixed! 
 
 Without a reliable code reproduction, it is unlikely we will be able to address the issue. In other words, creating a code reproduction of the issue helps us help you faster.
 
-#### How to create a reproduction
+### How to create a reproduction
 
 * Create a new Ionic application using one of our starter templates. The `blank` starter application is a great choice for this. You can create one using the following Ionic CLI command: `ionic start myApp blank`
-* Add the minimal amount of code needed to recreate the issue you are experiencing. Do not include anything that is not required to reproduce the issue. This includes any 3rd party plugins you have installed.
+* Add the minimum amount of code needed to recreate the issue you are experiencing. Do not include anything that is not required to reproduce the issue. This includes any 3rd party plugins you have installed.
 * Publish the application on GitHub and include a link to it when [creating an issue](https://github.com/ionic-team/ionic/issues/new/choose).
 * Be sure to include steps to reproduce the issue. These steps should be clear and easy to follow.
 
-#### Benefits of Creating a Reproduction
+### Benefits of creating a reproduction
 
-* Uses the latest version of Ionic: By creating a new Ionic application, you are ensuring that you are testing against the latest version of the framework. Sometimes the issues you are experiencing have already been resolved in a newer version of the framework!
-* Minimal surface area: By removing code that is not needed in order to reproduce the issue, it makes it easier to identify the cause of the issue.
-* No secret code needed: Creating a minimal reproduction of the issue prevents you from having to publish any proprietary code used in your project.
-* Get help fixing the issue: If we can reliably reproduce an issue, there is a good chance we will be able to address it.
+* **Uses the latest version of Ionic:** By creating a new Ionic application, you are ensuring that you are testing against the latest version of the framework. Sometimes the issues you are experiencing have already been resolved in a newer version of the framework!
+* **Minimal surface area:** By removing code that is not needed in order to reproduce the issue, it makes it easier to identify the cause of the issue.
+* **No secret code needed:** Creating a minimal reproduction of the issue prevents you from having to publish any proprietary code used in your project.
+* **Get help fixing the issue:** If we can reliably reproduce an issue, there is a good chance we will be able to address it.
 
 
 ## Creating a Pull Request

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Without a reliable code reproduction, it is unlikely we will be able to resolve 
 
 * Create a new Ionic application using one of our starter templates. The `blank` starter application is a great choice for this. You can create one using the following Ionic CLI command: `ionic start myApp blank`
 * Add the minimum amount of code needed to recreate the issue you are experiencing. Do not include anything that is not required to reproduce the issue. This includes any 3rd party plugins you have installed.
-* Publish the application on GitHub and include a link to it when [creating an issue](https://github.com/ionic-team/ionic/issues/new/choose).
+* Publish the application on GitHub and include a link to it when [creating an issue](#creating-an-issue).
 * Be sure to include steps to reproduce the issue. These steps should be clear and easy to follow.
 
 ### Benefits of Creating a Reproduction

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -54,11 +54,11 @@ Please see our [Contributor Code of Conduct](https://github.com/ionic-team/ionic
 
 A code reproduction is a small application that is built to demonstrate a particular issue. The code reproduction should contain the minimum amount of code needed to recreate the issue and should focus on a single issue.
 
-### Why should you create a reproduction?
+### Why should you create a repro?
 
 A code reproduction of the issue you are experiencing helps us better isolate the cause of the problem. This is an important first step to getting any bug fixed! 
 
-Without a reliable code reproduction, it is unlikely we will be able to address the issue. In other words, creating a code reproduction of the issue helps us help you faster.
+Without a reliable code reproduction, it is unlikely we will be able to address the issue. Issues that do not have a code reproduction may be closed. In other words, creating a code reproduction of the issue helps us help you faster.
 
 ### How to create a reproduction
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -50,24 +50,24 @@ Please see our [Contributor Code of Conduct](https://github.com/ionic-team/ionic
 
 ## Creating a Good Code Reproduction
 
-### What is a code reproduction?
+### What is a Code Reproduction?
 
 A code reproduction is a small application that is built to demonstrate a particular issue. The code reproduction should contain the minimum amount of code needed to recreate the issue and should focus on a single issue.
 
-### Why should you create a repro?
+### Why Should You Create a Reproduction?
 
 A code reproduction of the issue you are experiencing helps us better isolate the cause of the problem. This is an important first step to getting any bug fixed! 
 
-Without a reliable code reproduction, it is unlikely we will be able to address the issue. Issues that do not have a code reproduction may be closed. In other words, creating a code reproduction of the issue helps us help you faster.
+Without a reliable code reproduction, it is unlikely we will be able to resolve the issue, leading to it being closed. In other words, creating a code reproduction of the issue helps us help you.
 
-### How to create a reproduction
+### How to Create a Reproduction
 
 * Create a new Ionic application using one of our starter templates. The `blank` starter application is a great choice for this. You can create one using the following Ionic CLI command: `ionic start myApp blank`
 * Add the minimum amount of code needed to recreate the issue you are experiencing. Do not include anything that is not required to reproduce the issue. This includes any 3rd party plugins you have installed.
 * Publish the application on GitHub and include a link to it when [creating an issue](https://github.com/ionic-team/ionic/issues/new/choose).
 * Be sure to include steps to reproduce the issue. These steps should be clear and easy to follow.
 
-### Benefits of creating a reproduction
+### Benefits of Creating a Reproduction
 
 * **Uses the latest version of Ionic:** By creating a new Ionic application, you are ensuring that you are testing against the latest version of the framework. Sometimes the issues you are experiencing have already been resolved in a newer version of the framework!
 * **Minimal surface area:** By removing code that is not needed in order to reproduce the issue, it makes it easier to identify the cause of the issue.

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -21,6 +21,15 @@ comment:
 
 
         Thank you!
+    - label: "ionitron: needs reproduction"
+      message: >
+        Thanks for the issue! This issue has been labeled as `needs reproduction`. This label
+        is added to issues that need a code reproduction.
+
+        Please provide a reproduction with the minimal amount of code required to reproduce the issue. Without a reproduction
+        we are unable to fix any issues that you may be experiencing.
+
+        For a guide on how to create a good reproduction, see [How to Create a Good Code Reproduction](https://ionicframework.com/docs/contributing/how-to-contribute#creating-a-good-code-reproduction).
   dryRun: false
 
 closeAndLock:
@@ -83,7 +92,7 @@ stale:
   dryRun: false
 
 noReply:
-  days: 30
+  days: 14
   maxIssuesPerRun: 100
   label: "needs: reply"
   responseLabel: triage
@@ -91,6 +100,24 @@ noReply:
   exemptMilestones: true
   message: >
     Thanks for the issue! This issue is being closed due to the lack of a reply. If this is still
+    an issue with the latest version of Ionic, please create a new issue and ensure the
+    template is fully filled out.
+
+
+    Thank you for using Ionic!
+  close: true
+  lock: true
+  dryRun: false
+
+noReproduction:
+  days: 14
+  maxIssuesPerRun: 100
+  label: "ionitron: needs reproduction"
+  responseLabel: triage
+  exemptProjects: true
+  exemptMilestones: true
+  message: >
+    Thanks for the issue! This issue is being closed due to the lack of a code reproduction. If this is still
     an issue with the latest version of Ionic, please create a new issue and ensure the
     template is fully filled out.
 

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -26,7 +26,7 @@ comment:
         Thanks for the issue! This issue has been labeled as `needs reproduction`. This label
         is added to issues that need a code reproduction.
 
-        Please provide a reproduction with the minimal amount of code required to reproduce the issue. Without a reproduction
+        Please provide a reproduction with the minimum amount of code required to reproduce the issue. Without a reproduction
         we are unable to fix any issues that you may be experiencing.
 
         For a guide on how to create a good reproduction, see [How to Create a Good Code Reproduction](https://ionicframework.com/docs/contributing/how-to-contribute#creating-a-good-code-reproduction).

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -26,8 +26,7 @@ comment:
         Thanks for the issue! This issue has been labeled as `needs reproduction`. This label
         is added to issues that need a code reproduction.
 
-        Please provide a reproduction with the minimum amount of code required to reproduce the issue. Without a reproduction
-        we are unable to fix any issues that you may be experiencing.
+        Please provide a reproduction with the minimum amount of code required to reproduce the issue. Without a reliable code reproduction, it is unlikely we will be able to resolve the issue, leading to it being closed.
 
         For a guide on how to create a good reproduction, see [How to Create a Good Code Reproduction](https://ionicframework.com/docs/contributing/how-to-contribute#creating-a-good-code-reproduction).
   dryRun: false


### PR DESCRIPTION
Changed a few things:

1. Added a guide on how to create a good code reproduction (see also: https://github.com/ionic-team/ionic-docs/pull/1375)
2. Changed autoclose timeout on `needs reply` from 30 days to 14 days.
3. Added autoreply for `ionitron: needs reproduction` label
4. Added autoclose timeout of 14 days for `ionitron: needs reproduction` label.