### PR TITLE
fix(input): clear button can now be tabbed to

### DIFF
--- a/core/src/components/input/input.scss
+++ b/core/src/components/input/input.scss
@@ -147,6 +147,10 @@
   appearance: none;
 }
 
+.input-clear-icon:focus {
+  opacity: 0.5;
+}
+
 :host(.has-value) .input-clear-icon {
   visibility: visible;
 }

--- a/core/src/components/input/input.scss
+++ b/core/src/components/input/input.scss
@@ -147,7 +147,7 @@
   appearance: none;
 }
 
-:host(.has-focus.has-value) .input-clear-icon {
+:host(.has-value) .input-clear-icon {
   visibility: visible;
 }
 

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -324,7 +324,7 @@ export class Input implements ComponentInterface {
   }
 
   private clearTextOnEnter = (ev: KeyboardEvent) => {
-    if (ev.key === 'Enter') this.clearTextInput(ev);
+    if (ev.key === 'Enter') { this.clearTextInput(ev); }
   }
 
   private clearTextInput = (ev?: Event) => {

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -323,6 +323,10 @@ export class Input implements ComponentInterface {
     }
   }
 
+  private clearTextOnEnter = (ev: KeyboardEvent) => {
+    if (ev.key === 'Enter') this.clearTextInput(ev);
+  }
+
   private clearTextInput = (ev?: Event) => {
     if (this.clearInput && !this.readonly && !this.disabled && ev) {
       ev.preventDefault();
@@ -408,7 +412,9 @@ export class Input implements ComponentInterface {
           aria-label="reset"
           type="button"
           class="input-clear-icon"
-          onClick={this.clearTextInput}
+          onTouchStart={this.clearTextInput}
+          onMouseDown={this.clearTextInput}
+          onKeyDown={this.clearTextOnEnter}
         />}
       </Host>
     );

--- a/core/src/components/input/input.tsx
+++ b/core/src/components/input/input.tsx
@@ -408,9 +408,7 @@ export class Input implements ComponentInterface {
           aria-label="reset"
           type="button"
           class="input-clear-icon"
-          tabindex="-1"
-          onTouchStart={this.clearTextInput}
-          onMouseDown={this.clearTextInput}
+          onClick={this.clearTextInput}
         />}
       </Host>
     );


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fixes https://github.com/ionic-team/ionic/issues/21549


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

1. The clear button now always appears if there is text in the input regardless of focus state. This brings this inline with similar components on iOS and on the web. (for example, see any of the search boxes on iOS, or see the search on http://google.com/).

2. The clear button can now be tabbed to by removing `tabindex="-1"` which is also more in line with components on the web.

3. When tabbing to the clear button, you can now press "Enter" to click it. The one downside is that it blurs the input, but for touch-based presses, the behavior remains the same.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
