### PR TITLE
fix(item): input-wrapper now inherits overflow

### DIFF
--- a/core/src/components/item/item.scss
+++ b/core/src/components/item/item.scss
@@ -328,7 +328,7 @@ button, a {
 
   text-overflow: ellipsis;
 
-  overflow: hidden;
+  overflow: inherit;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
Related to #17670 and pull request #18502

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, a relatively positioned div within an `ion-item` element cannot overflow any absolutely positioned content it contains.


## What is the new behavior?
 If the overflow property on the `.input-wrapper` is set to inherit, it is now possible to overflow as expected.

I realise that this is an addition to a previous pull request (#18502) but I could see no reason to not include the `.input-wrapper` in the inheritance.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
