### PR TITLE
feat(all): add native part to missing components

### DIFF
--- a/angular/src/directives/proxies.ts
+++ b/angular/src/directives/proxies.ts
@@ -462,8 +462,8 @@ export class IonMenu {
 }
 export declare interface IonMenuButton extends Components.IonMenuButton {
 }
-@ProxyCmp({ inputs: ["autoHide", "color", "disabled", "menu", "type"] })
-@Component({ selector: "ion-menu-button", changeDetection: ChangeDetectionStrategy.OnPush, template: "<ng-content></ng-content>", inputs: ["autoHide", "color", "disabled", "menu", "type"] })
+@ProxyCmp({ inputs: ["autoHide", "color", "disabled", "menu", "mode", "type"] })
+@Component({ selector: "ion-menu-button", changeDetection: ChangeDetectionStrategy.OnPush, template: "<ng-content></ng-content>", inputs: ["autoHide", "color", "disabled", "menu", "mode", "type"] })
 export class IonMenuButton {
     protected el: HTMLElement;
     constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {

--- a/core/api.txt
+++ b/core/api.txt
@@ -119,6 +119,7 @@ ion-back-button,css-prop,--padding-start
 ion-back-button,css-prop,--padding-top
 ion-back-button,css-prop,--ripple-color
 ion-back-button,css-prop,--transition
+ion-back-button,part,native
 
 ion-backdrop,shadow
 ion-backdrop,prop,stopPropagation,boolean,true,false,false
@@ -177,6 +178,7 @@ ion-button,css-prop,--padding-start
 ion-button,css-prop,--padding-top
 ion-button,css-prop,--ripple-color
 ion-button,css-prop,--transition
+ion-button,part,native
 
 ion-buttons,scoped
 ion-buttons,prop,collapse,boolean,false,false,false
@@ -387,6 +389,7 @@ ion-fab-button,css-prop,--padding-start
 ion-fab-button,css-prop,--padding-top
 ion-fab-button,css-prop,--ripple-color
 ion-fab-button,css-prop,--transition
+ion-fab-button,part,native
 
 ion-fab-list,shadow
 ion-fab-list,prop,activated,boolean,false,false,false
@@ -561,6 +564,7 @@ ion-item-option,prop,target,string | undefined,undefined,false,false
 ion-item-option,prop,type,"button" | "reset" | "submit",'button',false,false
 ion-item-option,css-prop,--background
 ion-item-option,css-prop,--color
+ion-item-option,part,native
 
 ion-item-options,none
 ion-item-options,prop,side,"end" | "start",'end',false,false
@@ -662,6 +666,7 @@ ion-menu-button,prop,autoHide,boolean,true,false,false
 ion-menu-button,prop,color,string | undefined,undefined,false,false
 ion-menu-button,prop,disabled,boolean,false,false,false
 ion-menu-button,prop,menu,string | undefined,undefined,false,false
+ion-menu-button,prop,mode,"ios" | "md",undefined,false,false
 ion-menu-button,prop,type,"button" | "reset" | "submit",'button',false,false
 ion-menu-button,css-prop,--background
 ion-menu-button,css-prop,--background-focused
@@ -676,6 +681,7 @@ ion-menu-button,css-prop,--padding-bottom
 ion-menu-button,css-prop,--padding-end
 ion-menu-button,css-prop,--padding-start
 ion-menu-button,css-prop,--padding-top
+ion-menu-button,part,native
 
 ion-menu-toggle,shadow
 ion-menu-toggle,prop,autoHide,boolean,true,false,false
@@ -1029,6 +1035,7 @@ ion-segment-button,css-prop,--padding-end
 ion-segment-button,css-prop,--padding-start
 ion-segment-button,css-prop,--padding-top
 ion-segment-button,css-prop,--transition
+ion-segment-button,part,native
 
 ion-select,shadow
 ion-select,prop,cancelText,string,'Cancel',false,false
@@ -1166,6 +1173,7 @@ ion-tab-button,css-prop,--padding-end
 ion-tab-button,css-prop,--padding-start
 ion-tab-button,css-prop,--padding-top
 ion-tab-button,css-prop,--ripple-color
+ion-tab-button,part,native
 
 ion-tabs,shadow
 ion-tabs,method,getSelected,getSelected() => Promise<string | undefined>

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -1254,6 +1254,10 @@ export namespace Components {
          */
         "menu"?: string;
         /**
+          * The mode determines which platform styles to use.
+         */
+        "mode"?: "ios" | "md";
+        /**
           * The type of the button.
          */
         "type": "submit" | "reset" | "button";
@@ -4500,6 +4504,10 @@ declare namespace LocalJSX {
           * Optional property that maps to a Menu's `menuId` prop. Can also be `start` or `end` for the menu side. This is used to find the correct menu to toggle
          */
         "menu"?: string;
+        /**
+          * The mode determines which platform styles to use.
+         */
+        "mode"?: "ios" | "md";
         /**
           * The type of the button.
          */

--- a/core/src/components/back-button/back-button.tsx
+++ b/core/src/components/back-button/back-button.tsx
@@ -8,6 +8,8 @@ import { createColorClasses, hostContext, openURL } from '../../utils/theme';
 
 /**
  * @virtualProp {"ios" | "md"} mode - The mode determines which platform styles to use.
+ *
+ * @part native - The native HTML button element that is rendered around the content.
  */
 @Component({
   tag: 'ion-back-button',
@@ -126,7 +128,13 @@ export class BackButton implements ComponentInterface, ButtonInterface {
           'show-back-button': showBackButton
         }}
       >
-        <button type={type} disabled={disabled} class="button-native" aria-label={backButtonText || 'back'}>
+        <button
+          type={type}
+          disabled={disabled}
+          class="button-native"
+          part="native"
+          aria-label={backButtonText || 'back'}
+        >
           <span class="button-inner">
             {backButtonIcon && <ion-icon icon={backButtonIcon} aria-hidden="true" lazy={false}></ion-icon>}
             {backButtonText && <span aria-hidden="true" class="button-text">{backButtonText}</span>}

--- a/core/src/components/back-button/readme.md
+++ b/core/src/components/back-button/readme.md
@@ -312,6 +312,13 @@ export class BackButtonExample {
 | `type`        | `type`         | The type of the button.                                                                                                                                                                                                                                                | `"button" \| "reset" \| "submit"` | `'button'`  |
 
 
+## Shadow Parts
+
+| Part       | Description                                                         |
+| ---------- | ------------------------------------------------------------------- |
+| `"native"` | The native HTML button element that is rendered around the content. |
+
+
 ## CSS Custom Properties
 
 | Name                           | Description                                                                                                    |

--- a/core/src/components/button/button.tsx
+++ b/core/src/components/button/button.tsx
@@ -13,6 +13,8 @@ import { createColorClasses, hostContext, openURL } from '../../utils/theme';
  * @slot icon-only - Should be used on an icon in a button that has no text.
  * @slot start - Content is placed to the left of the button text in LTR, and to the right in RTL.
  * @slot end - Content is placed to the right of the button text in LTR, and to the left in RTL.
+ *
+ * @part native - The native HTML button element that is rendered around the content.
  */
 @Component({
   tag: 'ion-button',
@@ -216,6 +218,7 @@ export class Button implements ComponentInterface, AnchorInterface, ButtonInterf
         <TagType
           {...attrs}
           class="button-native"
+          part="native"
           disabled={disabled}
           onFocus={this.onFocus}
           onBlur={this.onBlur}

--- a/core/src/components/button/readme.md
+++ b/core/src/components/button/readme.md
@@ -317,6 +317,13 @@ export class ButtonExample {
 | `"start"`     | Content is placed to the left of the button text in LTR, and to the right in RTL. |
 
 
+## Shadow Parts
+
+| Part       | Description                                                         |
+| ---------- | ------------------------------------------------------------------- |
+| `"native"` | The native HTML button element that is rendered around the content. |
+
+
 ## CSS Custom Properties
 
 | Name                             | Description                                                                                               |

--- a/core/src/components/fab-button/fab-button.tsx
+++ b/core/src/components/fab-button/fab-button.tsx
@@ -7,6 +7,8 @@ import { createColorClasses, hostContext, openURL } from '../../utils/theme';
 
 /**
  * @virtualProp {"ios" | "md"} mode - The mode determines which platform styles to use.
+ *
+ * @part native - The native HTML button element that is rendered around the content.
  */
 @Component({
   tag: 'ion-fab-button',
@@ -144,6 +146,7 @@ export class FabButton implements ComponentInterface, AnchorInterface, ButtonInt
         <TagType
           {...attrs}
           class="button-native"
+          part="native"
           disabled={disabled}
           onFocus={this.onFocus}
           onBlur={this.onBlur}

--- a/core/src/components/fab-button/readme.md
+++ b/core/src/components/fab-button/readme.md
@@ -162,6 +162,13 @@ export class FabButtonExample {
 | `ionFocus` | Emitted when the button has focus.   | `CustomEvent<void>` |
 
 
+## Shadow Parts
+
+| Part       | Description                                                         |
+| ---------- | ------------------------------------------------------------------- |
+| `"native"` | The native HTML button element that is rendered around the content. |
+
+
 ## CSS Custom Properties
 
 | Name                             | Description                                                                                               |

--- a/core/src/components/item-option/item-option.tsx
+++ b/core/src/components/item-option/item-option.tsx
@@ -14,6 +14,8 @@ import { createColorClasses } from '../../utils/theme';
  * @slot icon-only - Should be used on an icon in an option that has no text.
  * @slot bottom - Content is placed below the option text.
  * @slot end - Content is placed to the right of the option text in LTR, and to the left in RTL.
+ *
+ * @part native - The native HTML button element that is rendered around the content.
  */
 @Component({
   tag: 'ion-item-option',
@@ -110,6 +112,7 @@ export class ItemOption implements ComponentInterface, AnchorInterface, ButtonIn
         <TagType
           {...attrs}
           class="button-native"
+          part="native"
           disabled={disabled}
         >
           <span class="button-inner">

--- a/core/src/components/item-option/readme.md
+++ b/core/src/components/item-option/readme.md
@@ -34,6 +34,13 @@ action for the item.
 | `"top"`       | Content is placed above the option text.                                          |
 
 
+## Shadow Parts
+
+| Part       | Description                                                         |
+| ---------- | ------------------------------------------------------------------- |
+| `"native"` | The native HTML button element that is rendered around the content. |
+
+
 ## CSS Custom Properties
 
 | Name           | Description                   |

--- a/core/src/components/menu-button/menu-button.tsx
+++ b/core/src/components/menu-button/menu-button.tsx
@@ -8,6 +8,11 @@ import { menuController } from '../../utils/menu-controller';
 import { createColorClasses, hostContext } from '../../utils/theme';
 import { updateVisibility } from '../menu-toggle/menu-toggle-util';
 
+/**
+ * @virtualProp {"ios" | "md"} mode - The mode determines which platform styles to use.
+ *
+ * @part native - The native HTML button element that is rendered around the content.
+ */
 @Component({
   tag: 'ion-menu-button',
   styleUrls: {
@@ -95,6 +100,7 @@ export class MenuButton implements ComponentInterface, ButtonInterface {
           {...attrs}
           disabled={disabled}
           class="button-native"
+          part="native"
           aria-label="menu"
         >
           <span class="button-inner">

--- a/core/src/components/menu-button/readme.md
+++ b/core/src/components/menu-button/readme.md
@@ -14,7 +14,15 @@ Menu Button is component that automatically creates the icon and functionality t
 | `color`    | `color`     | The color to use from your application's color palette. Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`. For more information on colors, see [theming](/docs/theming/basics). | `string \| undefined`             | `undefined` |
 | `disabled` | `disabled`  | If `true`, the user cannot interact with the menu button.                                                                                                                                                                                                              | `boolean`                         | `false`     |
 | `menu`     | `menu`      | Optional property that maps to a Menu's `menuId` prop. Can also be `start` or `end` for the menu side. This is used to find the correct menu to toggle                                                                                                                 | `string \| undefined`             | `undefined` |
+| `mode`     | `mode`      | The mode determines which platform styles to use.                                                                                                                                                                                                                      | `"ios" \| "md"`                   | `undefined` |
 | `type`     | `type`      | The type of the button.                                                                                                                                                                                                                                                | `"button" \| "reset" \| "submit"` | `'button'`  |
+
+
+## Shadow Parts
+
+| Part       | Description                                                         |
+| ---------- | ------------------------------------------------------------------- |
+| `"native"` | The native HTML button element that is rendered around the content. |
 
 
 ## CSS Custom Properties

--- a/core/src/components/segment-button/readme.md
+++ b/core/src/components/segment-button/readme.md
@@ -794,6 +794,13 @@ export class SegmentButtonExample {
 | `value`    | `value`    | The value of the segment button.                             | `string`                                                                                                | `'ion-sb-' + (ids++)` |
 
 
+## Shadow Parts
+
+| Part       | Description                                                         |
+| ---------- | ------------------------------------------------------------------- |
+| `"native"` | The native HTML button element that is rendered around the content. |
+
+
 ## CSS Custom Properties
 
 | Name                           | Description                                                                                                       |

--- a/core/src/components/segment-button/segment-button.tsx
+++ b/core/src/components/segment-button/segment-button.tsx
@@ -9,6 +9,8 @@ let ids = 0;
 
 /**
  * @virtualProp {"ios" | "md"} mode - The mode determines which platform styles to use.
+ *
+ * @part native - The native HTML button element that is rendered around the content.
  */
 @Component({
   tag: 'ion-segment-button',
@@ -103,6 +105,7 @@ export class SegmentButton implements ComponentInterface, ButtonInterface {
           type={type}
           aria-pressed={checked ? 'true' : 'false'}
           class="button-native"
+          part="native"
           disabled={disabled}
         >
           <span class="button-inner">

--- a/core/src/components/tab-button/readme.md
+++ b/core/src/components/tab-button/readme.md
@@ -232,6 +232,13 @@ export class TabButtonExample {
 | `target`   | `target`   | Specifies where to display the linked URL. Only applies when an `href` is provided. Special keywords: `"_blank"`, `"_self"`, `"_parent"`, `"_top"`.                                                                                                                                       | `string \| undefined`                                                                                   | `undefined` |
 
 
+## Shadow Parts
+
+| Part       | Description                                                         |
+| ---------- | ------------------------------------------------------------------- |
+| `"native"` | The native HTML button element that is rendered around the content. |
+
+
 ## CSS Custom Properties
 
 | Name                           | Description                                                                                                   |

--- a/core/src/components/tab-button/tab-button.tsx
+++ b/core/src/components/tab-button/tab-button.tsx
@@ -7,6 +7,8 @@ import { AnchorInterface } from '../../utils/element-interface';
 
 /**
  * @virtualProp {"ios" | "md"} mode - The mode determines which platform styles to use.
+ *
+ * @part native - The native HTML button element that is rendered around the content.
  */
 @Component({
   tag: 'ion-tab-button',
@@ -161,7 +163,7 @@ export class TabButton implements ComponentInterface, AnchorInterface {
           'ion-focusable': true
         }}
       >
-        <a {...attrs} tabIndex={-1} class="button-native">
+        <a {...attrs} tabIndex={-1} class="button-native" part="native">
           <span class="button-inner">
             <slot></slot>
           </span>


### PR DESCRIPTION
# Proposal For Additional Parts

- [Missing Parts Overview](#missing-parts-overview)
  * [Components that MAY need parts](#components-that-may-need-parts)
  * [Components MISSING parts](#components-missing-parts)
- [New Parts Overview](#new-parts-overview)
  * [Components with Native Buttons](#components-with-native-buttons)
    + [Part Proposal](#part-proposal)
  * [Back Button](#back-button)
    + [Part Proposal](#part-proposal-1)

# Missing Parts Overview

Components that have parts or do not need parts due to containing no shadow elements or only containing wrapper elements have been removed from this list for space, but are available if inquired.

:art: - Excessive CSS variables used

## Components that MAY need parts

- [ ] Item (native item) :art:
- [ ] Item Divider (inner item) :art:
- [ ] Progress bar (bars)
- [ ] Slides (pager, wrapper)
- [ ] Spinner - probably does not need, but look at svgs
- [ ] Toast (wrapper, buttons)
- [ ] Toolbar (background)


## Components MISSING parts

- [ ] Back button (native, icon, text) - discuss native button name :art:
- [ ] Button (native) - discuss native button name :art:
- [ ] Fab button (close icon, native) :art:
- [ ] Item Option (native)
- [ ] Menu button (native, icon)
- [ ] Segment button (native, indicator exists - just not added to the public API) :art:
- [ ] Tab button (native)

----------------------------------------------------------------

# New Parts Overview

* [Components with Native Buttons](#components-with-native-buttons)
  + [Part Proposal](#part-proposal)
* [Back Button](#back-button)
  + [Part Proposal](#part-proposal-1)

## Components with Native Buttons

- `ion-back-button`
- `ion-button`
- `ion-fab-button`
- `ion-item-option`
- `ion-menu-button`
- `ion-segment-button`
- `ion-tab-button`

### Part Proposal

Add `"native"` part to all components that contain a `.button-native` element due to it consuming a large amount of CSS variables (see image below):

:warning: Naming of this is up for discussion :warning:

```tsx
<Host>
  <button part="native" class="button-native">
    <span class="button-inner">
      ...
    </span>
  </button>
</Host>
```

![Screen Shot 2020-06-04 at 4 26 45 PM](https://user-images.githubusercontent.com/6577830/83809081-dbfdee80-a683-11ea-8606-47e6e79fd181.png)


## Back Button

### Part Proposal

```tsx
<Host>
  <button class="button-native" part="native">
    <span class="button-inner">
      <ion-icon part="icon"></ion-icon>
      <span part="text">{backButtonText}</span>
    </span>
  </button>
</Host>
```

