### PR TITLE
fix(angular): Synchronize css classes on form control validity status change and dirty/touched state change

### DIFF
--- a/angular/src/directives/control-value-accessors/boolean-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/boolean-value-accessor.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, HostListener } from '@angular/core';
+import { Directive, ElementRef, HostListener, Injector } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { ValueAccessor, setIonicClasses } from './value-accessor';
@@ -16,8 +16,8 @@ import { ValueAccessor, setIonicClasses } from './value-accessor';
 })
 export class BooleanValueAccessor extends ValueAccessor {
 
-  constructor(el: ElementRef) {
-    super(el);
+  constructor(injector: Injector, el: ElementRef) {
+    super(injector, el);
   }
 
   writeValue(value: any) {

--- a/angular/src/directives/control-value-accessors/boolean-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/boolean-value-accessor.ts
@@ -12,7 +12,10 @@ import { ValueAccessor, setIonicClasses } from './value-accessor';
       useExisting: BooleanValueAccessor,
       multi: true
     }
-  ]
+  ],
+  host: {
+    "[attr.ion-ng-state-sync]": "_syncControlState(_ngControl?.dirty, _ngControl?.touched)"
+  }
 })
 export class BooleanValueAccessor extends ValueAccessor {
 

--- a/angular/src/directives/control-value-accessors/boolean-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/boolean-value-accessor.ts
@@ -14,7 +14,7 @@ import { ValueAccessor, setIonicClasses } from './value-accessor';
     }
   ],
   host: {
-    '[attr.ion-ng-state-sync]': '_syncControlState(_ngControl?.dirty, _ngControl?.touched)'
+    '[attr.ion-ng-state-sync]': '((_ngControl?.dirty !== _controlState.dirty || _ngControl?.touched !== _controlState.touched) && _syncControlState()) || null'
   }
 })
 export class BooleanValueAccessor extends ValueAccessor {

--- a/angular/src/directives/control-value-accessors/boolean-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/boolean-value-accessor.ts
@@ -14,7 +14,7 @@ import { ValueAccessor, setIonicClasses } from './value-accessor';
     }
   ],
   host: {
-    "[attr.ion-ng-state-sync]": "_syncControlState(_ngControl?.dirty, _ngControl?.touched)"
+    '[attr.ion-ng-state-sync]': '_syncControlState(_ngControl?.dirty, _ngControl?.touched)'
   }
 })
 export class BooleanValueAccessor extends ValueAccessor {

--- a/angular/src/directives/control-value-accessors/numeric-value-accesssor.ts
+++ b/angular/src/directives/control-value-accessors/numeric-value-accesssor.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, HostListener } from '@angular/core';
+import { Directive, ElementRef, HostListener, Injector } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { ValueAccessor } from './value-accessor';
@@ -16,8 +16,8 @@ import { ValueAccessor } from './value-accessor';
 })
 export class NumericValueAccessor extends ValueAccessor {
 
-  constructor(el: ElementRef) {
-    super(el);
+  constructor(injector: Injector, el: ElementRef) {
+    super(injector, el);
   }
 
   @HostListener('ionChange', ['$event.target'])

--- a/angular/src/directives/control-value-accessors/numeric-value-accesssor.ts
+++ b/angular/src/directives/control-value-accessors/numeric-value-accesssor.ts
@@ -12,7 +12,10 @@ import { ValueAccessor } from './value-accessor';
       useExisting: NumericValueAccessor,
       multi: true
     }
-  ]
+  ],
+  host: {
+    "[attr.ion-ng-state-sync]": "_syncControlState(_ngControl?.dirty, _ngControl?.touched)"
+  }
 })
 export class NumericValueAccessor extends ValueAccessor {
 

--- a/angular/src/directives/control-value-accessors/numeric-value-accesssor.ts
+++ b/angular/src/directives/control-value-accessors/numeric-value-accesssor.ts
@@ -14,7 +14,7 @@ import { ValueAccessor } from './value-accessor';
     }
   ],
   host: {
-    "[attr.ion-ng-state-sync]": "_syncControlState(_ngControl?.dirty, _ngControl?.touched)"
+    '[attr.ion-ng-state-sync]': '_syncControlState(_ngControl?.dirty, _ngControl?.touched)'
   }
 })
 export class NumericValueAccessor extends ValueAccessor {

--- a/angular/src/directives/control-value-accessors/numeric-value-accesssor.ts
+++ b/angular/src/directives/control-value-accessors/numeric-value-accesssor.ts
@@ -14,7 +14,7 @@ import { ValueAccessor } from './value-accessor';
     }
   ],
   host: {
-    '[attr.ion-ng-state-sync]': '_syncControlState(_ngControl?.dirty, _ngControl?.touched)'
+    '[attr.ion-ng-state-sync]': '((_ngControl?.dirty !== _controlState.dirty || _ngControl?.touched !== _controlState.touched) && _syncControlState()) || null'
   }
 })
 export class NumericValueAccessor extends ValueAccessor {

--- a/angular/src/directives/control-value-accessors/radio-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/radio-value-accessor.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, HostListener } from '@angular/core';
+import { Directive, ElementRef, HostListener, Injector } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { ValueAccessor } from './value-accessor';
@@ -16,8 +16,8 @@ import { ValueAccessor } from './value-accessor';
 })
 export class RadioValueAccessor extends ValueAccessor {
 
-  constructor(el: ElementRef) {
-    super(el);
+  constructor(injector: Injector, el: ElementRef) {
+    super(injector, el);
   }
 
   @HostListener('ionSelect', ['$event.target'])

--- a/angular/src/directives/control-value-accessors/radio-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/radio-value-accessor.ts
@@ -14,7 +14,7 @@ import { ValueAccessor } from './value-accessor';
     }
   ],
   host: {
-    "[attr.ion-ng-state-sync]": "_syncControlState(_ngControl?.dirty, _ngControl?.touched)"
+    '[attr.ion-ng-state-sync]': '_syncControlState(_ngControl?.dirty, _ngControl?.touched)'
   }
 })
 export class RadioValueAccessor extends ValueAccessor {

--- a/angular/src/directives/control-value-accessors/radio-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/radio-value-accessor.ts
@@ -12,7 +12,10 @@ import { ValueAccessor } from './value-accessor';
       useExisting: RadioValueAccessor,
       multi: true
     }
