### PR TITLE
fix(input): check for tabindex and pass it properly to native input

### DIFF
--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -215,6 +215,9 @@ export class Input implements ComponentInterface {
   @Event() ionStyle!: EventEmitter<StyleEventDetail>;
 
   componentWillLoad() {
+    // If the ion-input has a tabindex attribute we get the value
+    // and pass it down to the native input, then remove it from the
+    // ion-input to avoid causing tabbing twice on the same element
     if (this.el.hasAttribute('tabindex')) {
       const tabindex = this.el.getAttribute('tabindex');
       this.tabindex = tabindex !== null ? tabindex : undefined;

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -217,7 +217,7 @@ export class Input implements ComponentInterface {
   componentWillLoad() {
     if (this.el.hasAttribute('tabindex')) {
       const tabindex = this.el.getAttribute('tabindex');
-      this.tabindex = tabindex ? tabindex : undefined;
+      this.tabindex = tabindex !== null ? tabindex : undefined;
       this.el.removeAttribute('tabindex');
     }
   }

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -21,6 +21,7 @@ export class Input implements ComponentInterface {
   private nativeInput?: HTMLInputElement;
   private inputId = `ion-input-${inputIds++}`;
   private didBlurAfterEdit = false;
+  private tabindex?: string | number;
 
   @State() hasFocus = false;
 
@@ -89,18 +90,18 @@ export class Input implements ComponentInterface {
   }
 
   /**
-   * A hint to the browser for which keyboard to display.
-   * Possible values: `"none"`, `"text"`, `"tel"`, `"url"`,
-   * `"email"`, `"numeric"`, `"decimal"`, and `"search"`.
-   */
-  @Prop() inputmode?: 'none' | 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal' | 'search';
-
-  /**
    * A hint to the browser for which enter key to display.
    * Possible values: `"enter"`, `"done"`, `"go"`, `"next"`,
    * `"previous"`, `"search"`, and `"send"`.
    */
   @Prop() enterkeyhint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send';
+
+  /**
+   * A hint to the browser for which keyboard to display.
+   * Possible values: `"none"`, `"text"`, `"tel"`, `"url"`,
+   * `"email"`, `"numeric"`, `"decimal"`, and `"search"`.
+   */
+  @Prop() inputmode?: 'none' | 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal' | 'search';
 
   /**
    * The maximum value, which must not be less than its minimum (min attribute) value.
@@ -212,6 +213,14 @@ export class Input implements ComponentInterface {
    * @internal
    */
   @Event() ionStyle!: EventEmitter<StyleEventDetail>;
+
+  componentWillLoad() {
+    if (this.el.hasAttribute('tabindex')) {
+      const tabindex = this.el.getAttribute('tabindex');
+      this.tabindex = tabindex ? tabindex : undefined;
+      this.el.removeAttribute('tabindex');
+    }
+  }
 
   connectedCallback() {
     this.emitStyle();
@@ -384,6 +393,7 @@ export class Input implements ComponentInterface {
           spellCheck={this.spellcheck}
           step={this.step}
           size={this.size}
+          tabindex={this.tabindex}
           type={this.type}
           value={value}
           onInput={this.onInput}

--- a/core/src/components/input/test/tabindex/index.html
+++ b/core/src/components/input/test/tabindex/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html dir="ltr">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Input - Tabindex</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <link href="../../../../../css/ionic.bundle.css" rel="stylesheet">
+  <link href="../../../../../scripts/testing/styles.css" rel="stylesheet">
+  <script src="../../../../../scripts/testing/scripts.js"></script>
+  <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
+  <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script></head>
+
+<body>
+  <ion-app>
+
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Input - Tabindex</ion-title>
+        <ion-buttons slot="primary">
+          <ion-button>
+            <ion-icon slot="icon-only" name="menu"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content class="ion-padding">
+      <ion-input placeholder="Tab 2nd: Normal IonInput"></ion-input>
+      <ion-input tabindex="1" placeholder="Tab 1st: tabindex 1"></ion-input>
+      <div tabindex="0">Tab 3rd: tabindex 0 on div</div>
+      <ion-input tabindex="0" placeholder="Tab 4th: tabindex 0"></ion-input>
+      <ion-input tabindex="-1" placeholder="IGNORE: tabindex -1"></ion-input>
+      <ion-input placeholder="Tab 5th: Normal IonInput"></ion-input>
+    </ion-content>
+
+    <style>
+      ion-input,
+      div {
+        margin-bottom: 10px;
+      }
+
+      .md div {
+        padding-left: 8px;
+      }
+    </style>
+  </ion-app>
+</body>
+
+</html>

--- a/core/src/components/input/test/tabindex/index.html
+++ b/core/src/components/input/test/tabindex/index.html
@@ -26,12 +26,38 @@
     </ion-header>
 
     <ion-content class="ion-padding">
-      <ion-input placeholder="Tab 2nd: Normal IonInput"></ion-input>
-      <ion-input tabindex="1" placeholder="Tab 1st: tabindex 1"></ion-input>
-      <div tabindex="0">Tab 3rd: tabindex 0 on div</div>
-      <ion-input tabindex="0" placeholder="Tab 4th: tabindex 0"></ion-input>
-      <ion-input tabindex="-1" placeholder="IGNORE: tabindex -1"></ion-input>
-      <ion-input placeholder="Tab 5th: Normal IonInput"></ion-input>
+      <ion-input tabindex="0" placeholder="Tab 9th"></ion-input>
+      <ion-input placeholder="Tab 10th"></ion-input>
+
+      <hr>
+
+      <ion-input placeholder="Tab 8th" tabindex="8"></ion-input>
+      <ion-input placeholder="Skip" tabindex="-1"></ion-input>
+      <ion-input placeholder="Tab 7th" tabindex="7"></ion-input>
+      <div tabindex="0">Tab 11th</div>
+      <ion-input placeholder="Tab 6th" tabindex="6"></ion-input>
+      <ion-input placeholder="Tab 5th" tabindex="5"></ion-input>
+
+      <ion-item tabindex="4">
+        <ion-label position="stacked">Tab 4th</ion-label>
+        <ion-input></ion-input>
+      </ion-item>
+      <ion-item tabindex="3">
+        <ion-label position="stacked">Tab 3rd</ion-label>
+        <ion-input></ion-input>
+      </ion-item>
+      <ion-item tabindex="-1">
+        <ion-label position="stacked">Skip</ion-label>
+        <ion-input></ion-input>
+      </ion-item>
+      <ion-item tabindex="2">
+        <ion-label position="stacked">Tab 2nd</ion-label>
+        <ion-input></ion-input>
+      </ion-item>
+      <ion-item tabindex="1">
+        <ion-label position="stacked">Tab 1st</ion-label>
+        <ion-input></ion-input>
+      </ion-item>
     </ion-content>
 
     <style>

--- a/core/src/components/item/item.tsx
+++ b/core/src/components/item/item.tsx
@@ -20,7 +20,9 @@ import { createColorClasses, hostContext, openURL } from '../../utils/theme';
     ios: 'item.ios.scss',
     md: 'item.md.scss'
   },
-  shadow: true
+  shadow: {
+    delegatesFocus: true
+  }
 })
 export class Item implements ComponentInterface, AnchorInterface, ButtonInterface {
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fixes #17515

Dev build: `5.1.0-dev.202005041740.7d6b4b5`

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This is not the best code ever written, but it does work. I can't think of a way to ignore `tabindex` on the main host element without removing it after passing it down. Open for review.

- Check if input has a `tabindex` attribute, pass it down if so and then remove it
- Makes it so the `ion-input` is ignored from being tabbed to, but the native input can still be tabbed to
- Delegates focus on the item to the input, can set `tabindex` on `ion-item` and it will pass down to the input in Chrome and Safari ignoring the focus on the item, in Firefox it will tab to the item then the input

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

To test this PR, install based on the project type

```
# angular project
npm i @ionic/angular@5.1.0-dev.202005041740.7d6b4b5

# core / vanilla JS project
npm i @ionic/core@5.1.0-dev.202005041740.7d6b4b5

# react project
npm i @ionic/react@5.1.0-dev.202005041740.7d6b4b5
```