### PR TITLE
fix(ios): respect toolbar opacity when doing nav transition

### DIFF
--- a/core/src/utils/transition/ios.transition.ts
+++ b/core/src/utils/transition/ios.transition.ts
@@ -363,7 +363,7 @@ export const iosTransitionAnimation = (navEl: HTMLElement, opts: TransitionOptio
 
         const translucentHeader = parentHeader?.translucent;
         if (!translucentHeader) {
-          enteringToolBarBg.fromTo(OPACITY, 0.01, 1);
+          enteringToolBarBg.fromTo(OPACITY, 0.01, 'var(--opacity)');
         } else {
           enteringToolBarBg.fromTo('transform', (isRTL ? 'translateX(-100%)' : 'translateX(100%)'), 'translateX(0px)');
         }
@@ -510,7 +510,7 @@ export const iosTransitionAnimation = (navEl: HTMLElement, opts: TransitionOptio
           // should just slide out, no fading out
           const translucentHeader = parentHeader?.translucent;
           if (!translucentHeader) {
-            leavingToolBarBg.fromTo(OPACITY, 0.99, 0);
+            leavingToolBarBg.fromTo(OPACITY, 'var(--opacity)', 0);
           } else {
             leavingToolBarBg.fromTo('transform', 'translateX(0px)', (isRTL ? 'translateX(-100%)' : 'translateX(100%)'));
           }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Page w/ a large title shows its toolbar when transitioning in because the ios transition forces opacity = 1 when --opacity may have been set otherwise

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- iOS transition now respects --opacity css var
- Prevents a flicker of the toolbar when doing a transition to a page containing a large title

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
