### PR TITLE
fix(all): improve scroll assist reliability for below the fold inputs

### DIFF
--- a/core/src/utils/input-shims/hacks/scroll-assist.ts
+++ b/core/src/utils/input-shims/hacks/scroll-assist.ts
@@ -119,7 +119,7 @@ const jsSetFocus = async (
       }
     }
 
-    scrollContent('automatic');
+    scrollContent();
   }
 };
 

--- a/core/src/utils/input-shims/hacks/scroll-assist.ts
+++ b/core/src/utils/input-shims/hacks/scroll-assist.ts
@@ -62,7 +62,6 @@ const jsSetFocus = async (
   // temporarily move the focus to the focus holder so the browser
   // doesn't freak out while it's trying to get the input in place
   // at this point the native text input still does not have focus
-  const inputLocation = inputEl.getBoundingClientRect();
   relocateInput(componentEl, inputEl, true, scrollData.inputSafeY);
   inputEl.focus();
 
@@ -90,23 +89,23 @@ const jsSetFocus = async (
       inputEl.focus();
     };
 
-    /**
-     * If an input is below the fold, Safari is not going
-     * to properly scroll to it until the webview is resized.
-     * As a result, we need to wait for the keyboard to be shown
-     * in order to properly scroll.
-     */
     if (contentEl) {
       const scrollEl = await contentEl.getScrollElement();
 
       /**
-       * An input is below the fold if it is not visible
-       * on a screen that has scrollTop = 0. Inputs
-       * that are partially visible are considered
-       * above the fold in this case.
+       * scrollData will only consider the amount we need
+       * to scroll in order to properly bring the input
+       * into view. It will not consider the amount
+       * we can scroll in the content element.
+       * As a result, scrollData may request a greater
+       * scroll position than is currently available
+       * in the DOM. If this is the case, we need to
+       * wait for the webview to resize/the keyboard
+       * to show in order for additional scroll
+       * bandwidth to become available.
        */
-      const offset = inputLocation.y + scrollEl.scrollTop;
-      if (offset > scrollEl.clientHeight) {
+      const totalScrollAmount = scrollEl.scrollHeight - scrollEl.clientHeight;
+      if (scrollData.scrollAmount > (totalScrollAmount - scrollEl.scrollTop)) {
         window.addEventListener('ionKeyboardDidShow', scrollContent);
 
         /**
@@ -120,7 +119,7 @@ const jsSetFocus = async (
       }
     }
 
-    scrollContent();
+    scrollContent('automatic');
   }
 };
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fixes https://github.com/ionic-team/ionic/issues/21196

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- For content that is below the fold, we need to wait for the webview to be resized/keyboard to be opened in order for scroll assist to work properly

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
