### PR TITLE
fix(angular): fix issue where navAnimation was being incorrectly overridden 

### DIFF
--- a/core/src/components/router-outlet/route-outlet.tsx
+++ b/core/src/components/router-outlet/route-outlet.tsx
@@ -187,7 +187,6 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
     await transition({
       mode,
       animated,
-      animationBuilder,
       enteringEl,
       leavingEl,
       baseEl: el,
@@ -195,7 +194,8 @@ export class RouterOutlet implements ComponentInterface, NavOutlet {
         ? ani => this.ani = ani
         : undefined
       ),
-      ...opts
+      ...opts,
+      animationBuilder,
     });
 
     // emit nav changed event


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fixes https://github.com/ionic-team/ionic/issues/21495

The problem was that when you did not provide an animation via `routerAnimation`, you would get an object that looked like:

```
{
  ...
  animationBuilder: undefined
  ...
}
```

Due to the way the code was structured, Ionic would properly get `config.get('navAnimation')`, but it would get overridden by the undefined `animationBuilder` in `opts`.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- let the `animationBuilder` option take precedence when using spread on `opts`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