-  ]
+  ],
+  host: {
+    "[attr.ion-ng-state-sync]": "_syncControlState(_ngControl?.dirty, _ngControl?.touched)"
+  }
 })
 export class RadioValueAccessor extends ValueAccessor {
 

--- a/angular/src/directives/control-value-accessors/radio-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/radio-value-accessor.ts
@@ -14,7 +14,7 @@ import { ValueAccessor } from './value-accessor';
     }
   ],
   host: {
-    '[attr.ion-ng-state-sync]': '_syncControlState(_ngControl?.dirty, _ngControl?.touched)'
+    '[attr.ion-ng-state-sync]': '((_ngControl?.dirty !== _controlState.dirty || _ngControl?.touched !== _controlState.touched) && _syncControlState()) || null'
   }
 })
 export class RadioValueAccessor extends ValueAccessor {

--- a/angular/src/directives/control-value-accessors/select-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/select-value-accessor.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, HostListener } from '@angular/core';
+import { Directive, ElementRef, HostListener, Injector } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { ValueAccessor } from './value-accessor';
@@ -16,8 +16,8 @@ import { ValueAccessor } from './value-accessor';
 })
 export class SelectValueAccessor extends ValueAccessor {
 
-  constructor(el: ElementRef) {
-    super(el);
+  constructor(injector: Injector, el: ElementRef) {
+    super(injector, el);
   }
 
   @HostListener('ionChange', ['$event.target'])

--- a/angular/src/directives/control-value-accessors/select-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/select-value-accessor.ts
@@ -14,7 +14,7 @@ import { ValueAccessor } from './value-accessor';
     }
   ],
   host: {
-    '[attr.ion-ng-state-sync]': '_syncControlState(_ngControl?.dirty, _ngControl?.touched)'
+    '[attr.ion-ng-state-sync]': '((_ngControl?.dirty !== _controlState.dirty || _ngControl?.touched !== _controlState.touched) && _syncControlState()) || null'
   }
 })
 export class SelectValueAccessor extends ValueAccessor {

--- a/angular/src/directives/control-value-accessors/select-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/select-value-accessor.ts
@@ -14,7 +14,7 @@ import { ValueAccessor } from './value-accessor';
     }
   ],
   host: {
-    "[attr.ion-ng-state-sync]": "_syncControlState(_ngControl?.dirty, _ngControl?.touched)"
+    '[attr.ion-ng-state-sync]': '_syncControlState(_ngControl?.dirty, _ngControl?.touched)'
   }
 })
 export class SelectValueAccessor extends ValueAccessor {

--- a/angular/src/directives/control-value-accessors/select-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/select-value-accessor.ts
@@ -12,7 +12,10 @@ import { ValueAccessor } from './value-accessor';
       useExisting: SelectValueAccessor,
       multi: true
     }
