### PR TITLE
fix(router): going back uses correct nav transition

### DIFF
--- a/core/src/components/router/router.tsx
+++ b/core/src/components/router/router.tsx
@@ -173,7 +173,7 @@ export class Router implements ComponentInterface {
     const lastState = this.lastState;
     this.lastState = state;
 
-    if (state > lastState) {
+    if (state > lastState || (state >= lastState && lastState > 0)) {
       return ROUTER_INTENT_FORWARD;
     } else if (state < lastState) {
       return ROUTER_INTENT_BACK;


### PR DESCRIPTION
Fixes #21300 

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
When navigating from the root route to a sibling and back the animation is "forward" is correctly applied. If you go to a sibling a second time the back animation is lost.

Issue Number: 21300


## What is the new behavior?
The animation is applied also the second time the user navigates back to the root.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
