### PR TITLE
fix(header): collapsable header no longer erroneously activates when using ion-refresher

### DIFF
--- a/core/src/components/header/header.tsx
+++ b/core/src/components/header/header.tsx
@@ -112,7 +112,15 @@ export class Header implements ComponentInterface {
      * as well as progressively showing/hiding the main header
      * border as the top-most toolbar collapses or expands.
      */
-    const toolbarIntersection = (ev: any) => { handleToolbarIntersection(ev, mainHeaderIndex, scrollHeaderIndex); };
+    const toolbarIntersection = (ev: any) => {
+      /**
+       * Since the native refresher relies on scroll/content positioning
+       * it can sometimes cause IO to fire erroneously. Whenever the refresher
+       * is active, we should ignore the IO since it is usually wrong.
+       */
+      const nativeRefresher = contentEl.querySelector('ion-refresher.refresher-native') as HTMLElement | null;
+      handleToolbarIntersection(ev, mainHeaderIndex, scrollHeaderIndex, nativeRefresher);
+    };
 
     this.intersectionObserver = new IntersectionObserver(toolbarIntersection, { root: contentEl, threshold: [0.25, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1] });
     this.intersectionObserver.observe(scrollHeaderIndex.toolbars[scrollHeaderIndex.toolbars.length - 1].el);

--- a/core/src/components/header/header.utils.ts
+++ b/core/src/components/header/header.utils.ts
@@ -72,8 +72,11 @@ export const setToolbarBackgroundOpacity = (toolbar: ToolbarIndex, opacity?: num
   }
 };
 
-const handleToolbarBorderIntersection = (ev: any, mainHeaderIndex: HeaderIndex) => {
-  if (!ev[0].isIntersecting) { return; }
+const handleToolbarBorderIntersection = (ev: any, mainHeaderIndex: HeaderIndex, nativeRefresherEl: HTMLElement | null) => {
+  if (
+    !ev[0].isIntersecting ||
+    (nativeRefresherEl && nativeRefresherEl.classList.contains('refresher-active'))
+  ) { return; }
 
   /**
    * There is a bug in Safari where overflow scrolling on a non-body element
@@ -93,9 +96,9 @@ const handleToolbarBorderIntersection = (ev: any, mainHeaderIndex: HeaderIndex) 
  * and show the primary toolbar content. If the toolbars are not intersecting,
  * hide the primary toolbar content and show the scrollable toolbar content
  */
-export const handleToolbarIntersection = (ev: any, mainHeaderIndex: HeaderIndex, scrollHeaderIndex: HeaderIndex) => {
+export const handleToolbarIntersection = (ev: any, mainHeaderIndex: HeaderIndex, scrollHeaderIndex: HeaderIndex, nativeRefresherEl: HTMLElement | null) => {
   writeTask(() => {
-    handleToolbarBorderIntersection(ev, mainHeaderIndex);
+    handleToolbarBorderIntersection(ev, mainHeaderIndex, nativeRefresherEl);
 
     const event = ev[0];
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Refresher manipulates content positioning and listens for scroll events which can interfere with the firing of IntersectionObserver for collapsable header. 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- When native refresher is active (I.e. pulling down), we ignore all IntersectionObserver events since they are guaranteed to be wrong. Only applies when devs are using the native ion-refresher.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