-  ]
+  ],
+  host: {
+    "[attr.ion-ng-state-sync]": "_syncControlState(_ngControl?.dirty, _ngControl?.touched)"
+  }
 })
 export class SelectValueAccessor extends ValueAccessor {
 

--- a/angular/src/directives/control-value-accessors/text-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/text-value-accessor.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, HostListener } from '@angular/core';
+import { Directive, ElementRef, HostListener, Injector } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { ValueAccessor } from './value-accessor';
@@ -16,8 +16,8 @@ import { ValueAccessor } from './value-accessor';
 })
 export class TextValueAccessor extends ValueAccessor {
 
-  constructor(el: ElementRef) {
-    super(el);
+  constructor(injector: Injector, el: ElementRef) {
+    super(injector, el);
   }
 
   @HostListener('ionChange', ['$event.target'])

--- a/angular/src/directives/control-value-accessors/text-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/text-value-accessor.ts
@@ -14,7 +14,7 @@ import { ValueAccessor } from './value-accessor';
     }
   ],
   host: {
-    '[attr.ion-ng-state-sync]': '_syncControlState(_ngControl?.dirty, _ngControl?.touched)'
+    '[attr.ion-ng-state-sync]': '((_ngControl?.dirty !== _controlState.dirty || _ngControl?.touched !== _controlState.touched) && _syncControlState()) || null'
   }
 })
 export class TextValueAccessor extends ValueAccessor {

--- a/angular/src/directives/control-value-accessors/text-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/text-value-accessor.ts
@@ -14,7 +14,7 @@ import { ValueAccessor } from './value-accessor';
     }
   ],
   host: {
-    "[attr.ion-ng-state-sync]": "_syncControlState(_ngControl?.dirty, _ngControl?.touched)"
+    '[attr.ion-ng-state-sync]': '_syncControlState(_ngControl?.dirty, _ngControl?.touched)'
   }
 })
 export class TextValueAccessor extends ValueAccessor {

--- a/angular/src/directives/control-value-accessors/text-value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/text-value-accessor.ts
@@ -12,7 +12,10 @@ import { ValueAccessor } from './value-accessor';
       useExisting: TextValueAccessor,
       multi: true
     }
-  ]
+  ],
+  host: {
+    "[attr.ion-ng-state-sync]": "_syncControlState(_ngControl?.dirty, _ngControl?.touched)"
+  }
 })
 export class TextValueAccessor extends ValueAccessor {
 

--- a/angular/src/directives/control-value-accessors/value-accessor.ts
+++ b/angular/src/directives/control-value-accessors/value-accessor.ts
@@ -10,11 +10,11 @@ export class ValueAccessor implements ControlValueAccessor, AfterViewInit, OnDes
   private onTouched: () => void = () => {/**/};
   protected lastValue: any;
   private statusChangeSubscription: Subscription;
-  private controlState: {dirty?: boolean, touched?: boolean} = {};
 
   constructor(protected injector: Injector, protected el: ElementRef) {}
 
   _ngControl: NgControl | undefined;
+  _controlState: {dirty?: boolean | null, touched?: boolean | null} = { dirty: null, touched: null };
 
   writeValue(value: any) {
     /**
@@ -46,11 +46,11 @@ export class ValueAccessor implements ControlValueAccessor, AfterViewInit, OnDes
     }
   }
 
-  _syncControlState(dirty: boolean, touched: boolean): null {
+  _syncControlState(): null {
 
-    if (this.controlState.dirty !== dirty || this.controlState.touched !== touched) {
-      this.controlState.dirty = dirty;
-      this.controlState.touched = touched;
+    if (this._ngControl && (this._controlState.dirty !== this._ngControl.dirty || this._controlState.touched !== this._ngControl.touched)) {
+      this._controlState.dirty = this._ngControl.dirty;
+      this._controlState.touched = this._ngControl.touched;
       setIonicClasses(this.el);
     }
 
@@ -70,7 +70,7 @@ export class ValueAccessor implements ControlValueAccessor, AfterViewInit, OnDes
   }
 
   ngAfterViewInit() {
-    this._ngControl = this.injector.get(NgControl, null);
+    this._ngControl = this.injector.get(NgControl, null); // tslint:disable-line deprecation
     if (this._ngControl && this._ngControl.statusChanges) {
       this.statusChangeSubscription = this._ngControl.statusChanges.subscribe(() => setIonicClasses(this.el));
     }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Lint (`npm run lint`) has passed locally and any fixes were made for failures
Lint reports Injector.get deprecation, but it is perfectly valid when type is provided as first argument. 


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When form control status change (e.g. from valid to invalid) Ionic validation css classes (e.g. ion-valid) do not change, which leads to invalid styling of the component.

Issue Number: fixes #17414, fixes #18426, fixes #20650


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- When control status changed (e.g. from valid to invalid) Ionic css classes matches angular form status.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
