### PR TITLE
fix(textarea): native textarea inherits max-width and max-height

### DIFF
--- a/core/src/components/textarea/textarea.scss
+++ b/core/src/components/textarea/textarea.scss
@@ -40,9 +40,6 @@
 
   width: 100%;
 
-  max-width: 100%;
-  max-height: 100%;
-
   background: var(--background);
   color: var(--color);
 

--- a/core/src/components/textarea/textarea.scss
+++ b/core/src/components/textarea/textarea.scss
@@ -48,6 +48,7 @@
   white-space: pre-wrap;
 
   z-index: $z-index-item-input;
+
   box-sizing: border-box;
 }
 

--- a/core/src/components/textarea/textarea.scss
+++ b/core/src/components/textarea/textarea.scss
@@ -75,11 +75,11 @@
 // --------------------------------------------------
 
 .textarea-wrapper {
-  max-width: inherit;
-  max-height: inherit;
 
   min-width: inherit;
+  max-width: inherit;
   min-height: inherit;
+  max-height: inherit;
 }
 
 .native-textarea {

--- a/core/src/components/textarea/textarea.scss
+++ b/core/src/components/textarea/textarea.scss
@@ -75,7 +75,6 @@
 // --------------------------------------------------
 
 .textarea-wrapper {
-
   min-width: inherit;
   max-width: inherit;
   min-height: inherit;

--- a/core/src/components/textarea/textarea.scss
+++ b/core/src/components/textarea/textarea.scss
@@ -77,6 +77,9 @@
 .textarea-wrapper {
   max-width: inherit;
   max-height: inherit;
+
+  min-width: inherit;
+  min-height: inherit;
 }
 
 .native-textarea {

--- a/core/src/components/textarea/textarea.scss
+++ b/core/src/components/textarea/textarea.scss
@@ -39,7 +39,9 @@
   flex: 1;
 
   width: 100%;
-  box-sizing: border-box;
+
+  max-width: 100%;
+  max-height: 100%;
 
   background: var(--background);
   color: var(--color);
@@ -49,6 +51,7 @@
   white-space: pre-wrap;
 
   z-index: $z-index-item-input;
+  box-sizing: border-box;
 }
 
 :host(.ion-color) {
@@ -74,6 +77,12 @@
 // Native Textarea
 // --------------------------------------------------
 
+.textarea-wrapper {
+  max-width: inherit;
+  max-height: inherit;
+}
+
+
 .native-textarea {
   @include border-radius(var(--border-radius));
   @include margin(0);
@@ -83,8 +92,8 @@
   display: block;
 
   width: 100%;
-  max-width: 100%;
-  max-height: 100%;
+  max-width: inherit;
+  max-height: inherit;
 
   border: 0;
 

--- a/core/src/components/textarea/textarea.scss
+++ b/core/src/components/textarea/textarea.scss
@@ -82,7 +82,6 @@
   max-height: inherit;
 }
 
-
 .native-textarea {
   @include border-radius(var(--border-radius));
   @include margin(0);
@@ -92,8 +91,8 @@
   display: block;
 
   width: 100%;
-  max-width: inherit;
-  max-height: inherit;
+  max-width: 100%;
+  max-height: 100%;
 
   border: 0;
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fixes https://github.com/ionic-team/ionic/issues/18543


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Uses inheritance for allow for max-width/max-height instead of exposing a CSS variable
- alternative to https://github.com/ionic-team/ionic/pull/19617

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
