### PR TITLE
fix(toast, action-sheet): button handler can return `Promise<void>`

### DIFF
--- a/core/src/components/action-sheet/action-sheet-interface.ts
+++ b/core/src/components/action-sheet/action-sheet-interface.ts
@@ -21,5 +21,5 @@ export interface ActionSheetButton {
   role?: 'cancel' | 'destructive' | 'selected' | string;
   icon?: string;
   cssClass?: string | string[];
-  handler?: () => boolean | void | Promise<boolean>;
+  handler?: () => boolean | void | Promise<boolean | void>;
 }

--- a/core/src/components/toast/toast-interface.ts
+++ b/core/src/components/toast/toast-interface.ts
@@ -26,5 +26,5 @@ export interface ToastButton {
   side?: 'start' | 'end';
   role?: 'cancel' | string;
   cssClass?: string | string[];
-  handler?: () => boolean | void | Promise<boolean>;
+  handler?: () => boolean | void | Promise<boolean | void>;
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

A toast button can't take an async function that returns `Promise<void>` as its handler.

```
Type '() => Promise<void>' is not assignable to type '() => boolean | void | Promise<boolean>'.
  Type 'Promise<void>' is not assignable to type 'boolean | void | Promise<boolean>'.
    Type 'Promise<void>' is not assignable to type 'Promise<boolean>'.
      Type 'void' is not assignable to type 'boolean'. ts(2322)
```

Issue Number: N/A


## What is the new behavior?

- A toast button can take an async function that returns `Promise<void>` as its handler.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

~There might be other button interfaces with this issue...~

**Update:** fixed the same thing for the action sheet (after checking all similar interfaces).