### PR TITLE
bug(modal): set card-style modal height using the --height css variable

### DIFF
--- a/core/src/components/modal/modal.ios.scss
+++ b/core/src/components/modal/modal.ios.scss
@@ -21,14 +21,14 @@
 
 @media screen and (max-width: 767px) {
   @supports (width: max(0px, 1px)) {
-    :host(.modal-card) .modal-wrapper {
-      height: calc(100% - max(30px, var(--ion-safe-area-top)) - 10px);
+    :host(.modal-card) {
+      --height: calc(100% - max(30px, var(--ion-safe-area-top)) - 10px);
     }
   }
 
   @supports not (width: max(0px, 1px)) {
-    :host(.modal-card) .modal-wrapper {
-      height: calc(100% - 40px);
+    :host(.modal-card) {
+      --height: calc(100% - 40px);
     }
   }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fixes https://github.com/ionic-team/ionic/issues/21449


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Height was not being set using the css var, so it was annoying to override.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
