### PR TITLE
fix(tabs): fix typing of IonTabs refs

### DIFF
--- a/packages/react/src/components/__tests__/IonTabs.spec.tsx
+++ b/packages/react/src/components/__tests__/IonTabs.spec.tsx
@@ -3,6 +3,9 @@ import { IonTabs, IonTabButton, IonLabel, IonIcon, IonTabBar} from '../index';
 import { render, cleanup } from 'react-testing-library';
 import { IonRouterOutlet } from '../IonRouterOutlet';
 
+// @ts-ignore
+import HTMLIonTabsElement from '@ionic/core/src/components';
+
 afterEach(cleanup)
 
 describe('IonTabs', () => {
@@ -32,8 +35,8 @@ describe('IonTabs', () => {
     );
 
     expect(container.children[0].children.length).toEqual(2);
-    expect(container.children[0].children[0].tagName).toEqual('DIV');
-    expect(container.children[0].children[0].className).toEqual('tabs-inner');
+    expect(container.children[0].children[0].tagName).toEqual('ION-ROUTER-OUTLET');
+    expect(container.children[0].children[0].className).toEqual('');
 
     expect(container.children[0].children[1].tagName).toEqual('ION-TAB-BAR');
     expect(container.children[0].children[1].children.length).toEqual(4);
@@ -68,11 +71,18 @@ describe('IonTabs', () => {
     );
 
     expect(container.children[0].children.length).toEqual(2);
-    expect(container.children[0].children[0].tagName).toEqual('DIV');
-    expect(container.children[0].children[0].className).toEqual('tabs-inner');
+    expect(container.children[0].children[0].tagName).toEqual('ION-ROUTER-OUTLET');
+    expect(container.children[0].children[0].className).toEqual('');
 
     expect(container.children[0].children[1].tagName).toEqual('ION-TAB-BAR');
     expect(container.children[0].children[1].children.length).toEqual(3);
     expect(Array.from(container.children[0].children[1].children).map(c => c.tagName)).toEqual(['ION-TAB-BUTTON', 'ION-TAB-BUTTON', 'ION-TAB-BUTTON']);
   });
+
+  test('should compile with HTMLIonTabsElement refs', () => {
+    const tabsRef = React.createRef<HTMLIonTabsElement>();
+    render(
+      <IonTabs ref={tabsRef}/>
+    )
+  })
 });

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -19,7 +19,6 @@ export { IonPopover } from './IonPopover';
 // Custom Components
 export { IonPage } from './IonPage';
 export { IonTabsContext, IonTabsContextState } from './navigation/IonTabsContext';
-export { IonTabs } from './navigation/IonTabs';
 export { IonTabBar } from './navigation/IonTabBar';
 export { IonBackButton } from './navigation/IonBackButton';
 export { IonRouterOutlet } from './IonRouterOutlet';

--- a/packages/react/src/components/proxies.ts
+++ b/packages/react/src/components/proxies.ts
@@ -6,6 +6,7 @@ import { HrefProps } from './hrefprops';
 // ionic/core
 export const IonApp = /*@__PURE__*/createReactComponent<JSX.IonApp, HTMLIonAppElement>('ion-app');
 export const IonTab = /*@__PURE__*/createReactComponent<JSX.IonTab, HTMLIonTabElement>('ion-tab');
+export const IonTabs = /*@__PURE__*/createReactComponent<JSX.IonTabs, HTMLIonTabsElement>('ion-tabs');
 export const IonTabButton = /*@__PURE__*/createReactComponent<JSX.IonTabButton, HTMLIonTabButtonElement>('ion-tab-button');
 export const IonRouterLink = /*@__PURE__*/createReactComponent<HrefProps<JSX.IonRouterLink>, HTMLIonRouterLinkElement>('ion-router-link', true);
 export const IonAvatar = /*@__PURE__*/createReactComponent<JSX.IonAvatar, HTMLIonAvatarElement>('ion-avatar');


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Current behavior: IonTabs in the React package doesn't accept HTMLIonTabsElement in refs.

Issue Number: #20669 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- IonTabs in the React package accept HTMLIonTabsElement in refs.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
