### PR TITLE
fix(display): update breakpoint max to reduce by 0.02px

### DIFF
--- a/core/src/themes/ionic.mixins.scss
+++ b/core/src/themes/ionic.mixins.scss
@@ -123,13 +123,18 @@
 }
 
 // Maximum breakpoint width. Null for the smallest (first) breakpoint.
-// The maximum value is calculated as the minimum of the current one.
+// The maximum value is reduced by 0.02px to work around the limitations of
+// `min-` and `max-` prefixes and viewports with fractional widths.
 //
-//    >> breakpoint-max(sm, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px))
-//    576px
+// See https://www.w3.org/TR/mediaqueries-4/#mq-min-max
+// Uses 0.02px rather than 0.01px to work around a current rounding bug in Safari.	// Uses 0.02px rather than 0.01px to work around a current rounding bug in Safari.
+// See https://bugs.webkit.org/show_bug.cgi?id=178261	// See https://bugs.webkit.org/show_bug.cgi?id=178261
+//
+//    >> breakpoint-max(md, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px))
+//    767.98px
 @function breakpoint-max($name, $breakpoints: $screen-breakpoints) {
-  $min: breakpoint-min($name, $breakpoints);
-  @return if($min, breakpoint-min($name, $breakpoints), null);
+  $max: map-get($breakpoints, $name);
+  @return if($max and $max > 0, $max - .02, null);
 }
 
 // Media of at most the maximum breakpoint width. No query for the largest breakpoint.


### PR DESCRIPTION
Dev build: `5.2.0-dev.202005112151.7166a29`

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #20993 closes #20743 

Currently the `ion-hide-down` breakpoints look like:

```scss
@media (max-width: 576px) {
  .ion-hide-sm-down {
    display: none !important;
  }
}

@media (max-width: 768px) {
  .ion-hide-md-down {
    display: none !important;
  }
}

@media (max-width: 992px) {
  .ion-hide-lg-down {
    display: none !important;
  }
}

@media (max-width: 1200px) {
  .ion-hide-xl-down {
    display: none !important;
  }
}
```

This causes interference when both hide **up** and hide **down** media queries are used for the exact breakpoint.

1. Open the following Codepen: https://codepen.io/brandyscarney/pen/OJyEggx
2. Drag the width of the browser to any of the exact breakpoints
3. Observe that the buttons for that breakpoint both hide

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Update the media queries to reduce by `0.02px` to remove the 1px gap where neither apply:

```scss
@media (max-width: 575.98px) {
  .ion-hide-sm-down {
    display: none !important;
  }
}

@media (max-width: 767.98px) {
  .ion-hide-md-down {
    display: none !important;
  }
}

@media (max-width: 991.98px) {
  .ion-hide-lg-down {
    display: none !important;
  }
}

@media (max-width: 1199.98px) {
  .ion-hide-xl-down {
    display: none !important;
  }
}
```

Fixed Codepen: https://codepen.io/brandyscarney/pen/rNOKzbm

> Note this will not work if a new dev build gets released after this one, released on May 11

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
